### PR TITLE
Change git version code to avoid "-git" suffix if it's from packages

### DIFF
--- a/openquake/hazardlib/general.py
+++ b/openquake/hazardlib/general.py
@@ -26,10 +26,10 @@ def git_suffix(fname):
     :returns: `<short git hash>` if Git repository found
     """
     try:
-        po = subprocess.Popen(
-            ['git', 'rev-parse', '--short', 'HEAD'], stdout=subprocess.PIPE,
-            stderr=open(os.devnull, 'w'), cwd=os.path.dirname(fname))
-        return "-git" + po.stdout.read().strip()
+        gh = subprocess.check_output(['git', 'rev-parse', '--short', 'HEAD'],
+             cwd=os.path.dirname(fname)).strip()
+        gh = "-git" + gh if gh else ''
+        return gh
     except:
         # trapping everything on purpose; git may not be installed or it
         # may not work properly


### PR DESCRIPTION
This improves the code that retrieve the git version. It avoids the "-git" suffix if the git executable is installed on system but the oq-engine comes from packages.