### PR TITLE
Add rupture_slip_direction attribute

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,7 @@
+ [Yen-Shin Chen]
+
+  * ParametricProbabilisticRupture: adds 'rupture_slip_direction' slot
+
   [Graeme Weatherill]
   * Adds Atkinson & Macias (2009) Subduction Interface GMPE
  

--- a/openquake/hazardlib/source/rupture.py
+++ b/openquake/hazardlib/source/rupture.py
@@ -231,7 +231,8 @@ class ParametricProbabilisticRupture(BaseProbabilisticRupture):
         If occurrence rate is not positive.
     """
     __slots__ = Rupture.__slots__ + [
-        'occurrence_rate', 'temporal_occurrence_model']
+        'occurrence_rate', 'temporal_occurrence_model',
+        'rupture_slip_direction']
 
     def __init__(self, mag, rake, tectonic_region_type, hypocenter, surface,
                  source_typology, occurrence_rate, temporal_occurrence_model,


### PR DESCRIPTION
Adds the term "rupture_slip_direction" to the slots of the ParametricProbabilisticRupture. 

Tests are green: https://ci.openquake.org/job/zdevel_oq-hazardlib/321/