### PR TITLE
Custom h5py

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,6 @@
   [Matteo Nastasi]
-  * Imposed version for python-h5py dependency. Ubuntu 12.04 will use
-    backported version from GEM repository.
+  * Imposed version for python-h5py dependency, Ubuntu 12.04 will use
+    backported version from GEM repository
   
   [Graeme Weatherill]
   * Adds Montalva et al. (2015) GMPE

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,7 @@
+  [Matteo Nastasi]
+  * Imposed version for python-h5py dependency. Ubuntu 12.04 will use
+    backported version from GEM repository.
+  
   [Graeme Weatherill]
   * Adds Montalva et al. (2015) GMPE
 

--- a/debian/control
+++ b/debian/control
@@ -11,5 +11,5 @@ Homepage: http://github.com/gem/oq-hazardlib
 Package: python-oq-hazardlib
 Architecture: any
 Conflicts: python-nhlib
-Depends: ${shlibs:Depends}, ${misc:Depends}, python-numpy, python-scipy, python-shapely, python-psutil, python-h5py
+Depends: ${shlibs:Depends}, ${misc:Depends}, python-numpy, python-scipy, python-shapely, python-psutil, python-h5py (>= 2.2.1)
 Description: hazardlib is a library for performing seismic hazard analysis

--- a/packager.sh
+++ b/packager.sh
@@ -180,6 +180,18 @@ _devtest_innervm_run () {
     ssh $lxc_ip "sudo apt-get update"
     ssh $lxc_ip "sudo apt-get upgrade -y"
 
+    gpg -a --export | ssh $lxc_ip "sudo apt-key add -"
+    # install package to manage repository properly
+    ssh $lxc_ip "sudo apt-get install -y python-software-properties"
+
+    # add custom packages
+    ssh $lxc_ip mkdir -p "repo"
+    scp -r ${GEM_DEB_REPO}/${BUILD_UBUVER}/custom_pkgs $lxc_ip:repo/custom_pkgs
+    ssh $lxc_ip "sudo apt-add-repository \"deb file:/home/ubuntu/repo/custom_pkgs ./\""
+
+    ssh $lxc_ip "sudo apt-get update"
+    ssh $lxc_ip "sudo apt-get upgrade -y"
+
     pkgs_list="$(deps_list debian/control)"
     ssh $lxc_ip "sudo apt-get install -y ${pkgs_list}"
 
@@ -221,7 +233,13 @@ _pkgtest_innervm_run () {
         build-deb/${GEM_DEB_PACKAGE}_*.dsc build-deb/${GEM_DEB_PACKAGE}_*.tar.gz \
         build-deb/Packages* build-deb/Sources*  build-deb/Release* $lxc_ip:repo/${GEM_DEB_PACKAGE}
     ssh $lxc_ip "sudo apt-add-repository \"deb file:/home/ubuntu/repo/${GEM_DEB_PACKAGE} ./\""
+
+    # add custom packages
+    scp -r ${GEM_DEB_REPO}/${BUILD_UBUVER}/custom_pkgs $lxc_ip:repo/custom_pkgs
+    ssh $lxc_ip "sudo apt-add-repository \"deb file:/home/ubuntu/repo/custom_pkgs ./\""
+
     ssh $lxc_ip "sudo apt-get update"
+    ssh $lxc_ip "sudo apt-get upgrade -y"
 
     # packaging related tests (install, remove, purge, install, reinstall)
     ssh $lxc_ip "sudo apt-get install -y ${GEM_DEB_PACKAGE}"


### PR DESCRIPTION
Imposed version for python-h5py dependency, Ubuntu 12.04 will use backported version from GEM repository.