### PR TITLE
imt.from_string now returns a ValueError and can be used as a validator

### DIFF
--- a/openquake/hazardlib/imt.py
+++ b/openquake/hazardlib/imt.py
@@ -41,7 +41,11 @@ def from_string(imt):
         period = float(match.group(1))
         return SA(period, DEFAULT_SA_DAMPING)
     else:
-        return globals()[imt](None, None)
+        try:
+            imt_class = globals()[imt]
+        except KeyError:
+            raise ValueError('Unknown IMT: %s' % imt)
+        return imt_class(None, None)
 
 
 @functools.total_ordering

--- a/openquake/hazardlib/tests/imt_test.py
+++ b/openquake/hazardlib/tests/imt_test.py
@@ -84,7 +84,7 @@ class BaseIMTTestCase(unittest.TestCase):
         self.assertEqual(sa, ('SA', 0.1, 5.0))
         pga = imt_module.from_string('PGA')
         self.assertEqual(pga, ('PGA', None, None))
-        with self.assertRaises(KeyError):
+        with self.assertRaises(ValueError):
             imt_module.from_string('XXX')
 
 


### PR DESCRIPTION
This is helpful for the new validation system. See the companion https://github.com/gem/oq-commonlib/pull/31.
The tests run: https://ci.openquake.org/job/zdevel_oq-hazardlib/92
