### PR TITLE
Modify get_fault_vertices_3d in simple_fault.py and the test

### DIFF
--- a/openquake/hazardlib/geo/surface/simple_fault.py
+++ b/openquake/hazardlib/geo/surface/simple_fault.py
@@ -185,6 +185,7 @@ class SimpleFaultSurface(BaseQuadrilateralSurface):
         """
         # Similar to :meth:`from_fault_data`, we just don't resample edges
         dip_tan = math.tan(math.radians(dip))
+        hdist_top = upper_seismogenic_depth / dip_tan
         hdist_bottom = lower_seismogenic_depth / dip_tan
 
         strike = fault_trace[0].azimuth(fault_trace[-1])
@@ -200,7 +201,7 @@ class SimpleFaultSurface(BaseQuadrilateralSurface):
         t_dep = []
 
         for point in fault_trace.points:
-            top_edge_point = point.point_at(0, 0, 0)
+            top_edge_point = point.point_at(hdist_top, 0, azimuth)
             bottom_edge_point = point.point_at(hdist_bottom, 0, azimuth)
 
             lons.append(top_edge_point.longitude)

--- a/openquake/hazardlib/tests/geo/surface/simple_fault_test.py
+++ b/openquake/hazardlib/tests/geo/surface/simple_fault_test.py
@@ -259,8 +259,10 @@ class SimpleFaultSurfaceProjectionTestCase(unittest.TestCase):
             upper_seismogenic_depth=25.3, lower_seismogenic_depth=53.6,
             dip=30,
         )
-        elons = [10, 11, 12, 12.13515987, 11.13560807, 10.1354272]
-        elats = [-20, -20.2, -19.7, -20.52520878, -21.02520738, -20.82520794]
+        elons = [10.06374285, 11.06382605, 12.06361991,
+                 12.13515987, 11.13560807, 10.1354272]
+        elats = [-20.3895235, -20.58952337, -20.08952368, -
+                 20.52520878, -21.02520738, -20.82520794]
         edeps = [25.3, 25.3, 25.3, 53.6, 53.6, 53.6]
 
         numpy.testing.assert_allclose(lons, elons)


### PR DESCRIPTION
Modify the get_fault_vertices_3d in simple_fault.py to make the definition more consistent with the libraries in hazardlib

The test has pass and shown in the following link:
https://ci.openquake.org/job/zdevel_oq-hazardlib/151/
