### PR TITLE
Make everything available by single import

### DIFF
--- a/nhlib/__init__.py
+++ b/nhlib/__init__.py
@@ -16,4 +16,5 @@
 """
 nhlib stands for New Hazard Library.
 """
-from nhlib import geo, mfd, scalerel, source, const, pmf, tom
+from nhlib import (calc, geo, gsim, mfd, scalerel, source, const,
+                   correlation, imt, pmf, site, tom)

--- a/nhlib/gsim/__init__.py
+++ b/nhlib/gsim/__init__.py
@@ -17,3 +17,4 @@
 Package :mod:`nhlib.gsim` contains base and specific implementations of
 ground shaking intensity models. See :mod:`nhlib.gsim.base`.
 """
+from nhlib.gsim.base import GMPE, IPE, CoeffsTable


### PR DESCRIPTION
This makes "single import" more consistent: now site, imt, calc and correlation modules are also available from "import nhlib".
