### PR TITLE
Added dependency on h5py

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,6 @@
+  [Michele Simionato]
+  * hazardlib now requires h5py
+
   [Graeme Weatherill]
   * Adds Atkinson & Macias (2009) Subduction Interface GMPE
   

--- a/debian/control
+++ b/debian/control
@@ -11,5 +11,5 @@ Homepage: http://github.com/gem/oq-hazardlib
 Package: python-oq-hazardlib
 Architecture: any
 Conflicts: python-nhlib
-Depends: ${shlibs:Depends}, ${misc:Depends}, python-numpy, python-scipy, python-shapely, python-psutil
+Depends: ${shlibs:Depends}, ${misc:Depends}, python-numpy, python-scipy, python-shapely, python-psutil, python-h5py
 Description: hazardlib is a library for performing seismic hazard analysis


### PR DESCRIPTION
This is required for the GSIMs for Canada (https://github.com/gem/oq-hazardlib/pull/353).
The build is green: https://ci.openquake.org/job/zdevel_oq-hazardlib/359