### PR TITLE
Bug fixed in get_dppvalue for multi-segment fault case

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,6 @@
+  [Yen-Shin Chen]
+  * Rupture: fix bug in get_dppvalue
+
   [Graeme Weatherill]
   * Adds 'sample' method to PMF class
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,7 @@
+
+  [Yen-Shin Chen]
+  * Rupture: fix a bug in get_dppvalue
+
   [Matteo Nastasi]
   * Packaging system improvement
 

--- a/openquake/hazardlib/source/rupture.py
+++ b/openquake/hazardlib/source/rupture.py
@@ -369,7 +369,7 @@ class ParametricProbabilisticRupture(BaseProbabilisticRupture):
                            len(self.surface.get_resampled_top_edge())):
 
                 idx_nxtp = False
-            elif index_patch >= len(self.fault_trace):
+            elif index_patch >= len(self.surface.get_resampled_top_edge()):
                 idx_nxtp = False
             elif idx_nxtp:
                 hypocenter = pd_geo


### PR DESCRIPTION
This pull request fixes a bug in rupture, get_dppvalue.
Instead of self.fault_trace, it should be self.surface.get_resampled_top_edge().
to get the top edge of each rupture and used in multi-segment fault case.

The testing is for this is absent since there is no reference table available for multi-segment case. 

The test shows green:
https://ci.openquake.org/job/zdevel_oq-hazardlib/336/