### PR TITLE
Removed "reset" support from MFD objects

### DIFF
--- a/nhlib/mfd/base.py
+++ b/nhlib/mfd/base.py
@@ -25,48 +25,11 @@ class BaseMFD(object):
     """
     __metaclass__ = abc.ABCMeta
 
-    #: The list of parameters' names that are required by actual
-    #: MFD implementation. The property is required to be overridden.
-    #: Those and only those attributes that are listed here are allowed
-    #: and required as constructor's kwargs. See :meth:`set_parameters`.
-    PARAMETERS = abc.abstractproperty()
-
     #: The set of modification type names that are supported by an MFD.
     #: Each modification should have a corresponding method named
     #: ``modify_modificationname()`` where the actual modification
     #: logic resides.
     MODIFICATIONS = abc.abstractproperty()
-
-    def __init__(self, **parameters):
-        self.set_parameters(parameters)
-        self._original_parameters = parameters.copy()
-
-    def set_parameters(self, parameters):
-        """
-        Assign parameters to object's attributes.
-
-        :param parameters:
-            The dictionary of parameters as passed to the constructor.
-        :raises ValueError:
-            If some actual parameters are missing in :attr:`PARAMETERS`
-            or if something from :attr:`PARAMETERS` is missing in actual
-            parameters.
-
-        Calls :meth:`check_constraints` once everything is assigned.
-        """
-        defined = set(parameters)
-        required = set(self.PARAMETERS)
-        unexpected = defined - required
-        missing = required - defined
-        if missing:
-            raise ValueError('These parameters are required but missing: %s'
-                             % ', '.join(sorted(missing)))
-        if unexpected:
-            raise ValueError('These parameters are unexpected: %s'
-                             % ', ' .join(sorted(unexpected)))
-        for param_name in self.PARAMETERS:
-            setattr(self, param_name, parameters[param_name])
-        self.check_constraints()
 
     def modify(self, modification, parameters):
         """
@@ -93,13 +56,6 @@ class BaseMFD(object):
         meth = getattr(self, 'modify_%s' % modification)
         meth(**parameters)
         self.check_constraints()
-
-    def reset(self):
-        """
-        Reset an MFD to its original state after any number of :meth:`modify`
-        calls.
-        """
-        self.set_parameters(self._original_parameters)
 
     @abc.abstractmethod
     def check_constraints(self):

--- a/nhlib/mfd/evenly_discretized.py
+++ b/nhlib/mfd/evenly_discretized.py
@@ -33,10 +33,14 @@ class EvenlyDiscretizedMFD(BaseMFD):
         annual occurrence rates. The resulting histogram has as many bins
         as this list length.
     """
-
-    PARAMETERS = ('min_mag', 'bin_width', 'occurrence_rates')
-
     MODIFICATIONS = set()
+
+    def __init__(self, min_mag, bin_width, occurrence_rates):
+        self.min_mag = min_mag
+        self.bin_width = bin_width
+        self.occurrence_rates = occurrence_rates
+
+        self.check_constraints()
 
     def check_constraints(self):
         """

--- a/nhlib/mfd/truncated_gr.py
+++ b/nhlib/mfd/truncated_gr.py
@@ -57,13 +57,19 @@ class TruncatedGRMFD(BaseMFD):
     both are divisible by ``bin_width`` just before converting a function
     to a histogram. See :meth:`_get_min_mag_and_num_bins`.
     """
-
-    PARAMETERS = ('min_mag', 'max_mag', 'bin_width', 'a_val', 'b_val')
-
     MODIFICATIONS = set(('increment_max_mag',
                          'set_max_mag',
                          'increment_b',
                          'set_ab'))
+
+    def __init__(self, min_mag, max_mag, bin_width, a_val, b_val):
+        self.min_mag = min_mag
+        self.max_mag = max_mag
+        self.bin_width = bin_width
+        self.a_val = a_val
+        self.b_val = b_val
+
+        self.check_constraints()
 
     def check_constraints(self):
         """

--- a/tests/mfd/base_test.py
+++ b/tests/mfd/base_test.py
@@ -20,7 +20,6 @@ from nhlib.mfd.base import BaseMFD
 
 class BaseMFDTestCase(unittest.TestCase):
     class BaseTestMFD(BaseMFD):
-        PARAMETERS = ()
         MODIFICATIONS = set()
         check_constraints_call_count = 0
 
@@ -37,34 +36,6 @@ class BaseMFDTestCase(unittest.TestCase):
         with self.assertRaises(ValueError) as exc_catcher:
             func(*args, **kwargs)
         return exc_catcher.exception
-
-
-class BaseMFDSetParametersTestCase(BaseMFDTestCase):
-    def test_missing(self):
-        class TestMFD(self.BaseTestMFD):
-            PARAMETERS = ('foo', 'bar', 'baz')
-        exc = self.assert_mfd_error(TestMFD, foo=1)
-        self.assertEqual(exc.message,
-                         'These parameters are required but missing: bar, baz')
-
-    def test_unexpected(self):
-        class TestMFD(self.BaseTestMFD):
-            PARAMETERS = ('foo', 'bar')
-        exc = self.assert_mfd_error(TestMFD, foo=1, bar=2, baz=3)
-        self.assertEqual(exc.message, 'These parameters are unexpected: baz')
-
-    def test_check_constraints_is_called(self):
-        class TestMFD(self.BaseTestMFD):
-            PARAMETERS = ('foo', 'bar')
-        mfd = TestMFD(foo=1, bar=2)
-        self.assertEqual(mfd.check_constraints_call_count, 1)
-
-    def test_parameters_are_assigned(self):
-        class TestMFD(self.BaseTestMFD):
-            PARAMETERS = ('baz', 'quux')
-        mfd = TestMFD(baz=1, quux=True)
-        self.assertEqual(mfd.baz, 1)
-        self.assertEqual(mfd.quux, True)
 
 
 class BaseMFDModificationsTestCase(BaseMFDTestCase):
@@ -85,18 +56,7 @@ class BaseMFDModificationsTestCase(BaseMFDTestCase):
                 self.foo_calls.append(kwargs)
 
         mfd = TestMFD()
-        self.assertEqual(mfd.check_constraints_call_count, 1)
+        self.assertEqual(mfd.check_constraints_call_count, 0)
         mfd.modify('foo', dict(a=1, b='2', c=True))
         self.assertEqual(mfd.foo_calls, [{'a': 1, 'b': '2', 'c': True}])
-        self.assertEqual(mfd.check_constraints_call_count, 2)
-
-    def test_reset(self):
-        class TestMFD(self.BaseTestMFD):
-            PARAMETERS = ('abc', 'defg')
-        mfd = TestMFD(abc=1, defg=None)
-        mfd.abc = 3
-        mfd.defg = []
-        mfd.reset()
-        self.assertEqual(mfd.abc, 1)
-        self.assertEqual(mfd.defg, None)
-        self.assertEqual(mfd.check_constraints_call_count, 2)
+        self.assertEqual(mfd.check_constraints_call_count, 1)


### PR DESCRIPTION
This would simplify our a bit over-engineered MFD revertible modifications support. We haven't used that resetting functionality and most likely wouldn't any time soon.
