### PR TITLE
Wrong order of the arguments

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,9 +1,10 @@
   [Michele Simionato]
+  * fixed the filtering of site IDs
   * hazardlib now requires h5py
 
   [Graeme Weatherill]
   * Adds Atkinson & Macias (2009) Subduction Interface GMPE
-  
+
   [Yen-Shin Chen]
   * Rupture: fix bug in get_dppvalue
 

--- a/openquake/baselib/general.py
+++ b/openquake/baselib/general.py
@@ -213,8 +213,9 @@ def split_in_blocks(sequence, hint, weight=lambda item: 1,
      [<WeightedSequence ['A', 'B'], weight=2>, <WeightedSequence ['C', 'D'], weight=2>, <WeightedSequence ['E'], weight=1>]
 
     """
-    assert hint > 0, hint
     items = list(sequence)
+    assert hint > 0, hint
+    assert len(items) > 0, len(items)
     total_weight = float(sum(weight(item) for item in items))
     return block_splitter(items, math.ceil(total_weight / hint), weight, key)
 

--- a/openquake/hazardlib/site.py
+++ b/openquake/hazardlib/site.py
@@ -415,8 +415,8 @@ class FilteredSiteCollection(object):
         """
         for i, location in enumerate(self.mesh):
             yield Site(location, self.vs30[i], self.vs30measured[i],
-                       self.z1pt0[i], self.z2pt5[i], self.sids[i],
-                       self.backarc[i])
+                       self.z1pt0[i], self.z2pt5[i],
+                       self.backarc[i], self.sids[i])
 
     def __len__(self):
         """Return the number of filtered sites"""

--- a/openquake/hazardlib/tests/site_test.py
+++ b/openquake/hazardlib/tests/site_test.py
@@ -127,13 +127,13 @@ class SiteCollectionCreationTestCase(unittest.TestCase):
 class SiteCollectionFilterTestCase(unittest.TestCase):
     SITES = [
         Site(location=Point(10, 20, 30), vs30=1.2, vs30measured=True,
-             z1pt0=3, z2pt5=5),
+             z1pt0=3, z2pt5=5, id=0),
         Site(location=Point(11, 12, 13), vs30=55.4, vs30measured=False,
-             z1pt0=6, z2pt5=8),
+             z1pt0=6, z2pt5=8, id=1),
         Site(location=Point(0, 2, 0), vs30=2, vs30measured=True,
-             z1pt0=9, z2pt5=17),
+             z1pt0=9, z2pt5=17, id=2),
         Site(location=Point(1, 1, 3), vs30=4, vs30measured=False,
-             z1pt0=22, z2pt5=11)
+             z1pt0=22, z2pt5=11, id=3)
     ]
 
     def test_filter(self):
@@ -147,6 +147,8 @@ class SiteCollectionFilterTestCase(unittest.TestCase):
         arreq(filtered.z2pt5, [5, 17])
         arreq(filtered.mesh.lons, [10, 0])
         arreq(filtered.mesh.lats, [20, 2])
+        arreq(filtered.sids, [0, 2])
+        arreq([site.id for site in filtered], [0, 2])
         self.assertIs(filtered.mesh.depths, None)
 
         filtered = col.filter(numpy.array([False, True, True, True]))


### PR DESCRIPTION
`self.backarc[i]` and `self.sids[i]` are exchanged in `FilteredSiteCollection.__iter__` :-(
While I am at that, I am also adding a check for empty lists in the block splitting routine, to simplify the debugging of errors in the engine. The tests are green: https://ci.openquake.org/job/zdevel_oq-hazardlib/365