### PR TITLE
Minor fix to GSIM docs

### DIFF
--- a/doc/gsim/index.rst
+++ b/doc/gsim/index.rst
@@ -14,6 +14,7 @@ Built-in GSIMs
     chiou_youngs_2008
     sadigh_1997
     boore_atkinson_2008
+    zhao_2006
 
 
 -----------------------------------


### PR DESCRIPTION
Added a missing TOC item (for the new Zhao 2006 GSIMs).

This is to address a build failure: http://ci.openquake.org/job/nhlib/186/
