### PR TITLE
Memory efficient representation for the GMFs

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,13 +1,16 @@
+  [Michele Simionato]
+  * Introduced a compact representation of the GMFs as a single array
+
   [Graeme Weatherill]
   * Implements Dost et al (2004) Induced Seismicity GMPE
   * Implements Atkinson (2015) Induced Seismicity GMPE
   * Adds new tectonic region type "Induced" to constants
-  
+
   [Graeme Weatherill]
   * Adds 'hypo_loc' slot to RuptureContext object
   * Implements Abrahamson et al. (2015) BC Hydro GMPE
   * Adds backarc term to the Site and SiteCollection object
-  
+
   [Marco Pagani]
   * Fixes a bug in the calculation of the hanging wall term of the Abrahamson
     et al. (2014)
@@ -16,7 +19,7 @@
   * Simple fault: added a method to finds the index of the fault patch including the hypocentre.
   * Base surface: fixes mesh input in get_hypo_location method
   * Near fault: implementing the Chiou & Spudich(2014) direcitivty model, the methods needed in the model.
-  
+
   [Yen-Shin Chen]
   * Simple fault: added a method to retrieve the vertexes of a patch given its index
   * Base surface: added a method to get a set of point representing a resampled top edge

--- a/openquake/hazardlib/calc/gmf.py
+++ b/openquake/hazardlib/calc/gmf.py
@@ -261,30 +261,3 @@ def ground_motion_fields(rupture, sites, imts, gsim, truncation_level,
             result[imt] = sites.expand(gmf, placeholder=0)
 
     return {from_string(imt): result[imt] for imt in result}
-
-
-# this is used in the engine and in oq-lite
-def build_gmf_by_tag(rsts, gsims, imts, truncation_level=None,
-                     correlation_model=None):
-    """
-    :param rsts:
-        a sequence of tuples of the form (rupture, sites, tags, seeds)
-    :param gsims:
-        an ordered sequence of GSIM instance
-    :param imts:
-        an ordered sequence of IMT strings
-    :param truncation_level:
-        the truncation level (default None)
-    :param correlation_model:
-        the correlation model to use (default None)
-    :returns:
-        a dictionary tag -> gmf
-
-    The tags are assumed to be unique and sortable.
-    """
-    gmf_by_tag = {}
-    for rupture, sites, tags, seeds in rsts:
-        gmfs = GmfComputer(rupture, sites, imts, gsims, truncation_level,
-                           correlation_model).compute(seeds)
-        gmf_by_tag.update(zip(tags, gmfs))
-    return gmf_by_tag

--- a/openquake/hazardlib/calc/gmf.py
+++ b/openquake/hazardlib/calc/gmf.py
@@ -84,7 +84,6 @@ class GmfComputer(object):
         self.sites = sites
         self.imts = map(from_string, imts)
         self.gsims = gsims
-        self.gsim_strings = map(str, gsims)
         self.truncation_level = truncation_level
         self.correlation_model = correlation_model
         self.ctx = {gsim: gsim.make_contexts(sites, rupture) for gsim in gsims}

--- a/openquake/hazardlib/calc/gmf.py
+++ b/openquake/hazardlib/calc/gmf.py
@@ -182,7 +182,12 @@ class GmfComputer(object):
                 for imt, value in self._compute(
                         seed, gsim, realizations=1).iteritems():
                     # 1 realization, get the 0-th colum of the v-array
-                    for i, gmv in enumerate(value[:, 0].reshape(-1)):
+                    array = map(float, value[:, 0])
+                    # NB: with correlation, the value is a numpy.matrix
+                    # not an array, flatten does not work and the only
+                    # way to extract the numbers is the map before!
+                    # something is wrong and must be fixed in the future
+                    for i, gmv in enumerate(array):
                         gmfa[i][gs][imt] = gmv
             gmfs.append(gmfa)
         return gmfs

--- a/openquake/hazardlib/calc/gmf.py
+++ b/openquake/hazardlib/calc/gmf.py
@@ -24,6 +24,7 @@ import scipy.stats
 
 from openquake.hazardlib.const import StdDev
 from openquake.hazardlib.calc import filters
+from openquake.hazardlib.gsim.base import gsim_imt_dt
 from openquake.hazardlib.imt import from_string
 
 
@@ -39,19 +40,6 @@ that defines only the total standard deviation. If you want to use a \
 correlation model you have to select a GMPE that provides the inter and \
 intra event standard deviations.''' % (
             self.corr.__class__.__name__, self.gsim.__class__.__name__)
-
-
-def dtype(sorted_gsims, sorted_imts):
-    """
-    Build a numpy dtype for the ground motion field, as an array
-    of nested records with keys gsim and IMT respectively.
-
-    :param sorted_gsims: a list of GSIM instances, sorted lexicographically
-    :param sorted_imts: a list of intensity measure type string, sorted
-    """
-    imt_dt = numpy.dtype([(imt, float) for imt in sorted_imts])
-    gmf_dt = numpy.dtype([(str(gsim), imt_dt) for gsim in sorted_gsims])
-    return gmf_dt
 
 
 class GmfComputer(object):
@@ -100,7 +88,7 @@ class GmfComputer(object):
         self.truncation_level = truncation_level
         self.correlation_model = correlation_model
         self.ctx = {gsim: gsim.make_contexts(sites, rupture) for gsim in gsims}
-        self.gmf_dt = dtype(gsims, imts)
+        self.gmf_dt = gsim_imt_dt(gsims, imts)
 
     def _compute(self, seed, gsim, realizations):
         # the method doing the real stuff; use compute instead

--- a/openquake/hazardlib/calc/gmf.py
+++ b/openquake/hazardlib/calc/gmf.py
@@ -41,6 +41,19 @@ intra event standard deviations.''' % (
             self.corr.__class__.__name__, self.gsim.__class__.__name__)
 
 
+def dtype(sorted_gsims, sorted_imts):
+    """
+    Build a numpy dtype for the ground motion field, as an array
+    of nested records with keys gsim and IMT respectively.
+
+    :param sorted_gsims: a list of GSIM instances, sorted lexicographically
+    :param sorted_imts: a list of intensity measure type string, sorted
+    """
+    imt_dt = numpy.dtype([(imt, float) for imt in sorted_imts])
+    gmf_dt = numpy.dtype([(str(gsim), imt_dt) for gsim in sorted_gsims])
+    return gmf_dt
+
+
 class GmfComputer(object):
     """
     Given an earthquake rupture, the ground motion field computer computes
@@ -87,9 +100,7 @@ class GmfComputer(object):
         self.truncation_level = truncation_level
         self.correlation_model = correlation_model
         self.ctx = {gsim: gsim.make_contexts(sites, rupture) for gsim in gsims}
-        self.imt_dt = numpy.dtype([(imt, float) for imt in imts])
-        self.gmf_dt = numpy.dtype([(gsim, self.imt_dt)
-                                   for gsim in self.gsim_strings])
+        self.gmf_dt = dtype(gsims, imts)
 
     def _compute(self, seed, gsim, realizations):
         # the method doing the real stuff; use compute instead

--- a/openquake/hazardlib/calc/gmf.py
+++ b/openquake/hazardlib/calc/gmf.py
@@ -165,22 +165,23 @@ class GmfComputer(object):
 
         return result
 
-    def compute(self, seed):
+    def compute(self, seeds):
         """
-        Compute the ground motion field for the given sites.
+        Compute the ground motion field for the given sites and seeds.
 
-        :param seed:
-            the seed for the numpy random number generator
+        :param seeds:
+            S seeds for the numpy random number generator
         :returns:
-            a numpy array of dtype gmf_dt
+            a numpy array of dtype gmf_dt and length S
         """
-        gmfs = numpy.zeros(1, self.gmf_dt)
-        for gsim in self.gsims:
-            gmf_by_imt = gmfs[str(gsim)]
-            result = self._compute(seed, gsim, realizations=1)
-            for imt, array in result.iteritems():
-                # consider 1 realization, i.e. return column 0-th of the array
-                gmf_by_imt[imt] = map(float, array[:, 0])
+        S = len(seeds)
+        gmfs = numpy.zeros(S, self.gmf_dt)
+        for seed, gmf_ in zip(seeds, gmfs):
+            for gsim in self.gsims:
+                result = self._compute(seed, gsim, realizations=1)
+                # 1 realization, i.e. consider column 0-th of the v-array
+                tup = tuple(v[:, 0].reshape(-1) for v in result.itervalues())
+                gmf_[str(gsim)] = numpy.array([tup], self.imt_dt)
         return gmfs
 
 

--- a/openquake/hazardlib/gsim/base.py
+++ b/openquake/hazardlib/gsim/base.py
@@ -77,7 +77,8 @@ def deprecated(message):
 
 def gsim_imt_dt(sorted_gsims, sorted_imts):
     """
-    Build a numpy dtype as a nested record with keys gsim and IMT respectively.
+    Build a numpy dtype as a nested record with keys 'idx' and nested
+    (gsim, imt).
 
     :param sorted_gsims: a list of GSIM instances, sorted lexicographically
     :param sorted_imts: a list of intensity measure type strings

--- a/openquake/hazardlib/gsim/base.py
+++ b/openquake/hazardlib/gsim/base.py
@@ -75,6 +75,18 @@ def deprecated(message):
     return _deprecated
 
 
+def gsim_imt_dt(sorted_gsims, sorted_imts):
+    """
+    Build a numpy dtype as a nested record with keys gsim and IMT respectively.
+
+    :param sorted_gsims: a list of GSIM instances, sorted lexicographically
+    :param sorted_imts: a list of intensity measure type strings
+    """
+    imt_dt = numpy.dtype([(imt, float) for imt in sorted_imts])
+    gsim_imt_dt = numpy.dtype([(str(gsim), imt_dt) for gsim in sorted_gsims])
+    return gsim_imt_dt
+
+
 class MetaGSIM(abc.ABCMeta):
     """
     Metaclass providing a warning on instantiation mechanism. A

--- a/openquake/hazardlib/gsim/base.py
+++ b/openquake/hazardlib/gsim/base.py
@@ -83,7 +83,9 @@ def gsim_imt_dt(sorted_gsims, sorted_imts):
     :param sorted_imts: a list of intensity measure type strings
     """
     imt_dt = numpy.dtype([(imt, float) for imt in sorted_imts])
-    gsim_imt_dt = numpy.dtype([(str(gsim), imt_dt) for gsim in sorted_gsims])
+    gsim_imt_dt = numpy.dtype(
+        [('idx', numpy.uint32)] +
+        [(str(gsim), imt_dt) for gsim in sorted_gsims])
     return gsim_imt_dt
 
 

--- a/openquake/hazardlib/tests/calc/gmf_test.py
+++ b/openquake/hazardlib/tests/calc/gmf_test.py
@@ -60,7 +60,6 @@ class FakeGSIMInterIntraStdDevs(BaseFakeGSIM):
 
     def get_mean_and_stddevs(gsim, mean, std_inter, std_intra, imt,
                              stddev_types):
-        assert imt is gsim.testcase.imt1 or imt is gsim.testcase.imt2
         if gsim.expect_stddevs:
             gsim.testcase.assertEqual(
                 stddev_types,
@@ -86,7 +85,6 @@ class FakeGSIMTotalStdDev(BaseFakeGSIM):
 
     def get_mean_and_stddevs(gsim, mean, std_total, not_used, imt,
                              stddev_types):
-        assert imt is gsim.testcase.imt1 or imt is gsim.testcase.imt2
         if gsim.expect_stddevs:
             gsim.testcase.assertEqual(stddev_types, [const.StdDev.TOTAL])
 

--- a/openquake/hazardlib/tests/calc/gmf_test.py
+++ b/openquake/hazardlib/tests/calc/gmf_test.py
@@ -412,9 +412,7 @@ class GMFCalcCorrelatedTestCase(BaseGMFCalcTestCase):
             ground_motion_fields(
                 self.rupture, self.sites, [self.imt1], gsim,
                 truncation_level=None, realizations=6000,
-                correlation_model=cormo,
-           )
-
+                correlation_model=cormo)
 
     def test_rupture_site_filtering(self):
         mean = 10


### PR DESCRIPTION
See https://bugs.launchpad.net/oq-engine/+bug/1438212. The tests are green: https://ci.openquake.org/job/zdevel_oq-hazardlib/280/
This requires two companions on risklib and the engine to be merged: https://github.com/gem/oq-risklib/pull/218 and https://github.com/gem/oq-engine/pull/1739