### PR TITLE
Added equality of site collections

### DIFF
--- a/openquake/hazardlib/site.py
+++ b/openquake/hazardlib/site.py
@@ -100,6 +100,13 @@ Backarc=False>'
         return self.__str__()
 
 
+def eq(array1, array2):
+    """
+    Compare two numpy arrays for equality and returns a boolean
+    """
+    return array1.shape == array2.shape and (array1 == array2).all()
+
+
 class SiteCollection(object):
     """
     A collection of :class:`sites <Site>`.
@@ -257,8 +264,7 @@ class SiteCollection(object):
         return self.total_sites
 
     def __eq__(self, other):
-        return (self.lons == other.lons).all() and (
-            self.lats == other.lats).all()
+        return eq(self.lons, other.lons) and eq(self.lats, other.lats)
 
     def __ne__(self, other):
         return not self.__eq__(other)

--- a/openquake/hazardlib/site.py
+++ b/openquake/hazardlib/site.py
@@ -257,8 +257,8 @@ class SiteCollection(object):
         return self.total_sites
 
     def __eq__(self, other):
-        return (self.lons, self.lats, self.depths) == (
-            other.lons, other.lats, other.depths)
+        return (self.lons == other.lons).all() and (
+            self.lats == other.lats).all()
 
     def __ne__(self, other):
         return not self.__eq__(other)

--- a/openquake/hazardlib/site.py
+++ b/openquake/hazardlib/site.py
@@ -102,7 +102,7 @@ Backarc=False>'
 
 def eq(array1, array2):
     """
-    Compare two numpy arrays for equality and returns a boolean
+    Compare two numpy arrays for equality and return a boolean
     """
     return array1.shape == array2.shape and (array1 == array2).all()
 

--- a/openquake/hazardlib/site.py
+++ b/openquake/hazardlib/site.py
@@ -256,6 +256,13 @@ class SiteCollection(object):
         """
         return self.total_sites
 
+    def __eq__(self, other):
+        return (self.lons, self.lats, self.depths) == (
+            other.lons, other.lats, other.depths)
+
+    def __ne__(self, other):
+        return not self.__eq__(other)
+
     def __repr__(self):
         return '<SiteCollection with %d sites>' % self.total_sites
 

--- a/openquake/hazardlib/tests/site_test.py
+++ b/openquake/hazardlib/tests/site_test.py
@@ -255,6 +255,9 @@ class SiteCollectionIterTestCase(unittest.TestCase):
         for i, s in enumerate([exp_s1, exp_s2]):
             self.assertEqual(s, cll_sites[i])
 
+        # test equality of site collections
+        sc = SiteCollection([exp_s1, exp_s2])
+        self.assertEqual(cll, sc)
 
 
 class SitePickleTestCase(unittest.TestCase):


### PR DESCRIPTION
This is used in oq-lite (see https://github.com/gem/oq-risklib/pull/318) to compare the hazard site collection with the risk site collection. The tests are running here: https://ci.openquake.org/job/zdevel_oq-hazardlib/364