### PR TITLE
Add a debug flag to enable set -x in packager.sh

### DIFF
--- a/packager.sh
+++ b/packager.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 # export PS4='+${BASH_SOURCE}:${LINENO}:${FUNCNAME[0]}: '
-# set -x
+if [ $GEM_SET_DEBUG ]; then
+    set -x
+fi
 set -e
 GEM_GIT_REPO="git://github.com/gem"
 GEM_GIT_PACKAGE="oq-hazardlib"


### PR DESCRIPTION
This PR allows to enable the `packager.sh` debug just setting the environment var `$GEM_SET_DEBUG` in Jenkins.
