### PR TITLE
Add tox.ini config for easy test running

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,13 @@
+[tox]
+minversion = 1.6
+envlist = py27
+
+[testenv]
+# NOTE: numpy and scipy should be installed separately
+# There is a bootstrapping problem with the setup.py of hazardlib,
+# because it imports numpy.
+deps = mock
+       nose
+       coverage
+sitepackages=True
+commands = nosetests {posargs} --with-doctest --with-coverage --cover-package=openquake.hazardlib


### PR DESCRIPTION
`tox` is currently the "blessed" way of executing tests. The nice thing about it is that you can add multiple test environments for different python versions (2.6, 2.7, 3.1, 3.2, 3.3, etc.). You can even add configuration for running pep8 and pyflakes.

To run it, just `pip install tox` once, then run `tox`. It will handle everything from there. I find this to be a really convenient way to execute tests. =)

NOTE: Numpy (and probably scipy) need to be installed outside of the tox virtualenv. See the note in `tox.ini`.
