### PR TITLE
Added a __repr__ to source objects

### DIFF
--- a/openquake/hazardlib/source/base.py
+++ b/openquake/hazardlib/source/base.py
@@ -208,3 +208,10 @@ class SeismicSource(object):
         return [(mag, occ_rate)
                 for (mag, occ_rate) in self.mfd.get_annual_occurrence_rates()
                 if min_rate is None or occ_rate > min_rate]
+
+    def __repr__(self):
+        """
+        String representation of a source, displaying the source class name
+        and the source id.
+        """
+        return '<%s %s>' % (self.__class__.__name__, self.source_id)


### PR DESCRIPTION
This is convenient in debugging. Also, if there is a slow source taking a lot of time in the computation, having the source_id in the `__repr__` make it possible to recognize which is the source. The use case is inspecting the arguments of a worker via celery.task.control.inspect.
