### PR TITLE
Undo a false optimization in the SiteCollection.

### DIFF
--- a/openquake/hazardlib/site.py
+++ b/openquake/hazardlib/site.py
@@ -215,10 +215,8 @@ class SiteCollection(object):
         num_values = data.shape[1]
         result = numpy.empty((total_sites, num_values))
         result.fill(placeholder)
-        #for i in xrange(num_values):
-        #    result[:, i].put(self.indices, data[:, i])
-        for i, idx in enumerate(self.indices):
-            result[idx] = data[i]
+        for i in xrange(num_values):
+            result[:, i].put(self.indices, data[:, i])
         return result
 
     def filter(self, mask):


### PR DESCRIPTION
Restores the original numpy-based SiteCollection `expand` algorithm.

While slower than a plain Python implementation with small datasets,
the advantage of numpy really shows through with larger datasets.

I've been meaning to reverse this change for a while, since I found
in profiling run that this change was indeed not faster.
