### PR TITLE
Point WKT

### DIFF
--- a/nhlib/geo/point.py
+++ b/nhlib/geo/point.py
@@ -60,6 +60,14 @@ class Point(object):
         self.latitude = latitude
         self.longitude = longitude
 
+    @property
+    def wkt2d(self):
+        """
+        Generate WKT (Well-Known Text) to represent this point in 2 dimensions
+        (ignoring depth).
+        """
+        return 'POINT(%s %s)' % (self.longitude, self.latitude)
+
     def point_at(self, horizontal_distance, vertical_increment, azimuth):
         """
         Compute the point with given horizontal, vertical distances

--- a/tests/geo/point_test.py
+++ b/tests/geo/point_test.py
@@ -239,3 +239,13 @@ class PointCloserThanTestCase(unittest.TestCase):
         numpy.testing.assert_array_equal(closer, [0, 0, 0, 0, 0, 0])
         closer = p.closer_than(mesh, 60)
         numpy.testing.assert_array_equal(closer, [1, 1, 1, 1, 1, 1])
+
+
+class PointWktTestCase(unittest.TestCase):
+    def test_point_wkt2d(self):
+        pt = geo.Point(13.5, 17.8)
+        self.assertEqual('POINT(13.5 17.8)', pt.wkt2d)
+
+        # Test a point with depth; the 2d wkt should be the same
+        pt = geo.Point(13.5, 17.8, 1.5)
+        self.assertEqual('POINT(13.5 17.8)', pt.wkt2d)


### PR DESCRIPTION
Point objects can produce 2d well-known text representations.

This is something oq-engine can use for the integration. This is something I found a need for while working on https://bugs.launchpad.net/openquake/+bug/1017466.
