### PR TITLE
Introduce a GmfComputer class calling gsim.make_context only once

### DIFF
--- a/openquake/hazardlib/calc/gmf.py
+++ b/openquake/hazardlib/calc/gmf.py
@@ -28,7 +28,13 @@ class GmfComputer(object):
     """
     Given an earthquake rupture, the ground motion field computer computes
     ground shaking over a set of sites, by randomly sampling a ground
-    shaking intensity model.
+    shaking intensity model. The usage is
+
+       gmfcomputer = GmfComputer(rupture, r_sites, imts, gsim,
+                                 truncation_level, correlation_model)
+       gmf_dict1 = gmfcomputer.compute(seed1)
+       gmf_dict2 = gmfcomputer.compute(seed2)
+       ...
 
     :param openquake.hazardlib.source.rupture.Rupture rupture:
         Rupture to calculate ground motion fields radiated from.


### PR DESCRIPTION
See https://bugs.launchpad.net/oq-hazardlib/+bug/1321998. The tests are green: https://ci.openquake.org/job/zdevel_oq-hazardlib/80/

There is a companion pull request on the engine: https://github.com/gem/oq-engine/pull/1441
