### PR TITLE
Rect mesh enclosing poly bug

### DIFF
--- a/openquake/hazardlib/geo/mesh.py
+++ b/openquake/hazardlib/geo/mesh.py
@@ -459,7 +459,7 @@ class RectangularMesh(Mesh):
             # specific platforms) so the work around here is to remove the
             # duplicate polygons. In fact, we only observed this error on our
             # CI/build machine. None of our dev environments or production
-            # machines has encountered this error, at least consistently.
+            # machines has encountered this error, at least consistently. >:(
             polygons = [shapely.wkt.loads(x) for x in
                         list(set(p.wkt for p in polygons))]
             polygon = shapely.ops.cascaded_union(polygons) \


### PR DESCRIPTION
This is handling for a special case has only consistently cropped up in our CI environment: http://ci.openquake.org/job/oq-engine/199/testReport/

Basically, this part of the code throws an exception when trying to create a cascading union of many polygons (resulting in a single polygon). This seems to happen only with VERY specific geometry AND when one of those very specific geometries is duplicated in the input list to `shapely.ops.cascading_union`.

Oh, it gets worse. The only machine on which I've been able to reproduce this error is the CI machine. No other machine can do it as far as I know.
