### PR TITLE
debian/changelog: wrong indentation

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,7 +1,7 @@
   [Graeme Weatherill]
   * Adds Atkinson & Macias (2009) Subduction Interface GMPE
  
- [Yen-Shin Chen]
+  [Yen-Shin Chen]
   * Simple fault: Adds 'hypo_list' and 'slip_list' slot
   * Adds 'rcdpp' slot to DistanceContext object
   * ParametricProbabilisticRupture: adds 'rupture_slip_direction' slot and get_dppvalue, get_cdppvalue method


### PR DESCRIPTION
This is causing lots of

```
parsechangelog/debian: warning:     debian/changelog(l9): unrecognized line
LINE:  [Yen-Shin Chen]
parsechangelog/debian: warning:     debian/changelog(l9): unrecognized line
LINE:  [Yen-Shin Chen]
```

warnings on CI and produces a bad readme in packages