### PR TITLE
Add rupture_slip_direction attribute

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,11 +1,10 @@
- [Yen-Shin Chen]
-
+  [Yen-Shin Chen]
   * Rupture: adds 'rupture_slip_direction' slot
 
   [Graeme Weatherill]
   * Adds Atkinson & Macias (2009) Subduction Interface GMPE
  
- [Yen-Shin Chen]
+  [Yen-Shin Chen]
   * Simple fault: Adds 'hypo_list' and 'slip_list' slot
   * Adds 'rcdpp' slot to DistanceContext object
   * ParametricProbabilisticRupture: adds 'rupture_slip_direction' slot and get_dppvalue, get_cdppvalue method

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,6 @@
  [Yen-Shin Chen]
 
-  * ParametricProbabilisticRupture: adds 'rupture_slip_direction' slot
+  * Rupture: adds 'rupture_slip_direction' slot
 
   [Graeme Weatherill]
   * Adds Atkinson & Macias (2009) Subduction Interface GMPE

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,7 @@
+ [Yen-Shin Chen]
+
+  * ParametricProbabilisticRupture: adds 'rupture_slip_direction' slot
+
   [Graeme Weatherill]
   * Adds Atkinson & Macias (2009) Subduction Interface GMPE
  

--- a/openquake/hazardlib/source/rupture.py
+++ b/openquake/hazardlib/source/rupture.py
@@ -231,7 +231,8 @@ class ParametricProbabilisticRupture(BaseProbabilisticRupture):
         If occurrence rate is not positive.
     """
     __slots__ = Rupture.__slots__ + [
-        'occurrence_rate', 'temporal_occurrence_model']
+        'occurrence_rate', 'temporal_occurrence_model',
+        'rupture_slip_direction']
 
     def __init__(self, mag, rake, tectonic_region_type, hypocenter, surface,
                  source_typology, occurrence_rate, temporal_occurrence_model,

--- a/openquake/hazardlib/source/rupture.py
+++ b/openquake/hazardlib/source/rupture.py
@@ -67,10 +67,10 @@ class Rupture(object):
     attribute surface_nodes to an appropriate value.
     """
     __slots__ = '''mag rake tectonic_region_type hypocenter surface
-    surface_nodes source_typology'''.split()
+    surface_nodes source_typology rupture_slip_direction'''.split()
 
     def __init__(self, mag, rake, tectonic_region_type, hypocenter,
-                 surface, source_typology, surface_nodes=()):
+                 surface, source_typology, rupture_slip_direction=None, surface_nodes=()):
         if not mag > 0:
             raise ValueError('magnitude must be positive')
         if not hypocenter.depth > 0:
@@ -83,6 +83,7 @@ class Rupture(object):
         self.surface = surface
         self.source_typology = source_typology
         self.surface_nodes = surface_nodes
+        self.rupture_slip_direction = rupture_slip_direction
 
 
 class BaseProbabilisticRupture(Rupture):
@@ -156,7 +157,7 @@ class NonParametricProbabilisticRupture(BaseProbabilisticRupture):
         in increasing order, and if they are not defined with unit step
     """
     def __init__(self, mag, rake, tectonic_region_type, hypocenter, surface,
-                 source_typology, pmf):
+                 source_typology, pmf, rupture_slip_direction=None):
         x = numpy.array([x for (y, x) in pmf.data])
         if not x[0] == 0:
             raise ValueError('minimum number of ruptures must be zero')
@@ -168,7 +169,7 @@ class NonParametricProbabilisticRupture(BaseProbabilisticRupture):
                 'numbers of ruptures must be defined with unit step')
         super(NonParametricProbabilisticRupture, self).__init__(
             mag, rake, tectonic_region_type, hypocenter, surface,
-            source_typology
+            source_typology, rupture_slip_direction
         )
         self.pmf = pmf
 
@@ -231,8 +232,7 @@ class ParametricProbabilisticRupture(BaseProbabilisticRupture):
         If occurrence rate is not positive.
     """
     __slots__ = Rupture.__slots__ + [
-        'occurrence_rate', 'temporal_occurrence_model',
-        'rupture_slip_direction']
+        'occurrence_rate', 'temporal_occurrence_model']
 
     def __init__(self, mag, rake, tectonic_region_type, hypocenter, surface,
                  source_typology, occurrence_rate, temporal_occurrence_model,
@@ -241,11 +241,10 @@ class ParametricProbabilisticRupture(BaseProbabilisticRupture):
             raise ValueError('occurrence rate must be positive')
         super(ParametricProbabilisticRupture, self).__init__(
             mag, rake, tectonic_region_type, hypocenter, surface,
-            source_typology
+            source_typology, rupture_slip_direction
         )
         self.temporal_occurrence_model = temporal_occurrence_model
         self.occurrence_rate = occurrence_rate
-        self.rupture_slip_direction = rupture_slip_direction
 
     def get_probability_one_or_more_occurrences(self):
         """


### PR DESCRIPTION
Adds the term "rupture_slip_direction" to the slots of the Rupture class.

Tests are green: https://ci.openquake.org/job/zdevel_oq-hazardlib/332/