### PR TITLE
New version management for development packaging.

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,35 @@
+python-oq-hazardlib (0.13.0-0) precise; urgency=low
+
+  [Marco Pagani]
+  * Implements Ask2014 GMPE
+
+  [Graeme Weatherill]
+  * Implements Rietbrock et al (2013) GMPE
+
+  [Yen-Shin Chen]
+  * enable to change the hypocentre location.
+
+  [Marco Pagani]
+  * Gridsource added
+
+  [Michele Simionato]
+  * Added a test sensitive to the underlying distance libraries
+
+  [Marco Pagani]
+  * Ry0 support
+
+  [Graeme Weatherill]
+  * Implements Bindi et al (2014) GMPE
+
+  [Laurentiu Danciu]
+  * Implements Cf2008 for Swiss GMPE
+
+  [Graeme Weatherill]
+  * Implements Cauzzi et al (2014) GMPE
+  * Implements PEER adaptation of Chiou & Youngs 2014
+
+ -- Matteo Nastasi (GEM Foundation) <nastasi@openquake.org>  Wed, 25 Feb 2015 16:04:03 +0100
+
 python-oq-hazardlib (0.12.1-0) precise; urgency=low
 
   * consistency in version management between debian/ubuntu package and

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,10 +1,3 @@
-  [Marco Pagani]
-  * Test item for development purpose
-
-  [Graeme Weatherill]
-  * Test item for development purpose with long description on
-    multiple lines
-
 python-oq-hazardlib (0.13.0-0) precise; urgency=low
 
   [Marco Pagani]

--- a/openquake/hazardlib/__init__.py
+++ b/openquake/hazardlib/__init__.py
@@ -23,5 +23,5 @@ from openquake.hazardlib import (
 )
 
 # the version is managed by packager.sh with a sed
-__version__ = '0.13.0'
+__version__ = '0.14.0'
 __version__ += general.git_suffix(__file__)

--- a/packager.sh
+++ b/packager.sh
@@ -484,7 +484,7 @@ if [ $BUILD_DEVEL -eq 1 ]; then
     if [ "$pkg_maj" = "$ini_maj" -a "$pkg_min" = "$ini_min" -a \
          "$pkg_bfx" = "$ini_bfx" -a "$pkg_deb" != "" ]; then
         deb_ct="$(echo "$pkg_deb" | sed 's/^-//g')"
-        pkg_deb="-$(( deb_ct + 1 ))"
+        pkg_deb="-${deb_ct}"
     else
         pkg_maj="$ini_maj"
         pkg_min="$ini_min"
@@ -492,7 +492,7 @@ if [ $BUILD_DEVEL -eq 1 ]; then
         pkg_deb="-1"
     fi
 
-    ( echo "$pkg_name (${pkg_maj}.${pkg_min}.${pkg_bfx}${pkg_deb}+dev${dt}-${hash}) $pkg_rest"
+    ( echo "$pkg_name (${pkg_maj}.${pkg_min}.${pkg_bfx}${pkg_deb}~dev${dt}-${hash}) $pkg_rest"
       echo
       echo "  * Development version from $hash commit"
       echo

--- a/packager.sh
+++ b/packager.sh
@@ -186,6 +186,8 @@ _pkgtest_innervm_run () {
     ssh $lxc_ip "sudo apt-get install -y ${GEM_DEB_PACKAGE}"
     ssh $lxc_ip "sudo apt-get install --reinstall -y ${GEM_DEB_PACKAGE}"
 
+    scp -r "$lxc_ip://usr/share/doc/${GEM_DEB_PACKAGE}" ./usr_share_doc
+
     trap ERR
 
     return

--- a/packager.sh
+++ b/packager.sh
@@ -465,7 +465,7 @@ ini_bfx="$(echo "$ini_vers" | sed -n 's/^[0-9]\+\.[0-9]\+\.\([0-9]\+\).*/\1/gp')
 ini_suf="" # currently not included into the version array structure
 
 # version info from debian/changelog
-h="$(head -n1 debian/changelog)"
+h="$(grep "^$GEM_DEB_PACKAGE" debian/changelog | head -n 1)"
 # pkg_vers="$(echo "$h" | cut -d ' ' -f 2 | cut -d '(' -f 2 | cut -d ')' -f 1 | sed -n 's/[-+].*//gp')"
 pkg_name="$(echo "$h" | cut -d ' ' -f 1)"
 pkg_vers="$(echo "$h" | cut -d ' ' -f 2 | cut -d '(' -f 2 | cut -d ')' -f 1)"
@@ -484,22 +484,24 @@ if [ $BUILD_DEVEL -eq 1 ]; then
     if [ "$pkg_maj" = "$ini_maj" -a "$pkg_min" = "$ini_min" -a \
          "$pkg_bfx" = "$ini_bfx" -a "$pkg_deb" != "" ]; then
         deb_ct="$(echo "$pkg_deb" | sed 's/^-//g')"
-        pkg_deb="-${deb_ct}"
+        pkg_deb="-$(( deb_ct ))"
     else
         pkg_maj="$ini_maj"
         pkg_min="$ini_min"
         pkg_bfx="$ini_bfx"
-        pkg_deb="-1"
+        pkg_deb="-0"
     fi
 
     ( echo "$pkg_name (${pkg_maj}.${pkg_min}.${pkg_bfx}${pkg_deb}~dev${dt}-${hash}) $pkg_rest"
       echo
+      echo "  [Automatic Script]"
       echo "  * Development version from $hash commit"
       echo
+      cat debian/changelog.orig | sed -n "/^$GEM_DEB_PACKAGE/q;p"
       echo " -- $DEBFULLNAME <$DEBEMAIL>  $(date -d@$dt -R)"
       echo
     )  > debian/changelog
-    cat debian/changelog.orig >> debian/changelog
+    cat debian/changelog.orig | sed -n "/^$GEM_DEB_PACKAGE/,\$ p" >> debian/changelog
     rm debian/changelog.orig
 fi
 

--- a/packager.sh
+++ b/packager.sh
@@ -186,7 +186,8 @@ _pkgtest_innervm_run () {
     ssh $lxc_ip "sudo apt-get install -y ${GEM_DEB_PACKAGE}"
     ssh $lxc_ip "sudo apt-get install --reinstall -y ${GEM_DEB_PACKAGE}"
 
-    scp -r "$lxc_ip://usr/share/doc/${GEM_DEB_PACKAGE}" ./usr_share_doc
+    scp -r "$lxc_ip://usr/share/doc/${GEM_DEB_PACKAGE}/changelog*" .
+    scp -r "$lxc_ip://usr/share/doc/${GEM_DEB_PACKAGE}/README*" .
 
     trap ERR
 


### PR DESCRIPTION
- implemented the new guideline for version management, on master branch we will have always the release version after the current released.
- development packages will use ```~gem...``` suffix to be **lesser than** version **without** suffix (Debian - behavior for suffixes starting with ```~``` character).
- changelog and README are copied back to jenkins folders to be able to check them, an example at:
  ```jenkins@ci.openquake.org:jobs/zdevel_oq-hazardlib/workspace_new_vers_mgmt2_236```