### PR TITLE
PEP8 fixes for test code

### DIFF
--- a/tests/calc/disagg_test.py
+++ b/tests/calc/disagg_test.py
@@ -336,7 +336,9 @@ class DisaggregateTestCase(_BaseDisaggTestCase):
                           array([], dtype=float64), array([], dtype=float64),
                           array([], dtype=float64), array([], dtype=int64), [])
 
-        with mock.patch('openquake.hazardlib.calc.disagg._collect_bins_data') as cbd:
+        with mock.patch(
+            'openquake.hazardlib.calc.disagg._collect_bins_data'
+        ) as cbd:
             with warnings.catch_warnings(record=True) as w:
                 cbd.return_value = fake_bins_data
 

--- a/tests/calc/hazard_curve_test.py
+++ b/tests/calc/hazard_curve_test.py
@@ -145,32 +145,42 @@ class HazardCurvesFiltersTestCase(unittest.TestCase):
 
     def test_point_sources(self):
         sources = [
-            openquake.hazardlib.source.PointSource(source_id='point1', name='point1',
+            openquake.hazardlib.source.PointSource(
+                source_id='point1', name='point1',
                 tectonic_region_type=const.TRT.ACTIVE_SHALLOW_CRUST,
-                mfd=openquake.hazardlib.mfd.EvenlyDiscretizedMFD(min_mag=4, bin_width=1,
-                                                   occurrence_rates=[5]),
+                mfd=openquake.hazardlib.mfd.EvenlyDiscretizedMFD(
+                    min_mag=4, bin_width=1, occurrence_rates=[5]
+                ),
                 nodal_plane_distribution=openquake.hazardlib.pmf.PMF([
-                    (1, openquake.hazardlib.geo.NodalPlane(strike=0.0, dip=90.0, rake=0.0))
+                    (1, openquake.hazardlib.geo.NodalPlane(strike=0.0,
+                                                           dip=90.0,
+                                                           rake=0.0))
                 ]),
                 hypocenter_distribution=openquake.hazardlib.pmf.PMF([(1, 10)]),
                 upper_seismogenic_depth=0.0,
                 lower_seismogenic_depth=10.0,
-                magnitude_scaling_relationship = openquake.hazardlib.scalerel.PeerMSR(),
+                magnitude_scaling_relationship = \
+                    openquake.hazardlib.scalerel.PeerMSR(),
                 rupture_aspect_ratio=2,
                 rupture_mesh_spacing=1.0,
                 location=Point(10, 10)
             ),
-            openquake.hazardlib.source.PointSource(source_id='point2', name='point2',
+            openquake.hazardlib.source.PointSource(
+                source_id='point2', name='point2',
                 tectonic_region_type=const.TRT.ACTIVE_SHALLOW_CRUST,
-                mfd=openquake.hazardlib.mfd.EvenlyDiscretizedMFD(min_mag=4, bin_width=2,
-                                                   occurrence_rates=[5, 6, 7]),
+                mfd=openquake.hazardlib.mfd.EvenlyDiscretizedMFD(
+                    min_mag=4, bin_width=2, occurrence_rates=[5, 6, 7]
+                ),
                 nodal_plane_distribution=openquake.hazardlib.pmf.PMF([
-                    (1, openquake.hazardlib.geo.NodalPlane(strike=0, dip=90, rake=0.0)),
+                    (1, openquake.hazardlib.geo.NodalPlane(strike=0,
+                                                           dip=90,
+                                                           rake=0.0)),
                 ]),
                 hypocenter_distribution=openquake.hazardlib.pmf.PMF([(1, 10)]),
                 upper_seismogenic_depth=0.0,
                 lower_seismogenic_depth=10.0,
-                magnitude_scaling_relationship = openquake.hazardlib.scalerel.PeerMSR(),
+                magnitude_scaling_relationship = \
+                    openquake.hazardlib.scalerel.PeerMSR(),
                 rupture_aspect_ratio=2,
                 rupture_mesh_spacing=1.0,
                 location=Point(10, 11)

--- a/tests/geo/mesh_test.py
+++ b/tests/geo/mesh_test.py
@@ -548,13 +548,15 @@ class RectangularMeshGetMeanInclinationAndAzimuthTestCase(unittest.TestCase):
         assert_angles_equal(self, strike, 360, delta=1e-7)
 
         row1 = [Point(-90.1, -0.1), Point(-90, 0), Point(-89.9, 0.1)]
-        row2 = [Point(-90.0, -0.1, 1), Point(-89.9, 0, 1), Point(-89.8, 0.1, 1)]
+        row2 = [Point(-90.0, -0.1, 1), Point(-89.9, 0, 1),
+                Point(-89.8, 0.1, 1)]
         mesh = RectangularMesh.from_points_list([row1, row2])
         dip, strike = mesh.get_mean_inclination_and_azimuth()
         self.assertAlmostEqual(strike, 45, delta=1e-4)
 
         row1 = [Point(-90.1, -0.1), Point(-90, 0), Point(-89.9, 0.1)]
-        row2 = [Point(-90.0, -0.1, 1), Point(-89.9, 0, 1), Point(-89.8, 0.1, 1)]
+        row2 = [Point(-90.0, -0.1, 1), Point(-89.9, 0, 1),
+                Point(-89.8, 0.1, 1)]
         mesh = RectangularMesh.from_points_list([row1, row2])
         dip, strike = mesh.get_mean_inclination_and_azimuth()
         self.assertAlmostEqual(strike, 45, delta=1e-3)

--- a/tests/geo/polygon_test.py
+++ b/tests/geo/polygon_test.py
@@ -359,7 +359,8 @@ class PolygonDilateTestCase(unittest.TestCase):
                          len(elons) + 1)
 
     def test_counterclockwise(self):
-        poly = polygon.Polygon([geo.Point(5, 6), geo.Point(4, 6), geo.Point(4, 5)])
+        poly = polygon.Polygon([geo.Point(5, 6), geo.Point(4, 6),
+                                geo.Point(4, 5)])
         dilated = poly.dilate(20)
         elons = [
             5.1280424, 4.1280406, 4.1149304, 4.1007112, 4.0855200, 4.0695036,
@@ -427,7 +428,8 @@ class PolygonDilateTestCase(unittest.TestCase):
 
 class PolygonWKTTestCase(unittest.TestCase):
     """
-    Test generation of WKT from a :class:`~openquake.hazardlib.geo.polygon.Polygon`.
+    Test generation of WKT from a
+    :class:`~openquake.hazardlib.geo.polygon.Polygon`.
     """
 
     def test_wkt(self):

--- a/tests/gsim/atkinson_boore_2003_test.py
+++ b/tests/gsim/atkinson_boore_2003_test.py
@@ -13,8 +13,9 @@
 #
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
-from openquake.hazardlib.gsim.atkinson_boore_2003 import AtkinsonBoore2003SInter, \
-    AtkinsonBoore2003SSlab
+from openquake.hazardlib.gsim.atkinson_boore_2003 import (
+    AtkinsonBoore2003SInter,  AtkinsonBoore2003SSlab
+)
 
 from tests.gsim.utils import BaseGSIMTestCase
 
@@ -28,7 +29,7 @@ class AtkinsonBoore2003SInterTestCase(BaseGSIMTestCase):
     def test_mean(self):
         self.check('AB03/AB03SInter_MEAN.csv',
                     max_discrep_percentage=0.1)
-                    
+
     def test_std_total(self):
         self.check('AB03/AB03SInter_STD_TOTAL.csv',
                     max_discrep_percentage=0.1)

--- a/tests/gsim/atkinson_boore_2006_test.py
+++ b/tests/gsim/atkinson_boore_2006_test.py
@@ -14,7 +14,8 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 from openquake.hazardlib.gsim.atkinson_boore_2006 import AtkinsonBoore2006
-from openquake.hazardlib.gsim.base import SitesContext, RuptureContext, DistancesContext
+from openquake.hazardlib.gsim.base import (SitesContext, RuptureContext,
+                                           DistancesContext)
 from openquake.hazardlib.imt import PGA
 from openquake.hazardlib.const import StdDev
 
@@ -25,14 +26,14 @@ import numpy
 
 class AtkinsonBoore2006TestCase(BaseGSIMTestCase):
     GSIM_CLASS = AtkinsonBoore2006
-    
+
     # Test data generated from Fortran implementation
     # of Dave Boore (http://www.daveboore.com/pubs_online.html)
 
     def test_mean(self):
         self.check('AB06/AB06_MEAN.csv',
                     max_discrep_percentage=0.9)
-                    
+
     def test_std_total(self):
         self.check('AB06/AB06_STD_TOTAL.csv',
                     max_discrep_percentage=0.1)

--- a/tests/gsim/base_test.py
+++ b/tests/gsim/base_test.py
@@ -19,8 +19,8 @@ import collections
 import numpy
 
 from openquake.hazardlib import const
-from openquake.hazardlib.gsim.base import GMPE, IPE, SitesContext, RuptureContext, \
-                            DistancesContext
+from openquake.hazardlib.gsim.base import (GMPE, IPE, SitesContext,
+                                           RuptureContext, DistancesContext)
 from openquake.hazardlib.geo.mesh import Mesh
 from openquake.hazardlib.geo.point import Point
 from openquake.hazardlib.imt import PGA, PGV

--- a/tests/gsim/campbell_2003_test.py
+++ b/tests/gsim/campbell_2003_test.py
@@ -13,7 +13,8 @@
 #
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
-from openquake.hazardlib.gsim.campbell_2003 import Campbell2003, Campbell2003SHARE
+from openquake.hazardlib.gsim.campbell_2003 import Campbell2003
+from openquake.hazardlib.gsim.campbell_2003 import Campbell2003SHARE
 
 from tests.gsim.utils import BaseGSIMTestCase
 

--- a/tests/gsim/cauzzi_faccioli_2008_test.py
+++ b/tests/gsim/cauzzi_faccioli_2008_test.py
@@ -16,7 +16,8 @@
 from openquake.hazardlib.gsim.cauzzi_faccioli_2008 import CauzziFaccioli2008
 
 from tests.gsim.utils import BaseGSIMTestCase
-from openquake.hazardlib.gsim.base import SitesContext, RuptureContext, DistancesContext
+from openquake.hazardlib.gsim.base import (SitesContext, RuptureContext,
+                                           DistancesContext)
 from openquake.hazardlib.imt import PGA
 from openquake.hazardlib.const import StdDev
 

--- a/tests/gsim/check_gsim.py
+++ b/tests/gsim/check_gsim.py
@@ -27,7 +27,8 @@ import numpy
 
 from openquake.hazardlib import const
 from openquake.hazardlib.gsim.base import GroundShakingIntensityModel
-from openquake.hazardlib.gsim.base import SitesContext, RuptureContext, DistancesContext
+from openquake.hazardlib.gsim.base import (SitesContext, RuptureContext,
+                                           DistancesContext)
 from openquake.hazardlib.imt import PGA, PGV, SA
 
 
@@ -184,13 +185,15 @@ def _parse_csv_line(headers, values):
         A tuple of the following values (in specified order):
 
         sctx
-            An instance of :class:`openquake.hazardlib.gsim.base.SitesContext` with
-            attributes populated by the information from in row in a form
+            An instance of :class:`openquake.hazardlib.gsim.base.SitesContext`
+            with attributes populated by the information from in row in a form
             of single-element numpy arrays.
         rctx
-            An instance of :class:`openquake.hazardlib.gsim.base.RuptureContext`.
+            An instance of
+            :class:`openquake.hazardlib.gsim.base.RuptureContext`.
         dctx
-            An instance of :class:`openquake.hazardlib.gsim.base.DistancesContext`.
+            An instance of
+            :class:`openquake.hazardlib.gsim.base.DistancesContext`.
         stddev_types
             An empty list, if the ``result_type`` column says "MEAN"
             for that row, otherwise it is a list with one item --
@@ -283,8 +286,9 @@ if __name__ == '__main__':
         if not isinstance(gsim_class, type) \
                 or not issubclass(gsim_class, GroundShakingIntensityModel):
             raise argparse.ArgumentTypeError(
-                "%r is not subclass of " \
-                "openquake.hazardlib.gsim.base.GroundShakingIntensityModel" % import_path
+                "%r is not subclass of "
+                "openquake.hazardlib.gsim.base.GroundShakingIntensityModel"
+                % import_path
             )
         return gsim_class
 

--- a/tests/gsim/lin_lee_2008_test.py
+++ b/tests/gsim/lin_lee_2008_test.py
@@ -13,7 +13,8 @@
 #
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
-from openquake.hazardlib.gsim.lin_lee_2008 import LinLee2008SInter, LinLee2008SSlab
+from openquake.hazardlib.gsim.lin_lee_2008 import LinLee2008SInter
+from openquake.hazardlib.gsim.lin_lee_2008 import LinLee2008SSlab
 
 from tests.gsim.utils import BaseGSIMTestCase
 
@@ -25,7 +26,7 @@ class LinLee2008SInterTestCase(BaseGSIMTestCase):
     def test_mean(self):
         self.check('LL08/LL08SInter_MEAN.csv',
                     max_discrep_percentage=0.1)
-                    
+
     def test_total_std(self):
         self.check('LL08/LL08SInter_STD_TOTAL.csv',
                     max_discrep_percentage=0.1)

--- a/tests/gsim/youngs_1997_test.py
+++ b/tests/gsim/youngs_1997_test.py
@@ -13,7 +13,8 @@
 #
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
-from openquake.hazardlib.gsim.youngs_1997 import YoungsEtAl1997SInter, YoungsEtAl1997SSlab
+from openquake.hazardlib.gsim.youngs_1997 import YoungsEtAl1997SInter
+from openquake.hazardlib.gsim.youngs_1997 import YoungsEtAl1997SSlab
 
 from tests.gsim.utils import BaseGSIMTestCase
 

--- a/tests/gsim/zhao_2006_test.py
+++ b/tests/gsim/zhao_2006_test.py
@@ -13,9 +13,11 @@
 #
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
-from openquake.hazardlib.gsim.zhao_2006 import ZhaoEtAl2006Asc, ZhaoEtAl2006SInter,\
-    ZhaoEtAl2006SSlab
-from openquake.hazardlib.gsim.base import SitesContext, RuptureContext, DistancesContext
+from openquake.hazardlib.gsim.zhao_2006 import (ZhaoEtAl2006Asc,
+                                                ZhaoEtAl2006SInter,
+                                                ZhaoEtAl2006SSlab)
+from openquake.hazardlib.gsim.base import (SitesContext, RuptureContext,
+                                           DistancesContext)
 from openquake.hazardlib.imt import PGA
 from openquake.hazardlib.const import StdDev
 

--- a/tests/mfd/youngs_coppersmith_1985_test.py
+++ b/tests/mfd/youngs_coppersmith_1985_test.py
@@ -112,9 +112,9 @@ class YoungsCoppersmith1985MFDConstraintsTestCase(BaseMFDTestCase):
             min_mag=4.0, a_val=2.0, b_val=1.0, char_mag=4.3, char_rate=0.001,
             bin_width=0.1
         )
-        error = 'Maximum magnitude of the G-R distribution (char_mag - 0.25) ' \
-                'must be greater than the minimum magnitude by at least one ' \
-                'magnitude bin.'
+        error = ('Maximum magnitude of the G-R distribution (char_mag - 0.25) '
+                 'must be greater than the minimum magnitude by at least one '
+                 'magnitude bin.')
         self.assertEqual(exc.message, error)
 
     def test_rate_char_mag_not_equal_rate_char_mag_less_1_pt_25(self):

--- a/tests/source/complex_fault_test.py
+++ b/tests/source/complex_fault_test.py
@@ -17,7 +17,8 @@ import unittest
 
 import numpy
 
-from openquake.hazardlib.source.complex_fault import ComplexFaultSource, _float_ruptures
+from openquake.hazardlib.source.complex_fault import (ComplexFaultSource,
+                                                      _float_ruptures)
 from openquake.hazardlib.geo import Line, Point
 from openquake.hazardlib.geo.surface.simple_fault import SimpleFaultSurface
 from openquake.hazardlib.scalerel.peer import PeerMSR


### PR DESCRIPTION
PEP8 fixes for test code, needed as a result of renaming the base package.
