### PR TITLE
Optimization for SiteCollection.expand()

### DIFF
--- a/nhlib/site.py
+++ b/nhlib/site.py
@@ -278,8 +278,8 @@ class SiteCollection(object):
         num_values = data.shape[1]
         result = numpy.empty((total_sites, num_values))
         result.fill(placeholder)
-        for i in xrange(num_values):
-            result[:, i].put(self.indices, data[:, i])
+        for i, idx in enumerate(self.indices):
+            result[idx] = data[i]
         return result
 
     def filter(self, mask):


### PR DESCRIPTION
Replaced numpy.put statement with an equivalent array assignment.

numpy.put was showing up a profiling report and was found to be a major
bottleneck, consuming 1-2ms per call. For a test computation on 1 source
with a SiteCollection containing 95k sites, 82% of the time was spent
on `put` calls.

The first profiling test ran in 6078.557 seconds. With this optimization,
the same test ran in 1107.623 seconds.

For more information, including the test script and full profiling reports, see: https://bugs.launchpad.net/openquake/+bug/1094297
