### PR TITLE
Make GEM_EPHEM_NAME customizable via an env variable

### DIFF
--- a/packager.sh
+++ b/packager.sh
@@ -23,7 +23,6 @@ GEM_ALWAYS_YES=false
 if [ "$GEM_EPHEM_CMD" = "" ]; then
     GEM_EPHEM_CMD="lxc-start-ephemeral"
 fi
-
 if [ "$GEM_EPHEM_NAME" = "" ]; then
     GEM_EPHEM_NAME="ubuntu-lxc-eph"
 fi

--- a/packager.sh
+++ b/packager.sh
@@ -23,7 +23,10 @@ GEM_ALWAYS_YES=false
 if [ "$GEM_EPHEM_CMD" = "" ]; then
     GEM_EPHEM_CMD="lxc-start-ephemeral"
 fi
-GEM_EPHEM_NAME="ubuntu-lxc-eph"
+
+if [ "$GEM_EPHEM_NAME" = "" ]; then
+    GEM_EPHEM_NAME="ubuntu-lxc-eph"
+fi
 
 if command -v lxc-shutdown &> /dev/null; then
     # Older lxc (< 1.0.0) with lxc-shutdown


### PR DESCRIPTION
This is needed for the LXC with all the dependencies installed.

An `ubuntu-lxc-eph-fast` has been created with all the dependencies installed except for: `python-celery` `rabbitmq-server` `python-concurrent.futures` `python-django16` to test that our custom packages are always fine.

This new LXC will be used by default by all the `zdevel` CI jobs.

See also: https://github.com/gem/oq-engine/pull/1696