### PR TITLE
Avoided a deprecation warning

### DIFF
--- a/openquake/hazardlib/geo/surface/base.py
+++ b/openquake/hazardlib/geo/surface/base.py
@@ -505,10 +505,10 @@ class BaseQuadrilateralSurface(BaseSurface):
 
         total_len_y = (len(mesh.depths) - 1) * mesh_spacing
         y_distance = hypo_loc[1] * total_len_y
-        y_node = numpy.round(y_distance / mesh_spacing)
+        y_node = int(numpy.round(y_distance / mesh_spacing))
         total_len_x = (len(mesh.lons[y_node]) - 1) * mesh_spacing
         x_distance = hypo_loc[0] * total_len_x
-        x_node = numpy.round(x_distance / mesh_spacing)
+        x_node = int(numpy.round(x_distance / mesh_spacing))
         hypocentre = Point(mesh.lons[y_node][x_node],
                            mesh.lats[y_node][x_node],
                            mesh.depths[y_node][x_node])


### PR DESCRIPTION
This avoids the message
```
DeprecationWarning: using a non-integer number instead of an integer will result in an error in the future
  mesh.depths[y_node][x_node])
```

Yen Shin, if you see such warnings, please take care of them, because I could not run your computation on my laptop, having a slightly newer version of numpy.

The tests are green: https://ci.openquake.org/job/zdevel_oq-hazardlib/349