### PR TITLE
Refactored the PerformanceMonitor

### DIFF
--- a/openquake/baselib/performance.py
+++ b/openquake/baselib/performance.py
@@ -20,7 +20,7 @@ import os
 import re
 import time
 import operator
-import datetime
+from datetime import datetime
 import collections
 
 import numpy

--- a/openquake/baselib/performance.py
+++ b/openquake/baselib/performance.py
@@ -153,6 +153,10 @@ class PerformanceMonitor(object):
         """
         Save the measurements on the performance file
         """
+        if os.environ.get('OQ_TASK_ID'):
+            # this is set by the litetask decorator
+            raise RuntimeError('PerformanceMonitor.flush() must not be called '
+                               'by a worker!')
         monitors = [self] + self.children
         for row in map(_get_data, monitors):
             self.write(row)

--- a/openquake/baselib/performance.py
+++ b/openquake/baselib/performance.py
@@ -154,10 +154,6 @@ class PerformanceMonitor(object):
         """
         Save the measurements on the performance file
         """
-        if os.environ.get('OQ_TASK_ID'):
-            # this is set by the litetask decorator
-            raise RuntimeError('PerformanceMonitor.flush() must not be called '
-                               'by a worker!')
         monitors = [self] + self.children
         for mon in monitors:
             self.write(mon.get_data())

--- a/openquake/baselib/tests/performance_test.py
+++ b/openquake/baselib/tests/performance_test.py
@@ -29,6 +29,20 @@ class MonitorTestCase(unittest.TestCase):
         self.assertGreaterEqual(mon.mem, 0)
         mon.flush()
 
+    def test_children(self):
+        mon = PerformanceMonitor('test', tempfile.mkdtemp())
+        mon1 = mon('child1')
+        mon2 = mon('child2')
+        with mon1:
+            time.sleep(0.1)
+        with mon2:
+            time.sleep(0.1)
+        mon.flush()
+        data = mon.collect_performance()
+        total_time = data['time_sec'].sum()
+        self.assertGreaterEqual(total_time, 0.2)
+        shutil.rmtree(mon.monitor_dir)
+
     @classmethod
     def tearDownClass(cls):
         data = cls.mon.collect_performance()

--- a/openquake/baselib/tests/performance_test.py
+++ b/openquake/baselib/tests/performance_test.py
@@ -2,14 +2,14 @@ import time
 import unittest
 import tempfile
 import shutil
-from openquake.baselib.performance import Monitor
+from openquake.baselib.performance import PerformanceMonitor
 
 
 class MonitorTestCase(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         tmpdir = tempfile.mkdtemp()
-        cls.mon = Monitor('test', tmpdir)
+        cls.mon = PerformanceMonitor('test', tmpdir)
 
     def test_no_mem(self):
         mon = self.mon('test_no_mem')

--- a/openquake/hazardlib/calc/hazard_curve.py
+++ b/openquake/hazardlib/calc/hazard_curve.py
@@ -217,7 +217,4 @@ def hazard_curves_per_trt(
     for i in range(len(gnames)):
         for imt in imtls:
             curves[i][imt] = 1. - curves[i][imt]
-    ctx_mon.flush()
-    rup_mon.flush()
-    pne_mon.flush()
     return curves


### PR DESCRIPTION
This is needed for https://github.com/gem/oq-risklib/issues/411. Here I am introducing the concept of "children" of a monitor object. Calling `.flush` on the parent monitor automatically flushes all the children.
So in a worker we can generate several different children and have them flushed at once in the controller node.
The tests are green: https://ci.openquake.org/job/zdevel_oq-hazardlib/410