### PR TITLE
Fix dimensionality bug in BooreAtkinson2008.

### DIFF
--- a/openquake/hazardlib/gsim/boore_atkinson_2008.py
+++ b/openquake/hazardlib/gsim/boore_atkinson_2008.py
@@ -241,7 +241,7 @@ class BooreAtkinson2008(GMPE):
         equation (8a) to (8c), pag 108.
         """
 
-        fnl = np.zeros(len(pga4nl))
+        fnl = np.zeros(pga4nl.shape)
         a1 = 0.03
         a2 = 0.09
         pga_low = 0.06


### PR DESCRIPTION
Hi folks,
I'm Bruce Worden, the developer of ShakeMap. I encountered this bug while experimenting with this module. Essentially if dists.rjb and sites.vs30 are 2-dimensional, then the module won't work. The suggested fix appears to resolve the issue.
Best,
Bruce
