### PR TITLE
Add support for both Precise and Trusty in packager.sh

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,7 @@
+  [Daniele Viganò]
+  * Add binary package support for both Ubuntu 12.04 (Precise)
+    and Ubuntu 14.04 (Trusty)
+  
   [Graeme Weatherill]
   * Adds 'hypo_loc' slot to RuptureContext object
   * Implements Abrahamson et al. (2015) BC Hydro GMPE

--- a/packager.sh
+++ b/packager.sh
@@ -27,6 +27,8 @@ if [ "$GEM_EPHEM_NAME" = "" ]; then
     GEM_EPHEM_NAME="ubuntu-lxc-eph"
 fi
 
+LSB_RELEASE=$(lsb_release --id --short)
+
 if command -v lxc-shutdown &> /dev/null; then
     # Older lxc (< 1.0.0) with lxc-shutdown
     LXC_TERM="lxc-shutdown -t 10 -w"
@@ -329,9 +331,9 @@ pkgtest_run () {
     dpkg-scansources . > Sources
     cat Sources | gzip > Sources.gz
     cat > Release <<EOF
-Archive: precise
+Archive: $LSB_RELEASE
 Origin: Ubuntu
-Label: Local Ubuntu Precise Repository
+Label: Local Ubuntu ${LSB_RELEASE^} Repository
 Architecture: amd64
 MD5Sum:
 EOF

--- a/packager.sh
+++ b/packager.sh
@@ -27,7 +27,7 @@ if [ "$GEM_EPHEM_NAME" = "" ]; then
     GEM_EPHEM_NAME="ubuntu-lxc-eph"
 fi
 
-LSB_RELEASE=$(lsb_release --id --short)
+LSB_RELEASE=$(lsb_release --codename --short)
 
 if command -v lxc-shutdown &> /dev/null; then
     # Older lxc (< 1.0.0) with lxc-shutdown


### PR DESCRIPTION
Tests on `precise`: https://ci.openquake.org/job/zdevel_oq-hazardlib/272/
Tests on `trusty`: https://ci-dev.openquake.org/job/zdevel_oq-hazardlib/266/

Tests are green.