### PR TITLE
Separates correlation model from distance calculation

### DIFF
--- a/openquake/hazardlib/correlation.py
+++ b/openquake/hazardlib/correlation.py
@@ -104,13 +104,25 @@ class JB2009CorrelationModel(BaseCorrelationModel):
         Parameters are the same as for
         :meth:`BaseCorrelationModel.get_lower_triangle_correlation_matrix`.
         """
+        distances = sites.mesh.get_distance_matrix()
+        return self._get_correlation_model(distances, imt)
+
+    def _get_correlation_model(self, distances, imt):
+        """
+        Returns the correlation model for a set of distances, given the
+        appropriate period
+
+        :param numpy.ndarray distances:
+            Distance matrix
+
+        :param float period:
+            Period of spectral acceleration
+        """
         if isinstance(imt, SA):
             period = imt.period
         else:
             assert isinstance(imt, PGA)
             period = 0
-
-        distances = sites.mesh.get_distance_matrix()
 
         # formulae are from page 1700
         if period < 1:


### PR DESCRIPTION
This PR separates the correlation model from the distance calculation in the JB2009 correlation model. This serves several purposes:

i) Permits the ability to define correlation coefficients for non-square matrices. This is needed for application to conditional simulation as it is necessary to define the correlation between two different sets of locations. 

ii) Makes new correlation models of the exponential form  easier to implement as they only need subclass the JB2009 model and modify the coefficients of the exponential model.
