### PR TITLE
gitignore: ignore build directory and *.so files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 .ropeproject
 *.*.swp
 doc/build
+build
+*.so


### PR DESCRIPTION
That change hides built extensions from git status.
