### PR TITLE
Changed the API of the GmfComputer

### DIFF
--- a/openquake/hazardlib/calc/gmf.py
+++ b/openquake/hazardlib/calc/gmf.py
@@ -238,7 +238,7 @@ def ground_motion_fields(rupture, sites, imts, gsim, truncation_level,
                     for imt in imts)
     [(rupture, sites)] = ruptures_sites
 
-    gc = GmfComputer(rupture, sites, imts, [gsim], truncation_level,
+    gc = GmfComputer(rupture, sites, imts, gsim, truncation_level,
                      correlation_model)
     result = gc._compute(seed, gsim, realizations)
     for imt, gmf in result.iteritems():


### PR DESCRIPTION
I am making the GMFComputer more similar to the ground_motion_field function. Now it accepts a single GSIM instead of a list of them. The tests are running here: https://ci.openquake.org/job/zdevel_oq-hazardlib/132
