### PR TITLE
Make baselib portable to other OSes (aka Windows)

### DIFF
--- a/openquake/baselib/general.py
+++ b/openquake/baselib/general.py
@@ -403,7 +403,7 @@ def import_all(module_or_package):
             if f.endswith('.py'):
                 # convert PKGPATH/subpackage/module.py -> subpackage.module
                 # works at any level of nesting
-                modname = (module_or_package + cwd[n:].replace('/', '.') +
+                modname = (module_or_package + cwd[n:].replace(os.sep, '.') +
                            '.' + os.path.basename(f[:-3]))
                 try:
                     importlib.import_module(modname)


### PR DESCRIPTION
This will fix some errors on Windows:
```
Could not import openquake.calculators\tests.base_test: ImportError: Import by filename is not supported.
Could not import openquake.calculators\tests.calc_test: ImportError: Import by filename is not supported.
Could not import openquake.calculators\tests.classical_damage_test: ImportError: Import by filename is not supported.
Could not import openquake.calculators\tests.classical_risk_test: ImportError: Import by filename is not supported.
Could not import openquake.calculators\tests.classical_test: ImportError: Import by filename is not supported.
Could not import openquake.calculators\tests.classical_tiling_test: ImportError: Import by filename is not supported.
Could not import openquake.calculators\tests.event_based_risk_test: ImportError: Import by filename is not supported.
Could not import openquake.calculators\tests.event_based_test: ImportError: Import by filename is not supported.
Could not import openquake.calculators\tests.scenario_damage_test: ImportError: Import by filename is not supported.
[cut]
```