### PR TITLE
Source writer support

### DIFF
--- a/openquake/hazardlib/source/characteristic.py
+++ b/openquake/hazardlib/source/characteristic.py
@@ -53,7 +53,7 @@ class CharacteristicFaultSource(ParametricSeismicSource):
 
     NB: if you want to convert a characteristic source into XML, you must set
     its attribute `surface_node` to an explicit representation of the surface
-    as a :class:`openquake.baselib.node.LiteralNode` object.
+    as a :class:`openquake.commonlib.node.LiteralNode` object.
     """
     __slots__ = ParametricSeismicSource.__slots__ + (
         'surface surface_node rake').split()

--- a/openquake/hazardlib/source/characteristic.py
+++ b/openquake/hazardlib/source/characteristic.py
@@ -44,15 +44,19 @@ class CharacteristicFaultSource(ParametricSeismicSource):
     :param rake:
         Angle describing rupture propagation direction in decimal degrees.
 
-    See also :class:`openquake.hazardlib.source.base.ParametricSeismicSource` for
-    description of other parameters.
+    See also :class:`openquake.hazardlib.source.base.ParametricSeismicSource`
+    for description of other parameters.
 
     Note that a ``CharacteristicFaultSource`` does not need any mesh spacing,
     magnitude scaling relationship, and aspect ratio, therefore the constructor
-    set these parameters to ``None``.
+    sets these parameters to ``None``.
+
+    NB: if you want to convert a characteristic source into XML, you must set
+    its attribute `surface_node` to an explicit representation of the surface
+    as a :class:`openquake.baselib.node.LiteralNode` object.
     """
     __slots__ = ParametricSeismicSource.__slots__ + (
-        'surface rake').split()
+        'surface surface_node rake').split()
 
     def __init__(self, source_id, name, tectonic_region_type,
                  mfd, temporal_occurrence_model, surface, rake):

--- a/openquake/hazardlib/source/characteristic.py
+++ b/openquake/hazardlib/source/characteristic.py
@@ -53,7 +53,7 @@ class CharacteristicFaultSource(ParametricSeismicSource):
 
     NB: if you want to convert a characteristic source into XML, you must set
     its attribute `surface_node` to an explicit representation of the surface
-    as a :class:`openquake.commonlib.node.LiteralNode` object.
+    as a LiteralNode object.
     """
     __slots__ = ParametricSeismicSource.__slots__ + (
         'surface surface_node rake').split()

--- a/openquake/hazardlib/source/characteristic.py
+++ b/openquake/hazardlib/source/characteristic.py
@@ -59,7 +59,8 @@ class CharacteristicFaultSource(ParametricSeismicSource):
         'surface surface_node rake').split()
 
     def __init__(self, source_id, name, tectonic_region_type,
-                 mfd, temporal_occurrence_model, surface, rake):
+                 mfd, temporal_occurrence_model, surface, rake,
+                 surface_node=None):
         super(CharacteristicFaultSource, self).__init__(
             source_id, name, tectonic_region_type, mfd, None, None, None,
             temporal_occurrence_model
@@ -67,6 +68,7 @@ class CharacteristicFaultSource(ParametricSeismicSource):
         NodalPlane.check_rake(rake)
         self.surface = surface
         self.rake = rake
+        self.surface_node = surface_node
 
     def get_rupture_enclosing_polygon(self, dilation=0):
         """

--- a/openquake/hazardlib/source/rupture.py
+++ b/openquake/hazardlib/source/rupture.py
@@ -62,9 +62,12 @@ class Rupture(object):
     :raises ValueError:
         If magnitude value is not positive, hypocenter is above the earth
         surface or tectonic region type is unknown.
+
+    NB: if you want to convert the rupture into XML, you should set the attribute
+    surface_nodes to an appropriate value.
     """
     __slots__ = '''mag rake tectonic_region_type hypocenter surface
-    source_typology'''.split()
+    surface_nodes source_typology'''.split()
 
     def __init__(self, mag, rake, tectonic_region_type, hypocenter,
                  surface, source_typology):

--- a/openquake/hazardlib/source/rupture.py
+++ b/openquake/hazardlib/source/rupture.py
@@ -63,14 +63,14 @@ class Rupture(object):
         If magnitude value is not positive, hypocenter is above the earth
         surface or tectonic region type is unknown.
 
-    NB: if you want to convert the rupture into XML, you should set the attribute
-    surface_nodes to an appropriate value.
+    NB: if you want to convert the rupture into XML, you should set the
+    attribute surface_nodes to an appropriate value.
     """
     __slots__ = '''mag rake tectonic_region_type hypocenter surface
     surface_nodes source_typology'''.split()
 
     def __init__(self, mag, rake, tectonic_region_type, hypocenter,
-                 surface, source_typology):
+                 surface, source_typology, surface_nodes=()):
         if not mag > 0:
             raise ValueError('magnitude must be positive')
         if not hypocenter.depth > 0:
@@ -82,6 +82,7 @@ class Rupture(object):
         self.hypocenter = hypocenter
         self.surface = surface
         self.source_typology = source_typology
+        self.surface_nodes = surface_nodes
 
 
 class BaseProbabilisticRupture(Rupture):


### PR DESCRIPTION
Adding two slots surface_node and surface_nodes so that it becomes possible to serialize to XML characteristic sources and non-parametric sources (https://bugs.launchpad.net/oq-engine/+bug/1456618). The functionality is implemented in the companion pull request https://github.com/gem/oq-risklib/pull/248.
The tests are green: https://ci.openquake.org/job/zdevel_oq-hazardlib/318