### PR TITLE
Adds hypo_loc to rupture context

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,7 +1,5 @@
   [Graeme Weatherill]
   * Adds 'hypo_loc' slot to RuptureContext object
-  
-  [Graeme Weatherill]
   * Implements Abrahamson et al. (2015) BC Hydro GMPE
   * Adds backarc term to the Site and SiteCollection object
   

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,7 @@
   [Graeme Weatherill]
+  * Adds 'hypo_loc' slot to RuptureContext object
+  
+  [Graeme Weatherill]
   * Implements Abrahamson et al. (2015) BC Hydro GMPE
   * Adds backarc term to the Site and SiteCollection object
   

--- a/openquake/hazardlib/gsim/base.py
+++ b/openquake/hazardlib/gsim/base.py
@@ -707,7 +707,7 @@ class RuptureContext(BaseContext):
     """
     __slots__ = (
         'mag', 'strike', 'dip', 'rake', 'ztor', 'hypo_lon', 'hypo_lat',
-        'hypo_depth', 'width'
+        'hypo_depth', 'width', 'hypo_loc'
     )
 
 


### PR DESCRIPTION
Adds the term "hypo_loc" to the slots of the Rupture Context. This may eventually be filled with a tuple indicating the fractional along-strike and down-dip location of the hypocentre on the rupture plane.

Tests are green: https://ci.openquake.org/job/zdevel_oq-hazardlib/258/