### PR TITLE
fixed bug in get_orthographic_projection

### DIFF
--- a/openquake/hazardlib/geo/utils.py
+++ b/openquake/hazardlib/geo/utils.py
@@ -197,7 +197,15 @@ def get_orthographic_projection(west, east, north, south):
             cos_c = numpy.sqrt(1 - (xx ** 2 + yy ** 2))
             phis = numpy.arcsin(cos_c * sin_phi0 + yy * cos_phi0)
             lambdas = numpy.arctan2(xx, cos_phi0 * cos_c - yy * sin_phi0)
-            return numpy.degrees(lambda0 + lambdas), numpy.degrees(phis)
+            xx = numpy.degrees(lambda0 + lambdas)
+            yy = numpy.degrees(phis)
+            # shift longitudes greater than 180 back into the western
+            # emisphere, that is in range [0, -180]. No need to check for
+            # values smaller than -180, because the formula used computes
+            # longitudes in the range [0, 360]
+            idx = xx >= 180.
+            xx[idx] = xx[idx] - 360.
+            return xx, yy
     return proj
 
 

--- a/tests/geo/utils_test.py
+++ b/tests/geo/utils_test.py
@@ -159,6 +159,25 @@ class GetOrthographicProjectionTestCase(unittest.TestCase):
                          'some points are too far from the projection '
                          'center lon=180.0 lat=45.0')
 
+    def test_projection_across_international_date_line(self):
+        # tests that given a polygon crossing the internation date line,
+        # projecting its coordinates from spherical to cartesian and then back
+        # to spherical gives the original values
+        west = 179.7800
+        east = -179.8650
+        north = 51.4320
+        south = 50.8410
+        proj = utils.get_orthographic_projection(west, east, north, south)
+
+        lons = numpy.array([179.8960, 179.9500, -179.9930, -179.9120,
+                            -179.8650, -179.9380, 179.9130, 179.7800])
+        lats = numpy.array([50.8410, 50.8430, 50.8490, 50.8540, 51.4160,
+                            51.4150, 51.4270, 51.4320])
+        xx, yy = proj(lons, lats)
+        comp_lons, comp_lats = proj(xx, yy, reverse=True)
+        numpy.testing.assert_allclose(lons, comp_lons)
+        numpy.testing.assert_allclose(lats, comp_lats)
+
 
 class GetMiddlePointTestCase(unittest.TestCase):
     def test_same_points(self):


### PR DESCRIPTION
Fixes bug with `openquake.hazardlib.geo.utils.get_orthographic_projection`, see: https://bugs.launchpad.net/oq-hazardlib/+bug/1175545
