### PR TITLE
Adds 'azimuth' and 'hanging_wall' to DistancesContext

### DIFF
--- a/openquake/hazardlib/gsim/base.py
+++ b/openquake/hazardlib/gsim/base.py
@@ -816,7 +816,8 @@ class DistancesContext(BaseContext):
     does it need. Only those required values are calculated and made available
     in a result context object.
     """
-    __slots__ = ('rrup', 'rx', 'rjb', 'rhypo', 'repi', 'ry0', 'rcdpp')
+    __slots__ = ('rrup', 'rx', 'rjb', 'rhypo', 'repi', 'ry0', 'rcdpp',
+        'azimuth', 'hanging_wall')
 
 
 class RuptureContext(BaseContext):


### PR DESCRIPTION
Adds two more terms into the __slots__ of the openquake.hazardlib.gsim.base.DistancesContext objects. These aren't really used in the hazardlib, but they are useful for compatibility with this PR on the OQ Ground Motion Toolkit https://github.com/GEMScienceTools/gmpe-smtk/pull/32