### PR TITLE
Initial support for Python 3 compatibility

### DIFF
--- a/openquake/baselib/general.py
+++ b/openquake/baselib/general.py
@@ -235,13 +235,13 @@ def split_in_blocks_2(long_sequence, short_sequence, hint,
     A few examples will explain how it works:
 
     >>> for b1, b2 in split_in_blocks_2(range(10), 'ABC', 3):
-    ...      print b1, b2
+    ...      print(b1, b2)
     [0, 1, 2, 3] ['A']
     [4, 5, 6, 7] ['B']
     [8, 9] ['C']
 
     >>> for b1, b2 in split_in_blocks_2(range(10), 'ABC', 2):
-    ...      print b1, b2
+    ...      print(b1, b2)
     [0, 1, 2, 3, 4] ['A', 'B']
     [5, 6, 7, 8, 9] ['C']
 
@@ -250,7 +250,7 @@ def split_in_blocks_2(long_sequence, short_sequence, hint,
     number of blocks equal to the number of blocks of the first sequence:
 
     >>> for b1, b2 in split_in_blocks_2(range(10), 'ABC', 4):
-    ...      print b1, b2
+    ...      print(b1, b2)
     [0, 1, 2] ['A']
     [3, 4, 5] ['B']
     [6, 7, 8] ['C']

--- a/openquake/baselib/general.py
+++ b/openquake/baselib/general.py
@@ -20,7 +20,7 @@
 """
 Utility functions of general interest.
 """
-from __future__ import division
+from __future__ import print_function
 import os
 import sys
 import imp
@@ -95,10 +95,11 @@ class WeightedSequence(collections.MutableSequence):
         new.weight = self.weight + other.weight
         return new
 
-    def insert(self, i, (item, weight)):
+    def insert(self, i, item_weight):
         """
         Insert an item with the given weight in the sequence
         """
+        item, weight = item_weight
         self._seq.insert(i, item)
         self.weight += weight
 
@@ -301,7 +302,7 @@ def assert_close(a, b, rtol=1e-07, atol=0, context=None):
             assert_close(getattr(a, x), getattr(b, y), rtol, atol, x)
         return
     if isinstance(a, collections.Mapping):  # dict-like objects
-        assert_close_seq(a.keys(), b.keys(), rtol, atol, a)
+        assert_close_seq(list(a), list(b), rtol, atol, a)
         assert_close_seq(a.values(), b.values(), rtol, atol, a)
         return
     if hasattr(a, '__iter__'):  # iterable objects
@@ -367,7 +368,7 @@ def run_in_process(code, *args):
     try:
         out = subprocess.check_output([sys.executable, '-c', code])
     except subprocess.CalledProcessError as exc:
-        print >> sys.stderr, exc.cmd[-1]
+        print(exc.cmd[-1], file=sys.stderr)
         raise
     if out:
         return eval(out, {}, {})
@@ -404,8 +405,8 @@ def import_all(module_or_package):
                 try:
                     importlib.import_module(modname)
                 except Exception as exc:
-                    print >> sys.stderr, 'Could not import %s: %s: %s' % (
-                        modname, exc.__class__.__name__, exc)
+                    print('Could not import %s: %s: %s' % (
+                        modname, exc.__class__.__name__, exc), file=sys.stderr)
     return set(sys.modules) - already_imported
 
 
@@ -529,7 +530,7 @@ class AccumDict(dict):
 
     def __iadd__(self, other):
         if hasattr(other, 'iteritems'):
-            for k, v in other.iteritems():
+            for k, v in other.items():
                 try:
                     self[k] = self[k] + v
                 except KeyError:
@@ -548,7 +549,7 @@ class AccumDict(dict):
 
     def __isub__(self, other):
         if hasattr(other, 'iteritems'):
-            for k, v in other.iteritems():
+            for k, v in other.items():
                 try:
                     self[k] = self[k] - v
                 except KeyError:
@@ -567,11 +568,11 @@ class AccumDict(dict):
         return - self.__sub__(other)
 
     def __neg__(self):
-        return self.__class__({k: -v for k, v in self.iteritems()})
+        return self.__class__({k: -v for k, v in self.items()})
 
     def __imul__(self, other):
         if hasattr(other, 'iteritems'):
-            for k, v in other.iteritems():
+            for k, v in other.items():
                 try:
                     self[k] = self[k] * v
                 except KeyError:
@@ -598,7 +599,7 @@ class AccumDict(dict):
         {'a': 3, 'b': 5}
         """
         return self.__class__({key: func(value, *extras)
-                               for key, value in self.iteritems()})
+                               for key, value in self.items()})
 
 
 def groupby(objects, key, reducegroup=list):

--- a/openquake/baselib/general.py
+++ b/openquake/baselib/general.py
@@ -20,7 +20,7 @@
 """
 Utility functions of general interest.
 """
-from __future__ import print_function
+from __future__ import division, print_function
 import os
 import sys
 import imp
@@ -302,7 +302,7 @@ def assert_close(a, b, rtol=1e-07, atol=0, context=None):
             assert_close(getattr(a, x), getattr(b, y), rtol, atol, x)
         return
     if isinstance(a, collections.Mapping):  # dict-like objects
-        assert_close_seq(list(a), list(b), rtol, atol, a)
+        assert_close_seq(a.keys(), b.keys(), rtol, atol, a)
         assert_close_seq(a.values(), b.values(), rtol, atol, a)
         return
     if hasattr(a, '__iter__'):  # iterable objects

--- a/openquake/baselib/performance.py
+++ b/openquake/baselib/performance.py
@@ -188,7 +188,7 @@ class Monitor(object):
         perf_dt = numpy.dtype([('operation', (str, 50)), ('time_sec', float),
                                ('memory_mb', float), ('counts', int)])
         rows = []
-        for operation, rec in data.iteritems():
+        for operation, rec in data.items():
             rows.append((operation, rec[0], rec[1], rec[2]))
         rows.sort(key=operator.itemgetter(1), reverse=True)
         return numpy.array(rows, perf_dt)

--- a/openquake/baselib/python3compat.py
+++ b/openquake/baselib/python3compat.py
@@ -1,3 +1,26 @@
+#  -*- coding: utf-8 -*-
+#  vim: tabstop=4 shiftwidth=4 softtabstop=4
+
+#  Copyright (c) 2015, GEM Foundation
+
+#  OpenQuake is free software: you can redistribute it and/or modify it
+#  under the terms of the GNU Affero General Public License as published
+#  by the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+
+#  OpenQuake is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+
+#  You should have received a copy of the GNU Affero General Public License
+#  along with OpenQuake.  If not, see <http://www.gnu.org/licenses/>.
+
+"""
+Compatibility layer for Python 2 and 3. Mostly copied from six and future,
+but reduced to the subset of utilities needed by GEM. This is done to
+avoid an external dependency.
+"""
 from __future__ import print_function
 import os
 import sys
@@ -26,13 +49,21 @@ if PY3:
             raise exc.with_traceback(tb)
         raise exc
 
-else:
+else:  # Python 2
     range = xrange
-   
+
     exec('''
 def raise_(tp, value=None, tb=None):
     raise tp, value, tb
 ''')
+
+
+def with_metaclass(meta, *bases):
+    """
+    Returns an instance of meta inheriting from the given bases.
+    To be used to replace the __metaclass__ syntax.
+    """
+    return meta('%sInstance' % meta.__name__, bases, {})
 
 
 def check_syntax(pkg):

--- a/openquake/baselib/python3compat.py
+++ b/openquake/baselib/python3compat.py
@@ -6,6 +6,12 @@ import subprocess
 
 
 def check_syntax(pkg):
+    """
+    Recursively check all modules in the given package for compatibility with
+    Python 3 syntax. No imports are performed.
+
+    :param pkg: a Python package
+    """
     ok, err = 0, 0
     for cwd, dirs, files in os.walk(pkg.__path__[0]):
         for f in files:

--- a/openquake/baselib/python3compat.py
+++ b/openquake/baselib/python3compat.py
@@ -58,12 +58,21 @@ def raise_(tp, value=None, tb=None):
 ''')
 
 
+# copied from http://lucumr.pocoo.org/2013/5/21/porting-to-python-3-redux/
 def with_metaclass(meta, *bases):
     """
     Returns an instance of meta inheriting from the given bases.
     To be used to replace the __metaclass__ syntax.
     """
-    return meta('%sInstance' % meta.__name__, bases, {})
+    class metaclass(meta):
+        __call__ = type.__call__
+        __init__ = type.__init__
+
+        def __new__(mcl, name, this_bases, d):
+            if this_bases is None:
+                return type.__new__(mcl, name, (), d)
+            return meta(name, bases, d)
+    return metaclass('temporary_class', None, {})
 
 
 def check_syntax(pkg):

--- a/openquake/baselib/python3compat.py
+++ b/openquake/baselib/python3compat.py
@@ -1,0 +1,23 @@
+from __future__ import print_function
+import os
+import sys
+import importlib
+import subprocess
+
+
+def check_syntax(pkg):
+    ok, err = 0, 0
+    for cwd, dirs, files in os.walk(pkg.__path__[0]):
+        for f in files:
+            if f.endswith('.py'):
+                fname = os.path.join(cwd, f)
+                errno = subprocess.call(['python3', '-m', 'py_compile', fname])
+                if errno:
+                    err += 1
+                else:
+                    ok += 1
+    print('Checked %d ok, %d wrong modules' % (ok, err))
+
+
+if __name__ == '__main__':
+    check_syntax(importlib.import_module(sys.argv[1]))

--- a/openquake/baselib/python3compat.py
+++ b/openquake/baselib/python3compat.py
@@ -4,6 +4,36 @@ import sys
 import importlib
 import subprocess
 
+PY3 = sys.version_info[0] == 3
+PY2 = sys.version_info[0] == 2
+
+if PY3:
+    range = range
+
+    def raise_(tp, value=None, tb=None):
+        """
+        A function that matches the Python 2.x ``raise`` statement. This
+        allows re-raising exceptions with the cls value and traceback on
+        Python 2 and 3.
+        """
+        if value is not None and isinstance(tp, Exception):
+            raise TypeError("instance exception may not have a separate value")
+        if value is not None:
+            exc = tp(value)
+        else:
+            exc = tp
+        if exc.__traceback__ is not tb:
+            raise exc.with_traceback(tb)
+        raise exc
+
+else:
+    range = xrange
+   
+    exec('''
+def raise_(tp, value=None, tb=None):
+    raise tp, value, tb
+''')
+
 
 def check_syntax(pkg):
     """

--- a/openquake/baselib/tests/general_test.py
+++ b/openquake/baselib/tests/general_test.py
@@ -56,16 +56,18 @@ class BlockSplitterTestCase(unittest.TestCase):
 
     def test_block_splitter_zero_block_size(self):
         gen = block_splitter(self.DATA, 0)
-        self.assertRaises(ValueError, gen.next)
+        with self.assertRaises(ValueError):
+            next(gen)
 
     def test_block_splitter_block_size_lt_zero(self):
         gen = block_splitter(self.DATA, -1)
-        self.assertRaises(ValueError, gen.next)
+        with self.assertRaises(ValueError):
+            next(gen)
 
     def test_block_splitter_with_generator(self):
         # Test the block with a data set of unknown length
         # (such as a generator)
-        data = xrange(10)
+        data = range(10)
         expected = [
             [0, 1, 2],
             [3, 4, 5],
@@ -77,7 +79,7 @@ class BlockSplitterTestCase(unittest.TestCase):
 
     def test_block_splitter_with_iter(self):
         # Test the block with a data set of unknown length
-        data = iter(range(10))
+        data = range(10)
         expected = [
             [0, 1, 2],
             [3, 4, 5],
@@ -157,7 +159,7 @@ class AssertCloseTestCase(unittest.TestCase):
             gmf2 = {'a': {'PGA': [0.1, 0.2], 'SA(0.1)': [0.3, 0.41]}}
             assert_close(gmf1, gmf2)
 
-        class C:
+        class C(object):
             pass
 
         c1 = C()

--- a/openquake/baselib/tests/general_test.py
+++ b/openquake/baselib/tests/general_test.py
@@ -25,8 +25,7 @@ from operator import attrgetter
 from collections import namedtuple
 
 from openquake.baselib.general import (
-    block_splitter, split_in_blocks, assert_independent, search_module,
-    assert_close)
+    block_splitter, split_in_blocks, search_module, assert_close)
 
 
 class BlockSplitterTestCase(unittest.TestCase):
@@ -115,14 +114,14 @@ class BlockSplitterTestCase(unittest.TestCase):
             block_splitter([s1, s2, s3, s4, s5], max_weight=6,
                            weight=attrgetter('weight'),
                            kind=attrgetter('typology')))
-        self.assertEqual(map(len, blocks), [2, 2, 1])
+        self.assertEqual(list(map(len, blocks)), [2, 2, 1])
         self.assertEqual([b.weight for b in blocks], [2, 6, 4])
 
         blocks = list(
             split_in_blocks([s1, s2, s3, s4, s5], hint=6,
                             weight=attrgetter('weight'),
                             key=attrgetter('typology')))
-        self.assertEqual(map(len, blocks), [2, 1, 1, 1])
+        self.assertEqual(list(map(len, blocks)), [2, 1, 1, 1])
         self.assertEqual([b.weight for b in blocks], [2, 2, 4, 4])
 
 

--- a/openquake/baselib/tests/performance_test.py
+++ b/openquake/baselib/tests/performance_test.py
@@ -1,3 +1,4 @@
+from builtins import range
 import time
 import unittest
 import tempfile
@@ -24,7 +25,7 @@ class MonitorTestCase(unittest.TestCase):
         ls = []
         for i in range(3):
             with mon:
-                ls.append(range(100000))  # allocate some RAM
+                ls.append(list(range(100000)))  # allocate some RAM
                 time.sleep(0.1)
         self.assertGreaterEqual(mon.mem, 0)
         mon.flush()

--- a/openquake/baselib/tests/performance_test.py
+++ b/openquake/baselib/tests/performance_test.py
@@ -1,4 +1,3 @@
-from builtins import range
 import time
 import unittest
 import tempfile

--- a/openquake/hazardlib/calc/disagg.py
+++ b/openquake/hazardlib/calc/disagg.py
@@ -18,6 +18,8 @@
 :func:`disaggregation` as well as several aggregation functions for
 extracting a specific PMF from the result of :func:`disaggregation`.
 """
+from __future__ import division
+from openquake.baselib.python3compat import range
 import sys
 import numpy
 import warnings
@@ -233,7 +235,7 @@ def _define_bins(bins_data, mag_bin_width, dist_bin_width,
     lon_extent = get_longitudinal_extent(west, east)
     lon_bins, _, _ = npoints_between(
         west, 0, 0, east, 0, 0,
-        numpy.round(lon_extent / coord_bin_width) + 1
+        numpy.round(old_div(lon_extent, coord_bin_width)) + 1
     )
 
     lat_bins = coord_bin_width * numpy.arange(

--- a/openquake/hazardlib/calc/disagg.py
+++ b/openquake/hazardlib/calc/disagg.py
@@ -22,7 +22,7 @@ import sys
 import numpy
 import warnings
 import collections
-from itertools import izip
+from future.utils import raise_
 
 from openquake.hazardlib.calc import filters
 from openquake.hazardlib.geo.geodetic import npoints_between
@@ -184,11 +184,11 @@ def _collect_bins_data(sources, site, imt, iml, gsims,
                 probs_no_exceed.append(
                     rupture.get_probability_no_exceedance(poes_given_rup_eps)
                 )
-        except Exception, err:
+        except Exception as err:
             etype, err, tb = sys.exc_info()
             msg = 'An error occurred with source id=%s. Error: %s'
             msg %= (source.source_id, err.message)
-            raise etype, msg, tb
+            raise_(etype, msg, tb)
 
     mags = numpy.array(mags, float)
     dists = numpy.array(dists, float)
@@ -285,7 +285,7 @@ def _arrange_data_in_bins(bins_data, bin_edges):
 
     for i, (i_mag, i_dist, i_lon, i_lat, i_trt) in \
         enumerate(
-            izip(mags_idx, dists_idx, lons_idx, lats_idx, tect_reg_types)):
+            zip(mags_idx, dists_idx, lons_idx, lats_idx, tect_reg_types)):
 
         diss_matrix[i_mag, i_dist, i_lon, i_lat, :, i_trt] *= \
             probs_no_exceed[i, :]
@@ -301,7 +301,7 @@ def _digitize_lons(lons, lon_bins):
     """
     if cross_idl(lon_bins[0], lon_bins[-1]):
         idx = []
-        for i_lon in xrange(len(lon_bins) - 1):
+        for i_lon in range(len(lon_bins) - 1):
             extents = get_longitudinal_extent(lons, lon_bins[i_lon + 1])
             lon_idx = extents > 0
             if i_lon != 0:
@@ -322,14 +322,14 @@ def mag_pmf(matrix):
     """
     nmags, ndists, nlons, nlats, neps, ntrts = matrix.shape
     mag_pmf = numpy.zeros(nmags)
-    for i in xrange(nmags):
+    for i in range(nmags):
         mag_pmf[i] = numpy.prod(
             [1 - matrix[i][j][k][l][m][n]
-             for j in xrange(ndists)
-             for k in xrange(nlons)
-             for l in xrange(nlats)
-             for m in xrange(neps)
-             for n in xrange(ntrts)]
+             for j in range(ndists)
+             for k in range(nlons)
+             for l in range(nlats)
+             for m in range(neps)
+             for n in range(ntrts)]
         )
     return 1 - mag_pmf
 
@@ -343,14 +343,14 @@ def dist_pmf(matrix):
     """
     nmags, ndists, nlons, nlats, neps, ntrts = matrix.shape
     dist_pmf = numpy.zeros(ndists)
-    for j in xrange(ndists):
+    for j in range(ndists):
         dist_pmf[j] = numpy.prod(
             [1 - matrix[i][j][k][l][m][n]
-             for i in xrange(nmags)
-             for k in xrange(nlons)
-             for l in xrange(nlats)
-             for m in xrange(neps)
-             for n in xrange(ntrts)]
+             for i in range(nmags)
+             for k in range(nlons)
+             for l in range(nlats)
+             for m in range(neps)
+             for n in range(ntrts)]
         )
     return 1 - dist_pmf
 
@@ -364,14 +364,14 @@ def trt_pmf(matrix):
     """
     nmags, ndists, nlons, nlats, neps, ntrts = matrix.shape
     trt_pmf = numpy.zeros(ntrts)
-    for n in xrange(ntrts):
+    for n in range(ntrts):
         trt_pmf[n] = numpy.prod(
             [1 - matrix[i][j][k][l][m][n]
-             for i in xrange(nmags)
-             for j in xrange(ndists)
-             for k in xrange(nlons)
-             for l in xrange(nlats)
-             for m in xrange(neps)]
+             for i in range(nmags)
+             for j in range(ndists)
+             for k in range(nlons)
+             for l in range(nlats)
+             for m in range(neps)]
         )
     return 1 - trt_pmf
 
@@ -386,14 +386,14 @@ def mag_dist_pmf(matrix):
     """
     nmags, ndists, nlons, nlats, neps, ntrts = matrix.shape
     mag_dist_pmf = numpy.zeros((nmags, ndists))
-    for i in xrange(nmags):
-        for j in xrange(ndists):
+    for i in range(nmags):
+        for j in range(ndists):
             mag_dist_pmf[i][j] = numpy.prod(
                 [1 - matrix[i][j][k][l][m][n]
-                 for k in xrange(nlons)
-                 for l in xrange(nlats)
-                 for m in xrange(neps)
-                 for n in xrange(ntrts)]
+                 for k in range(nlons)
+                 for l in range(nlats)
+                 for m in range(neps)
+                 for n in range(ntrts)]
             )
     return 1 - mag_dist_pmf
 
@@ -409,14 +409,14 @@ def mag_dist_eps_pmf(matrix):
     """
     nmags, ndists, nlons, nlats, neps, ntrts = matrix.shape
     mag_dist_eps_pmf = numpy.zeros((nmags, ndists, neps))
-    for i in xrange(nmags):
-        for j in xrange(ndists):
-            for m in xrange(neps):
+    for i in range(nmags):
+        for j in range(ndists):
+            for m in range(neps):
                 mag_dist_eps_pmf[i][j][m] = numpy.prod(
                     [1 - matrix[i][j][k][l][m][n]
-                     for k in xrange(nlons)
-                     for l in xrange(nlats)
-                     for n in xrange(ntrts)]
+                     for k in range(nlons)
+                     for l in range(nlats)
+                     for n in range(ntrts)]
                 )
     return 1 - mag_dist_eps_pmf
 
@@ -431,14 +431,14 @@ def lon_lat_pmf(matrix):
     """
     nmags, ndists, nlons, nlats, neps, ntrts = matrix.shape
     lon_lat_pmf = numpy.zeros((nlons, nlats))
-    for k in xrange(nlons):
-        for l in xrange(nlats):
+    for k in range(nlons):
+        for l in range(nlats):
             lon_lat_pmf[k][l] = numpy.prod(
                 [1 - matrix[i][j][k][l][m][n]
-                 for i in xrange(nmags)
-                 for j in xrange(ndists)
-                 for m in xrange(neps)
-                 for n in xrange(ntrts)]
+                 for i in range(nmags)
+                 for j in range(ndists)
+                 for m in range(neps)
+                 for n in range(ntrts)]
             )
     return 1 - lon_lat_pmf
 
@@ -454,14 +454,14 @@ def mag_lon_lat_pmf(matrix):
     """
     nmags, ndists, nlons, nlats, neps, ntrts = matrix.shape
     mag_lon_lat_pmf = numpy.zeros((nmags, nlons, nlats))
-    for i in xrange(nmags):
-        for k in xrange(nlons):
-            for l in xrange(nlats):
+    for i in range(nmags):
+        for k in range(nlons):
+            for l in range(nlats):
                 mag_lon_lat_pmf[i][k][l] = numpy.prod(
                     [1 - matrix[i][j][k][l][m][n]
-                     for j in xrange(ndists)
-                     for m in xrange(neps)
-                     for n in xrange(ntrts)]
+                     for j in range(ndists)
+                     for m in range(neps)
+                     for n in range(ntrts)]
                 )
     return 1 - mag_lon_lat_pmf
 
@@ -477,14 +477,14 @@ def lon_lat_trt_pmf(matrix):
     """
     nmags, ndists, nlons, nlats, neps, ntrts = matrix.shape
     lon_lat_trt_pmf = numpy.zeros((nlons, nlats, ntrts))
-    for k in xrange(nlons):
-        for l in xrange(nlats):
-            for n in xrange(ntrts):
+    for k in range(nlons):
+        for l in range(nlats):
+            for n in range(ntrts):
                 lon_lat_trt_pmf[k][l][n] = numpy.prod(
                     [1 - matrix[i][j][k][l][m][n]
-                     for i in xrange(nmags)
-                     for j in xrange(ndists)
-                     for m in xrange(neps)]
+                     for i in range(nmags)
+                     for j in range(ndists)
+                     for m in range(neps)]
                 )
     return 1 - lon_lat_trt_pmf
 

--- a/openquake/hazardlib/calc/disagg.py
+++ b/openquake/hazardlib/calc/disagg.py
@@ -22,7 +22,7 @@ import sys
 import numpy
 import warnings
 import collections
-from future.utils import raise_
+from openquake.baselib.python3compat import raise_
 
 from openquake.hazardlib.calc import filters
 from openquake.hazardlib.geo.geodetic import npoints_between

--- a/openquake/hazardlib/calc/disagg.py
+++ b/openquake/hazardlib/calc/disagg.py
@@ -235,7 +235,7 @@ def _define_bins(bins_data, mag_bin_width, dist_bin_width,
     lon_extent = get_longitudinal_extent(west, east)
     lon_bins, _, _ = npoints_between(
         west, 0, 0, east, 0, 0,
-        numpy.round(old_div(lon_extent, coord_bin_width)) + 1
+        numpy.round(lon_extent / coord_bin_width + 1)
     )
 
     lat_bins = coord_bin_width * numpy.arange(

--- a/openquake/hazardlib/calc/gmf.py
+++ b/openquake/hazardlib/calc/gmf.py
@@ -82,7 +82,7 @@ class GmfComputer(object):
         assert sites and imts, (sites, imts)
         self.rupture = rupture
         self.sites = sites
-        self.imts = map(from_string, imts)
+        self.imts = list(map(from_string, imts))
         self.gsims = gsims
         self.truncation_level = truncation_level
         self.correlation_model = correlation_model
@@ -179,9 +179,9 @@ class GmfComputer(object):
             for gsim in self.gsims:
                 gs = str(gsim)
                 for imt, value in self._compute(
-                        seed, gsim, realizations=1).iteritems():
+                        seed, gsim, realizations=1).items():
                     # 1 realization, get the 0-th colum of the v-array
-                    array = map(float, value[:, 0])
+                    array = list(map(float, value[:, 0]))
                     # NB: with correlation, the value is a numpy.matrix
                     # not an array, flatten does not work and the only
                     # way to extract the numbers is the map before!
@@ -252,10 +252,10 @@ def ground_motion_fields(rupture, sites, imts, gsim, truncation_level,
                     for imt in imts)
     [(rupture, sites)] = ruptures_sites
 
-    gc = GmfComputer(rupture, sites, map(str, imts), [gsim], truncation_level,
+    gc = GmfComputer(rupture, sites, list(map(str, imts)), [gsim], truncation_level,
                      correlation_model)
     result = gc._compute(seed, gsim, realizations)
-    for imt, gmf in result.iteritems():
+    for imt, gmf in result.items():
         # makes sure the lenght of the arrays in output is the same as sites
         if rupture_site_filter is not filters.rupture_site_noop_filter:
             result[imt] = sites.expand(gmf, placeholder=0)

--- a/openquake/hazardlib/calc/hazard_curve.py
+++ b/openquake/hazardlib/calc/hazard_curve.py
@@ -39,7 +39,7 @@ def zero_curves(num_sites, imtls):
     """
     # numpy dtype for the hazard curves
     imt_dt = numpy.dtype([(imt, float, 1 if imls is None else len(imls))
-                          for imt, imls in list(imtls.items())])
+                          for imt, imls in imtls.items()])
     zero = numpy.zeros(num_sites, imt_dt)
     return zero
 

--- a/openquake/hazardlib/calc/hazard_curve.py
+++ b/openquake/hazardlib/calc/hazard_curve.py
@@ -18,6 +18,7 @@
 :mod:`openquake.hazardlib.calc.hazard_curve` implements
 :func:`hazard_curves`.
 """
+from openquake.baselib.python3compat range
 from openquake.baselib.python3compat import raise_
 import sys
 import collections

--- a/openquake/hazardlib/calc/hazard_curve.py
+++ b/openquake/hazardlib/calc/hazard_curve.py
@@ -18,7 +18,7 @@
 :mod:`openquake.hazardlib.calc.hazard_curve` implements
 :func:`hazard_curves`.
 """
-from openquake.baselib.python3compat range
+from openquake.baselib.python3compat import range
 from openquake.baselib.python3compat import raise_
 import sys
 import collections

--- a/openquake/hazardlib/calc/hazard_curve.py
+++ b/openquake/hazardlib/calc/hazard_curve.py
@@ -18,7 +18,7 @@
 :mod:`openquake.hazardlib.calc.hazard_curve` implements
 :func:`hazard_curves`.
 """
-from future.utils import raise_
+from openquake.baselib.python3compat import raise_
 import sys
 import collections
 

--- a/openquake/hazardlib/calc/stochastic.py
+++ b/openquake/hazardlib/calc/stochastic.py
@@ -18,7 +18,7 @@
 :func:`stochastic_event_set`.
 """
 import sys
-from openquake.baselib.python3compat range
+from openquake.baselib.python3compat import range
 from openquake.baselib.python3compat import raise_
 from openquake.hazardlib.calc import filters
 

--- a/openquake/hazardlib/calc/stochastic.py
+++ b/openquake/hazardlib/calc/stochastic.py
@@ -18,6 +18,7 @@
 :func:`stochastic_event_set`.
 """
 import sys
+from openquake.baselib.python3compat range
 from openquake.baselib.python3compat import raise_
 from openquake.hazardlib.calc import filters
 

--- a/openquake/hazardlib/calc/stochastic.py
+++ b/openquake/hazardlib/calc/stochastic.py
@@ -18,6 +18,7 @@
 :func:`stochastic_event_set`.
 """
 import sys
+from future.utils import raise_
 from openquake.hazardlib.calc import filters
 
 
@@ -59,13 +60,13 @@ def stochastic_event_set(
         for source in sources:
             try:
                 for rupture in source.iter_ruptures():
-                    for i in xrange(rupture.sample_number_of_occurrences()):
+                    for i in range(rupture.sample_number_of_occurrences()):
                         yield rupture
-            except Exception, err:
+            except Exception as err:
                 etype, err, tb = sys.exc_info()
                 msg = 'An error occurred with source id=%s. Error: %s'
                 msg %= (source.source_id, err.message)
-                raise etype, msg, tb
+                raise_(etype, msg, tb)
         return
     # else apply filtering
     sources_sites = source_site_filter((source, sites) for source in sources)
@@ -74,10 +75,10 @@ def stochastic_event_set(
             ruptures_sites = rupture_site_filter(
                 (rupture, r_sites) for rupture in source.iter_ruptures())
             for rupture, _sites in ruptures_sites:
-                for i in xrange(rupture.sample_number_of_occurrences()):
+                for i in range(rupture.sample_number_of_occurrences()):
                     yield rupture
-        except Exception, err:
+        except Exception as err:
             etype, err, tb = sys.exc_info()
             msg = 'An error occurred with source id=%s. Error: %s'
             msg %= (source.source_id, err.message)
-            raise etype, msg, tb
+            raise_(etype, msg, tb)

--- a/openquake/hazardlib/calc/stochastic.py
+++ b/openquake/hazardlib/calc/stochastic.py
@@ -18,7 +18,7 @@
 :func:`stochastic_event_set`.
 """
 import sys
-from future.utils import raise_
+from openquake.baselib.python3compat import raise_
 from openquake.hazardlib.calc import filters
 
 

--- a/openquake/hazardlib/gsim/__init__.py
+++ b/openquake/hazardlib/gsim/__init__.py
@@ -37,7 +37,7 @@ def get_available_gsims():
             modname, _ext = os.path.splitext(fname)
             mod = importlib.import_module(
                 'openquake.hazardlib.gsim.' + modname)
-            for cls in mod.__dict__.itervalues():
+            for cls in mod.__dict__.values():
                 if inspect.isclass(cls) and issubclass(
                     cls, GroundShakingIntensityModel) and cls not in (
                         GroundShakingIntensityModel, GMPE, IPE):

--- a/openquake/hazardlib/gsim/abrahamson_2014.py
+++ b/openquake/hazardlib/gsim/abrahamson_2014.py
@@ -20,6 +20,7 @@ Module exports :class:`AbrahamsonEtAl2014`
                :class:`AbrahamsonEtAl2014RegTWN`
 """
 from __future__ import division
+from __future__ import print_function
 
 import copy
 import numpy as np
@@ -352,8 +353,8 @@ class AbrahamsonEtAl2014(GMPE):
         derAmp = self._get_derivative(C, sa1180, vs30)
         phi_amp = 0.4
         if any(phi_al**2 < phi_amp**2):
-            print 'phi_al:' % (phi_al)
-            print 'magnitude: %.2f' % (mag)
+            print('phi_al:' % (phi_al))
+            print('magnitude: %.2f' % (mag))
             raise ValueError('sqrt argument < 0')
         phi_b = np.sqrt(phi_al**2 - phi_amp**2)
         phi = np.sqrt(phi_b**2 * (1 + derAmp)**2 + phi_amp**2)

--- a/openquake/hazardlib/gsim/base.py
+++ b/openquake/hazardlib/gsim/base.py
@@ -31,6 +31,7 @@ import numpy
 
 from openquake.hazardlib import const
 from openquake.hazardlib import imt as imt_module
+from openquake.baselib.python3compat import with_metaclass
 
 
 class NotVerifiedWarning(UserWarning):
@@ -110,7 +111,7 @@ class MetaGSIM(abc.ABCMeta):
 
 
 @functools.total_ordering
-class GroundShakingIntensityModel(object):
+class GroundShakingIntensityModel(with_metaclass(MetaGSIM)):
     """
     Base class for all the ground shaking intensity models.
 
@@ -126,7 +127,6 @@ class GroundShakingIntensityModel(object):
     and all the class attributes with names starting from ``DEFINED_FOR``
     and ``REQUIRES``.
     """
-    __metaclass__ = MetaGSIM
 
     #: Reference to a
     #: :class:`tectonic region type <openquake.hazardlib.const.TRT>` this GSIM
@@ -721,11 +721,10 @@ class IPE(GroundShakingIntensityModel):
         return numpy.array(values, dtype=float)
 
 
-class BaseContext(object):
+class BaseContext(with_metaclass(abc.ABCMeta)):
     """
     Base class for context object.
     """
-    __metaclass__ = abc.ABCMeta
 
     def __eq__(self, other):
         """
@@ -953,7 +952,7 @@ class CoeffsTable(object):
             pass
 
         max_below = min_above = None
-        for unscaled_imt in self.sa_coeffs.keys():
+        for unscaled_imt in list(self.sa_coeffs):
             if unscaled_imt.damping != imt.damping:
                 continue
             if unscaled_imt.period > imt.period:
@@ -974,5 +973,5 @@ class CoeffsTable(object):
         min_above = self.sa_coeffs[min_above]
         return dict(
             (co, (min_above[co] - max_below[co]) * ratio + max_below[co])
-            for co in max_below.keys()
+            for co in max_below
         )

--- a/openquake/hazardlib/gsim/frankel_1996.py
+++ b/openquake/hazardlib/gsim/frankel_1996.py
@@ -108,7 +108,7 @@ class FrankelEtAl1996MblgAB1987NSHMP2008(GMPE):
         assert all(stddev_type in self.DEFINED_FOR_STANDARD_DEVIATION_TYPES
                    for stddev_type in stddev_types)
 
-        if imt not in self.IMTS_TABLES.keys():
+        if imt not in self.IMTS_TABLES:
             raise ValueError(
                 'IMT %s not supported in FrankelEtAl1996NSHMP. ' % repr(imt) +
                 'FrankelEtAl1996NSHMP does not allow interpolation for ' +

--- a/openquake/hazardlib/gsim/megawati_pan_2010.py
+++ b/openquake/hazardlib/gsim/megawati_pan_2010.py
@@ -17,6 +17,7 @@
 Module exports :class:`megawatipan2010`.
 """
 from __future__ import division
+from __future__ import print_function
 
 import numpy as np
 from scipy.constants import g
@@ -84,7 +85,7 @@ class MegawatiPan2010(GMPE):
         mean = (self._get_magnitude_scaling(C, rup.mag) +
                 self._get_distance_scaling(C, rup.mag, dists.rhypo))
         if isinstance(imt, (PGA, SA)):
-            print imt, rup.mag
+            print(imt, rup.mag)
             mean = np.log(np.exp(mean) / (100.0 * g))
         stddevs = self._compute_std(C, stddev_types, len(dists.rhypo))
         return mean, stddevs

--- a/openquake/hazardlib/tests/geo/utils_test.py
+++ b/openquake/hazardlib/tests/geo/utils_test.py
@@ -224,7 +224,8 @@ class GetMiddlePointTestCase(unittest.TestCase):
 
 
 class SphericalToCartesianAndBackTestCase(unittest.TestCase):
-    def _test(self, (lons, lats, depths), vectors):
+    def _test(self, lons_lats_depths, vectors):
+        (lons, lats, depths) = lons_lats_depths
         res_cart = utils.spherical_to_cartesian(lons, lats, depths)
         self.assertIsInstance(res_cart, numpy.ndarray)
         self.assertTrue(numpy.allclose(vectors, res_cart), str(res_cart))

--- a/openquake/hazardlib/tests/gsim/utils.py
+++ b/openquake/hazardlib/tests/gsim/utils.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 # The Hazard Library
 # Copyright (C) 2012-2014, GEM Foundation
 #
@@ -54,5 +55,5 @@ class BaseGSIMTestCase(unittest.TestCase):
         )
         if errors:
             raise AssertionError(stats)
-        print
-        print stats
+        print()
+        print(stats)


### PR DESCRIPTION
While we do not plan to migrate to Python 3 anytime soon, it is useful to introduce now an utility telling us how far we are from a Python 3-compatible syntax. Here is how to use it:

```bash
$ python -m openquake.baselib.python3compat openquake.hazardlib
.. several errors ...
Checked 248 ok, 7 wrong modules
```

We are actually already quite close to support Python 3. baselib and risklib are ready:

```bash
$  python -m openquake.baselib.python3compat openquake.baselib
Checked 7 ok, 0 wrong modules
$  python -m openquake.baselib.python3compat openquake.risklib
Checked 20 ok, 0 wrong modules
```

The other packages are not so bad:

```bash
$  python -m openquake.baselib.python3compat openquake.commonlib
Checked 82 ok, 7 wrong modules
$ python -m openquake.baselib.python3compat openquake.engine
Checked 100 ok, 13 wrong modules
$  python -m openquake.baselib.python3compat openquake.server
Checked 13 ok, 3 wrong modules
```

The tests are green: https://ci.openquake.org/job/zdevel_oq-hazardlib/357/

Here is the plan for the future: https://bugs.launchpad.net/oq-engine/+bug/1470396