### PR TITLE
Adds __str__ method to scalrel and mfd base class

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,6 @@
+  [Graeme Weatherill]
+  * Adds `__repr__` method to scalerel and MFD base classes
+
   [Michele Simionato]
   * Now hazardlib unofficially supports Python 3
   * Added support for python setup.py test

--- a/openquake/hazardlib/mfd/base.py
+++ b/openquake/hazardlib/mfd/base.py
@@ -93,8 +93,8 @@ class BaseMFD(with_metaclass(abc.ABCMeta)):
             Magnitude value, float number.
         """
 
-    def __str__(self):
+    def __repr__(self):
         """
         Returns the name of the magnitude frequency distribution class
         """
-        return self.__class__.__name__
+        return "<%s>" % self.__class__.__name__

--- a/openquake/hazardlib/mfd/base.py
+++ b/openquake/hazardlib/mfd/base.py
@@ -92,3 +92,9 @@ class BaseMFD(with_metaclass(abc.ABCMeta)):
         :return:
             Magnitude value, float number.
         """
+
+    def __str__(self):
+        """
+        Returns the name of the magnitude frequency distribution class
+        """
+        return self.__class__.__name__

--- a/openquake/hazardlib/scalerel/base.py
+++ b/openquake/hazardlib/scalerel/base.py
@@ -41,11 +41,11 @@ class BaseASR(with_metaclass(abc.ABCMeta)):
             from -180 to 180.
         """
 
-    def __str__(self):
+    def __repr__(self):
         """
         Returns the name of the class
         """
-        return self.__class__.__name__
+        return "<%s>" % self.__class__.__name__
 
 
 class BaseASRSigma(with_metaclass(abc.ABCMeta, BaseASR)):
@@ -84,11 +84,11 @@ class BaseMSR(with_metaclass(abc.ABCMeta)):
             from -180 to 180.
         """
 
-    def __str__(self):
+    def __repr__(self):
         """
         Returns the name of the class
         """
-        return self.__class__.__name__
+        return "<%s>" % self.__class__.__name__
 
 
 class BaseMSRSigma(with_metaclass(abc.ABCMeta, BaseMSR)):

--- a/openquake/hazardlib/scalerel/base.py
+++ b/openquake/hazardlib/scalerel/base.py
@@ -41,6 +41,12 @@ class BaseASR(with_metaclass(abc.ABCMeta)):
             from -180 to 180.
         """
 
+    def __str__(self):
+        """
+        Returns the name of the class
+        """
+        return self.__class__.__name__
+
 
 class BaseASRSigma(with_metaclass(abc.ABCMeta, BaseASR)):
     """
@@ -57,7 +63,6 @@ class BaseASRSigma(with_metaclass(abc.ABCMeta, BaseASR)):
             Rake angle (the rupture propagation direction) in degrees,
             from -180 to 180.
         """
-
 
 class BaseMSR(with_metaclass(abc.ABCMeta)):
     """
@@ -78,6 +83,12 @@ class BaseMSR(with_metaclass(abc.ABCMeta)):
             Rake angle (the rupture propagation direction) in degrees,
             from -180 to 180.
         """
+
+    def __str__(self):
+        """
+        Returns the name of the class
+        """
+        return self.__class__.__name__
 
 
 class BaseMSRSigma(with_metaclass(abc.ABCMeta, BaseMSR)):
@@ -100,3 +111,4 @@ class BaseMSRSigma(with_metaclass(abc.ABCMeta, BaseMSR)):
             Rake angle (the rupture propagation direction) in degrees,
             from -180 to 180.
         """
+

--- a/openquake/hazardlib/tests/mfd/base_test.py
+++ b/openquake/hazardlib/tests/mfd/base_test.py
@@ -60,4 +60,4 @@ class BaseMFDModificationsTestCase(BaseMFDTestCase):
         mfd.modify('foo', dict(a=1, b='2', c=True))
         self.assertEqual(mfd.foo_calls, [{'a': 1, 'b': '2', 'c': True}])
         self.assertEqual(mfd.check_constraints_call_count, 1)
-        self.assertEqual(str(mfd), "TestMFD")
+        self.assertEqual(str(mfd), "<TestMFD>")

--- a/openquake/hazardlib/tests/mfd/base_test.py
+++ b/openquake/hazardlib/tests/mfd/base_test.py
@@ -60,3 +60,4 @@ class BaseMFDModificationsTestCase(BaseMFDTestCase):
         mfd.modify('foo', dict(a=1, b='2', c=True))
         self.assertEqual(mfd.foo_calls, [{'a': 1, 'b': '2', 'c': True}])
         self.assertEqual(mfd.check_constraints_call_count, 1)
+        self.assertEqual(str(mfd), "TestMFD")

--- a/openquake/hazardlib/tests/scalerel/asr_test.py
+++ b/openquake/hazardlib/tests/scalerel/asr_test.py
@@ -40,4 +40,4 @@ class WC1994ASRTestCase(unittest.TestCase):
         self.assertAlmostEqual(self.asr.get_median_mag(800, -130), 6.8911518)
 
     def test_str(self):
-        self.assertEqual(str(self.asr), "WC1994")
+        self.assertEqual(str(self.asr), "<WC1994>")

--- a/openquake/hazardlib/tests/scalerel/asr_test.py
+++ b/openquake/hazardlib/tests/scalerel/asr_test.py
@@ -38,3 +38,6 @@ class WC1994ASRTestCase(unittest.TestCase):
         self.assertAlmostEqual(self.asr.get_median_mag(500, -136), 6.7329494)
         self.assertAlmostEqual(self.asr.get_median_mag(700, 50), 6.8905882)
         self.assertAlmostEqual(self.asr.get_median_mag(800, -130), 6.8911518)
+
+    def test_str(self):
+        self.assertEqual(str(self.asr), "WC1994")

--- a/openquake/hazardlib/tests/scalerel/msr_test.py
+++ b/openquake/hazardlib/tests/scalerel/msr_test.py
@@ -73,4 +73,4 @@ class WC1994MSRTestCase(BaseMSRTestCase):
         self.assertEqual(self.msr.get_std_dev_area(None, -130), 0.22)
 
     def test_string(self):
-        self.assertEqual(str(self.msr), "WC1994")
+        self.assertEqual(str(self.msr), "<WC1994>")

--- a/openquake/hazardlib/tests/scalerel/msr_test.py
+++ b/openquake/hazardlib/tests/scalerel/msr_test.py
@@ -71,3 +71,6 @@ class WC1994MSRTestCase(BaseMSRTestCase):
         self.assertEqual(self.msr.get_std_dev_area(None, -136), 0.22)
         self.assertEqual(self.msr.get_std_dev_area(None, 50), 0.26)
         self.assertEqual(self.msr.get_std_dev_area(None, -130), 0.22)
+
+    def test_string(self):
+        self.assertEqual(str(self.msr), "WC1994")


### PR DESCRIPTION
For consistency with the GSIM class, adds the method `__str__` to the scalerel and mfd base classes