### PR TITLE
Fix for an obscure `cascading union` use case in RectangularMesh

### DIFF
--- a/openquake/hazardlib/geo/mesh.py
+++ b/openquake/hazardlib/geo/mesh.py
@@ -446,9 +446,24 @@ class RectangularMesh(Mesh):
                                      .buffer(self.DIST_TOLERANCE, 2)
             polygons.append(shapely.geometry.Polygon(stripe.exterior))
             prev_line = line[::-1]
-        # create a final polygon as the union of all the stripe ones
-        polygon = shapely.ops.cascaded_union(polygons) \
-                             .simplify(self.DIST_TOLERANCE)
+        try:
+            # create a final polygon as the union of all the stripe ones
+            polygon = shapely.ops.cascaded_union(polygons) \
+                                 .simplify(self.DIST_TOLERANCE)
+        except ValueError:
+            # NOTE(larsbutler): In some rare cases, we've observed ValueErrors
+            # ("No Shapely geometry can be created from null value") with very
+            # specific sets of polygons such that there are two unique
+            # and many duplicates of one.
+            # This bug is very difficult to reproduce consistently (except on
+            # specific platforms) so the work around here is to remove the
+            # duplicate polygons. In fact, we only observed this error on our
+            # CI/build machine. None of our dev environments or production
+            # machines has encountered this error, at least consistently. >:(
+            polygons = [shapely.wkt.loads(x) for x in
+                        list(set(p.wkt for p in polygons))]
+            polygon = shapely.ops.cascaded_union(polygons) \
+                                 .simplify(self.DIST_TOLERANCE)
         return proj, polygon
 
     def get_middle_point(self):


### PR DESCRIPTION
Addresses https://bugs.launchpad.net/openquake/+bug/1133447.

This is handling for a special case has only consistently cropped up in our CI environment: http://ci.openquake.org/job/oq-engine/199/testReport/

Basically, this part of the code throws an exception when trying to create a cascading union of many polygons (resulting in a single polygon). This seems to happen only with VERY specific geometry AND when one of those very specific geometries is duplicated in the input list to shapely.ops.cascading_union.

Oh, it gets worse. The only machine on which I've been able to reproduce this error is the CI machine. No other machine can do it as far as I know.
