### PR TITLE
Solved a long standing bug with inconsistent unpickling of the IMTs

### DIFF
--- a/openquake/hazardlib/imt.py
+++ b/openquake/hazardlib/imt.py
@@ -72,9 +72,6 @@ class _IMT(tuple):
             return 'SA(%s)' % self[1]
         return self[0]
 
-    def __hash__(self):
-        return hash(repr(self))
-
     def __repr__(self):
         return '%s(%s)' % (type(self).__name__,
                            ', '.join('%s=%s' % (field, getattr(self, field))

--- a/openquake/hazardlib/tests/imt_test.py
+++ b/openquake/hazardlib/tests/imt_test.py
@@ -73,6 +73,12 @@ class BaseIMTTestCase(unittest.TestCase):
             imt_pik = cPickle.dumps(imt, cPickle.HIGHEST_PROTOCOL)
             self.assertEqual(cPickle.loads(imt_pik), imt)
 
+    def test_equivalent(self):
+        sa1 = imt_module.from_string('SA(0.1)')
+        sa2 = imt_module.from_string('SA(0.10)')
+        self.assertEqual(sa1, sa2)
+        self.assertEqual(set([sa1, sa2]), set([sa1]))
+
     def test_from_string(self):
         sa = imt_module.from_string('SA(0.1)')
         self.assertEqual(sa, ('SA', 0.1, 5.0))


### PR DESCRIPTION
This has been annoying me to no end on the engine side. See https://bugs.launchpad.net/oq-hazardlib/+bug/1322794
The tests are green: https://ci.openquake.org/job/zdevel_oq-hazardlib/82/
