### PR TITLE
change development version syntax to support multiple '~' characters

### DIFF
--- a/packager.sh
+++ b/packager.sh
@@ -559,7 +559,7 @@ if [ $BUILD_DEVEL -eq 1 ]; then
     fi
 
     (
-      echo "$pkg_name (${pkg_maj}.${pkg_min}.${pkg_bfx}${pkg_deb}~${BUILD_UBUVER}01~dev${dt}-${hash}) ${BUILD_UBUVER}; urgency=low"
+      echo "$pkg_name (${pkg_maj}.${pkg_min}.${pkg_bfx}${pkg_deb}~${BUILD_UBUVER}01~dev${dt}+${hash}) ${BUILD_UBUVER}; urgency=low"
       echo
       echo "  [Automatic Script]"
       echo "  * Development version from $hash commit"


### PR DESCRIPTION
replacing "``-``" with "``+``" latest block isn't splitted in 2 different and comparable units.