### PR TITLE
refactor algorithm for calculating planar surface coordinates

### DIFF
--- a/openquake/hazardlib/source/point.py
+++ b/openquake/hazardlib/source/point.py
@@ -301,32 +301,42 @@ class PointSource(SeismicSource):
                 azimuth=(azimuth_up if vshift < 0 else azimuth_down)
             )
 
-        # now we can find four corner points of the rupture rectangle.
-        # we find the point that is on the same depth than the rupture
-        # center but lies on the right border of its surface:
-        right_center = rupture_center.point_at(
-            horizontal_distance=rup_length / 2.0,
-            vertical_increment=0, azimuth=azimuth_right
+        # from the rupture center we can now compute the coordinates of the
+        # four coorners by moving along the diagonals of the plane. This seems
+        # to be better then moving along the perimeter, because in this case
+        # errors are accumulated that induce distorsions in the shape with
+        # consequent raise of exceptions when creating PlanarSurface objects
+        # theta is the angle between the diagonal of the surface projection
+        # and the line passing through the rupture center and parallel to the
+        # top and bottom edges. Theta is zero for vertical ruptures (because
+        # rup_proj_width is zero)
+        theta = math.degrees(
+            math.atan((rup_proj_width / 2.) / (rup_length / 2.))
         )
-        # than we get the right bottom corner:
-        right_bottom = right_center.point_at(
-            horizontal_distance=rup_proj_width / 2.0,
-            vertical_increment=rup_proj_height / 2.0,
-            azimuth=azimuth_down
+        hor_dist = math.sqrt(
+            (rup_length / 2.) ** 2 + (rup_proj_width / 2.) ** 2
         )
-        # and other three points can be easily found by stepping from
-        # already known points horizontally only by rupture length
-        # (to get to left point from right one) or horizontally and
-        # vertically (to get to top edge from bottom).
-        right_top = right_bottom.point_at(horizontal_distance=rup_proj_width,
-                                          vertical_increment=-rup_proj_height,
-                                          azimuth=azimuth_up)
-        left_top = right_top.point_at(horizontal_distance=rup_length,
-                                      vertical_increment=0,
-                                      azimuth=azimuth_left)
-        left_bottom = right_bottom.point_at(horizontal_distance=rup_length,
-                                            vertical_increment=0,
-                                            azimuth=azimuth_left)
+
+        left_top = rupture_center.point_at(
+            horizontal_distance=hor_dist,
+            vertical_increment=-rup_proj_height / 2,
+            azimuth=(nodal_plane.strike + 180 + theta) % 360
+        )
+        right_top = rupture_center.point_at(
+            horizontal_distance=hor_dist,
+            vertical_increment=-rup_proj_height / 2,
+            azimuth=(nodal_plane.strike - theta) % 360
+        )
+        left_bottom = rupture_center.point_at(
+            horizontal_distance=hor_dist,
+            vertical_increment=rup_proj_height / 2,
+            azimuth=(nodal_plane.strike + 180 - theta) % 360
+        )
+        right_bottom = rupture_center.point_at(
+            horizontal_distance=hor_dist,
+            vertical_increment=rup_proj_height / 2,
+            azimuth=(nodal_plane.strike + theta) % 360
+        )
 
         return PlanarSurface(self.rupture_mesh_spacing, nodal_plane.strike,
                              nodal_plane.dip, left_top, right_top,


### PR DESCRIPTION
This patch simply refactor the algorithm used to compute planar surface coordinates generated by PointSources to fix: https://bugs.launchpad.net/oq-hazardlib/+bug/1190569

With the current algorithm PointSources close to the poles generate invalid ruptures throwing this exception ("surface's angles are not right"). This has been found using Graeme's input for the global model.

It seems that by simply rearranging the way coordinates are computed (rather then moving along the perimeter, compute coordinates with respect to rupture center) solves the issue, presumably because in this way numerical errors are not propagated from one corner to the other.
