### PR TITLE
Add an .id attribute to Site objects

### DIFF
--- a/openquake/hazardlib/site.py
+++ b/openquake/hazardlib/site.py
@@ -79,6 +79,7 @@ class Site(object):
             * vs30measured (`True`/`False`)
             * z1pt0
             * z2pt5
+            * id
         """
         return dict(
             location=self.location,
@@ -86,6 +87,7 @@ class Site(object):
             vs30measured=self.vs30measured,
             z1pt0=self.z1pt0,
             z2pt5=self.z2pt5,
+            id=self.id,
         )
 
     def __setstate__(self, state):
@@ -97,6 +99,7 @@ class Site(object):
         self.vs30measured = state['vs30measured']
         self.z1pt0 = state['z1pt0']
         self.z2pt5 = state['z2pt5']
+        self.id = state['id']
 
     def __eq__(self, other):
         """


### PR DESCRIPTION
This is a companion to https://github.com/gem/oq-engine/pull/1192 and it is refers to https://bugs.launchpad.net/oq-engine/+bug/1184603.

Why it is needed? The scenario calculator performs a distribution per site. In order to store the GMVs for a given site, it is necessary to know the database id of that site. However the
calculator gets a hazardlib Site object that contains no id. This pull request adds an id attribute which is filled by the engine with the right id of the corresponding db record.
This is perhaps suboptimal, but it does the job with a minimal change to the current logic of the engine.
