### PR TITLE
We must not lose the traceback of exceptions

### DIFF
--- a/openquake/hazardlib/calc/disagg.py
+++ b/openquake/hazardlib/calc/disagg.py
@@ -18,6 +18,7 @@
 :func:`disaggregation` as well as several aggregation functions for
 extracting a specific PMF from the result of :func:`disaggregation`.
 """
+import sys
 import numpy
 import warnings
 
@@ -182,9 +183,10 @@ def _collect_bins_data(sources, site, imt, iml, gsims,
                     rupture.get_probability_no_exceedance(poes_given_rup_eps)
                 )
         except Exception, err:
+            etype, err, tb = sys.exc_info()
             msg = 'An error occurred with source id=%s. Error: %s'
             msg %= (source.source_id, err.message)
-            raise RuntimeError(msg)
+            raise etype, msg, tb
 
     mags = numpy.array(mags, float)
     dists = numpy.array(dists, float)

--- a/openquake/hazardlib/calc/hazard_curve.py
+++ b/openquake/hazardlib/calc/hazard_curve.py
@@ -18,6 +18,7 @@
 :mod:`openquake.hazardlib.calc.hazard_curve` implements
 :func:`hazard_curves`.
 """
+import sys
 import numpy
 
 from openquake.hazardlib.calc import filters
@@ -103,9 +104,10 @@ def hazard_curves(
                         pno, total_sites, placeholder=1
                     )
         except Exception, err:
+            etype, err, tb = sys.exc_info()
             msg = 'An error occurred with source id=%s. Error: %s'
             msg %= (source.source_id, err.message)
-            raise RuntimeError(msg)
+            raise etype, msg, tb
 
     for imt in imts:
         curves[imt] = 1 - curves[imt]

--- a/openquake/hazardlib/calc/stochastic.py
+++ b/openquake/hazardlib/calc/stochastic.py
@@ -17,6 +17,7 @@
 :mod:`openquake.hazardlib.calc.stochastic` contains
 :func:`stochastic_event_set`.
 """
+import sys
 from openquake.hazardlib.calc import filters
 
 
@@ -61,9 +62,10 @@ def stochastic_event_set(
                     for i in xrange(rupture.sample_number_of_occurrences()):
                         yield rupture
             except Exception, err:
+                etype, err, tb = sys.exc_info()
                 msg = 'An error occurred with source id=%s. Error: %s'
                 msg %= (source.source_id, err.message)
-                raise RuntimeError(msg)
+                raise etype, msg, tb
         return
     # else apply filtering
     sources_sites = source_site_filter((source, sites) for source in sources)
@@ -75,6 +77,7 @@ def stochastic_event_set(
                 for i in xrange(rupture.sample_number_of_occurrences()):
                     yield rupture
         except Exception, err:
+            etype, err, tb = sys.exc_info()
             msg = 'An error occurred with source id=%s. Error: %s'
             msg %= (source.source_id, err.message)
-            raise RuntimeError(msg)
+            raise etype, msg, tb

--- a/openquake/hazardlib/tests/calc/hazard_curve_test.py
+++ b/openquake/hazardlib/tests/calc/hazard_curve_test.py
@@ -54,8 +54,10 @@ class HazardCurvesTestCase(unittest.TestCase):
             self.imts = imts
             self.poes = poes
             self.dists = object()
+
         def make_contexts(self, sites, rupture):
             return (sites, rupture, self.dists)
+
         def get_poes(self, sctx, rctx, dctx, imt, imls, truncation_level):
             assert truncation_level is self.truncation_level
             assert dctx is self.dists
@@ -138,7 +140,7 @@ class HazardCurvesTestCase(unittest.TestCase):
                                       self.source2.time_span)
         sources = iter([self.source1, fail_source])
 
-        with self.assertRaises(RuntimeError) as ae:
+        with self.assertRaises(ValueError) as ae:
             hazard_curves(sources, self.sites, self.imts, self.gsims,
                           self.truncation_level)
         expected_error = (

--- a/openquake/hazardlib/tests/calc/stochastic_test.py
+++ b/openquake/hazardlib/tests/calc/stochastic_test.py
@@ -15,7 +15,6 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 import unittest
 
-from openquake.hazardlib.tom import PoissonTOM
 from openquake.hazardlib.calc.stochastic import stochastic_event_set
 
 
@@ -95,7 +94,7 @@ class StochasticEventSetTestCase(unittest.TestCase):
         # seismic source; in this case, we expect an error to be raised which
         # signals the id of the source in question
         fail_source = self.FailSource(2, [self.r2_1])
-        with self.assertRaises(RuntimeError) as ae:
+        with self.assertRaises(ValueError) as ae:
             list(stochastic_event_set([self.source1, fail_source]))
 
         expected_error = (
@@ -109,9 +108,9 @@ class StochasticEventSetTestCase(unittest.TestCase):
         # signals the id of the source in question
         fail_source = self.FailSource(2, [self.r2_1])
         fake_sites = [1, 2, 3]
-        with self.assertRaises(RuntimeError) as ae:
+        with self.assertRaises(ValueError) as ae:
             list(stochastic_event_set([self.source1, fail_source],
-                                       sites=fake_sites))
+                                      sites=fake_sites))
 
         expected_error = (
             'An error occurred with source id=2. Error: Something bad happened'


### PR DESCRIPTION
The three arguments form of `raise` is the recommended one, if you do not want to lose the type and the traceback of the exception. Also some PEP8 fixes.
