### PR TITLE
Fixes CRITICAL area source hypocentral depth bug

### DIFF
--- a/openquake/hazardlib/source/area.py
+++ b/openquake/hazardlib/source/area.py
@@ -16,6 +16,7 @@
 """
 Module :mod:`openquake.hazardlib.source.area` defines :class:`AreaSource`.
 """
+from copy import deepcopy
 from openquake.hazardlib.geo import Point
 from openquake.hazardlib.source.point import PointSource
 from openquake.hazardlib.source.rupture import ParametricProbabilisticRupture
@@ -123,7 +124,7 @@ class AreaSource(PointSource):
                 # translate the surface from first epicenter position
                 # to the target one preserving it's geometry
                 surface = surface.translate(epicenter0, epicenter)
-                hypocenter = epicenter
+                hypocenter = deepcopy(epicenter)
                 hypocenter.depth = hc_depth
                 rupture = ParametricProbabilisticRupture(
                     mag, rake, self.tectonic_region_type, hypocenter,


### PR DESCRIPTION
This PR attempts to fix a bug in the hypocentral depth distribution within the iter_ruptures() method of the area source.

Currently, when generating the ruptures a binding is taking place between the hypocentral depth used in each hypocentre in the rupture. https://github.com/gem/oq-hazardlib/blob/master/openquake/hazardlib/source/area.py#L127. This means that each time hc_depth changes, the hypocentral depth on all the previous ruptures are changed. This gives the unwanted, and incorrect, outcome that the hypocentral depth for all of the ruptures corresponds to the last value of the data PMF. This PR proposes the use of deepcopy(epicentre) to avoid binding the classes together.

Furthermore, the hypocentral depths of the resulting ruptures were not checked in the tests. The area_source test has now been extended to include this case.