### PR TITLE
Adds geometry modifiers to fault sources

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,6 @@
+  [Graeme Weatherill]
+  * Adds methods for modifying the geometry configurations of the fault sources
+
   [Matteo Nastasi]
   * Imposed version for python-h5py dependency, Ubuntu 12.04 will use
     backported version from GEM repository

--- a/openquake/hazardlib/source/area.py
+++ b/openquake/hazardlib/source/area.py
@@ -41,6 +41,8 @@ class AreaSource(PointSource):
     """
     __slots__ = PointSource.__slots__ + 'polygon area_discretization'.split()
 
+    MODIFICATIONS = set(())
+
     def __init__(self, source_id, name, tectonic_region_type,
                  mfd, rupture_mesh_spacing,
                  magnitude_scaling_relationship, rupture_aspect_ratio,

--- a/openquake/hazardlib/source/base.py
+++ b/openquake/hazardlib/source/base.py
@@ -142,7 +142,7 @@ class BaseSeismicSource(with_metaclass(abc.ABCMeta)):
         as keyword arguments. See also :attr:`MODIFICATIONS`.
 
         Modifications can be applied one on top of another. The logic
-        of stacking modifications is up to a specific MFD implementation.
+        of stacking modifications is up to a specific source implementation.
 
         :param modification:
             String name representing the type of modification.

--- a/openquake/hazardlib/source/characteristic.py
+++ b/openquake/hazardlib/source/characteristic.py
@@ -58,6 +58,8 @@ class CharacteristicFaultSource(ParametricSeismicSource):
     __slots__ = ParametricSeismicSource.__slots__ + (
         'surface surface_node rake').split()
 
+    MODIFICATIONS = set(('set_geometry',))
+
     def __init__(self, source_id, name, tectonic_region_type,
                  mfd, temporal_occurrence_model, surface, rake,
                  surface_node=None):

--- a/openquake/hazardlib/source/characteristic.py
+++ b/openquake/hazardlib/source/characteristic.py
@@ -125,6 +125,12 @@ class CharacteristicFaultSource(ParametricSeismicSource):
     def modify_set_geometry(self, surface, surface_node=None):
         """
         Modifies the current fault geometry
+
+        :param surface:
+            Fault surface, see :mod:`openquake.hazardlib.geo.surface`.
+
+        :param surface_node:
+            If needed for export, provide the surface as a LiteralNode object
         """
         self.surface = surface
         self.surface_node = surface_node

--- a/openquake/hazardlib/source/characteristic.py
+++ b/openquake/hazardlib/source/characteristic.py
@@ -119,3 +119,10 @@ class CharacteristicFaultSource(ParametricSeismicSource):
         `openquake.hazardlib.source.base.BaseSeismicSource.count_ruptures`.
         """
         return len(self.get_annual_occurrence_rates())
+
+    def modify_set_geometry(self, surface, surface_node=None):
+        """
+        Modifies the current fault geometry
+        """
+        self.surface = surface
+        self.surface_node = surface_node

--- a/openquake/hazardlib/source/complex_fault.py
+++ b/openquake/hazardlib/source/complex_fault.py
@@ -50,6 +50,8 @@ class ComplexFaultSource(ParametricSeismicSource):
 
     __slots__ = ParametricSeismicSource.__slots__ + '''edges rake'''.split()
 
+    MODIFICATIONS = set(('set_geometry',))
+
     def __init__(self, source_id, name, tectonic_region_type, mfd,
                  rupture_mesh_spacing, magnitude_scaling_relationship,
                  rupture_aspect_ratio, temporal_occurrence_model,

--- a/openquake/hazardlib/source/complex_fault.py
+++ b/openquake/hazardlib/source/complex_fault.py
@@ -152,12 +152,13 @@ class ComplexFaultSource(ParametricSeismicSource):
             counts += len(rupture_slices)
         return counts
 
-    def modify_set_geometry(self, edges):
+    def modify_set_geometry(self, edges, spacing):
         """
         Modifies the complex fault geometry
         """
-        ComplexFaultSurface.check_fault_data(edges, self.rupture_mesh_spacing)
+        ComplexFaultSurface.check_fault_data(edges, spacing)
         self.edges = edges
+        self.rupture_mesh_spacing = spacing
 
 
 def _float_ruptures(rupture_area, rupture_length, cell_area, cell_length):

--- a/openquake/hazardlib/source/complex_fault.py
+++ b/openquake/hazardlib/source/complex_fault.py
@@ -152,6 +152,13 @@ class ComplexFaultSource(ParametricSeismicSource):
             counts += len(rupture_slices)
         return counts
 
+    def modify_set_geometry(self, edges):
+        """
+        Modifies the complex fault geometry
+        """
+        ComplexFaultSurface.check_fault_data(edges, self.rupture_mesh_spacing)
+        self.edges = edges
+
 
 def _float_ruptures(rupture_area, rupture_length, cell_area, cell_length):
     """

--- a/openquake/hazardlib/source/non_parametric.py
+++ b/openquake/hazardlib/source/non_parametric.py
@@ -46,6 +46,8 @@ class NonParametricSeismicSource(BaseSeismicSource):
     """
     __slots__ = BaseSeismicSource.__slots__ + ['data']
 
+    MODIFICATIONS = set(())
+
     def __init__(self, source_id, name, tectonic_region_type, data):
         super(NonParametricSeismicSource, self). \
             __init__(source_id, name, tectonic_region_type)

--- a/openquake/hazardlib/source/point.py
+++ b/openquake/hazardlib/source/point.py
@@ -63,6 +63,8 @@ class PointSource(ParametricSeismicSource):
     hypocenter_distribution
     '''.split()
 
+    MODIFICATIONS = set(())
+
     def __init__(self, source_id, name, tectonic_region_type,
                  mfd, rupture_mesh_spacing,
                  magnitude_scaling_relationship, rupture_aspect_ratio,

--- a/openquake/hazardlib/source/simple_fault.py
+++ b/openquake/hazardlib/source/simple_fault.py
@@ -277,3 +277,47 @@ class SimpleFaultSource(ParametricSeismicSource):
         rup_cols = int(round(rup_length / self.rupture_mesh_spacing) + 1)
         rup_rows = int(round(rup_width / self.rupture_mesh_spacing) + 1)
         return rup_cols, rup_rows
+
+    def modify_set_geometry(self, fault_trace, upper_seismogenic_depth,
+                            lower_seismogenic_depth, dip):
+        """
+        Modifies the current source geometry including trace, seismogenic
+        depths and dip
+        """
+        # Check the new geometries are valid
+        SimpleFaultSurface.check_fault_data(
+            fault_trace, upper_seismogenic_depth, lower_seismogenic_depth,
+            dip, self.rupture_mesh_spacing
+        )
+        self.fault_trace = fault_trace
+        self.upper_seismogenic_depth = upper_seismogenic_depth
+        self.lower_seismogenic_depth = lower_seismogenic_depth
+        self.dip = dip
+
+    def modify_adjust_dip(self, increment):
+        """
+        Modifies the dip by an incremental value
+
+        :param float increment:
+            Value by which to increase or decrease the dip (the resulting
+            dip must still be within 0.0 to 90.0 degrees)
+        """
+        SimpleFaultSurface.check_fault_data(
+            self.fault_trace, self.upper_seismogenic_depth,
+            self.lower_seismogenic_depth, self.dip + increment,
+            self.rupture_mesh_spacing
+        )
+        self.dip += increment
+
+    def modify_set_dip(self, dip):
+        """
+        Modifies the dip to the specified value
+
+        :param float dip:
+            New value of dip (must still be within 0.0 to 90.0 degrees)
+        """
+        SimpleFaultSurface.check_fault_data(
+            self.fault_trace, self.upper_seismogenic_depth,
+            self.lower_seismogenic_depth, dip, self.rupture_mesh_spacing
+        )
+        self.dip = dip

--- a/openquake/hazardlib/source/simple_fault.py
+++ b/openquake/hazardlib/source/simple_fault.py
@@ -279,7 +279,7 @@ class SimpleFaultSource(ParametricSeismicSource):
         return rup_cols, rup_rows
 
     def modify_set_geometry(self, fault_trace, upper_seismogenic_depth,
-                            lower_seismogenic_depth, dip):
+                            lower_seismogenic_depth, dip, spacing):
         """
         Modifies the current source geometry including trace, seismogenic
         depths and dip
@@ -287,12 +287,14 @@ class SimpleFaultSource(ParametricSeismicSource):
         # Check the new geometries are valid
         SimpleFaultSurface.check_fault_data(
             fault_trace, upper_seismogenic_depth, lower_seismogenic_depth,
-            dip, self.rupture_mesh_spacing
+            dip, spacing
         )
         self.fault_trace = fault_trace
         self.upper_seismogenic_depth = upper_seismogenic_depth
         self.lower_seismogenic_depth = lower_seismogenic_depth
         self.dip = dip
+        self.rupture_mesh_spacing = spacing
+
 
     def modify_adjust_dip(self, increment):
         """

--- a/openquake/hazardlib/source/simple_fault.py
+++ b/openquake/hazardlib/source/simple_fault.py
@@ -85,6 +85,10 @@ class SimpleFaultSource(ParametricSeismicSource):
     lower_seismogenic_depth fault_trace dip rake hypo_list
     slip_list'''.split()
 
+    MODIFICATIONS = set(('set_geometry',
+                         'adjust_dip',
+                         'set_dip'))
+
     def __init__(self, source_id, name, tectonic_region_type,
                  mfd, rupture_mesh_spacing,
                  magnitude_scaling_relationship, rupture_aspect_ratio,

--- a/openquake/hazardlib/tests/source/base_test.py
+++ b/openquake/hazardlib/tests/source/base_test.py
@@ -48,6 +48,7 @@ class _BaseSeismicSourceTestCase(unittest.TestCase):
 
     def setUp(self):
         class FakeSource(ParametricSeismicSource):
+            MODIFICATIONS = set(())
             iter_ruptures = None
             count_ruptures = None
             get_rupture_enclosing_polygon = None

--- a/openquake/hazardlib/tests/source/characteristic_test.py
+++ b/openquake/hazardlib/tests/source/characteristic_test.py
@@ -110,3 +110,26 @@ class CharacteristicFaultSourceIterRuptures(_BaseFaultSourceTestCase):
             self.assertTrue(ruptures[i].occurrence_rate == self.RATES[i])
             self.assertTrue(ruptures[i].temporal_occurrence_model == self.TOM)
 
+
+class ModifyCharacteristicFaultSurfaceTestCase(_BaseFaultSourceTestCase):
+
+    def setUp(self):
+        self.fault = self._make_source()
+
+    def test_modify_set_geometry(self):
+        new_corner_lons = numpy.array([-1.1, 1.1, -1.1, 1.1])
+        new_corner_lats = numpy.array([0., 0., 0., 0.])
+        new_corner_depths = numpy.array([0., 0., 15., 15.])
+        points = [Point(lon, lat, depth) for lon, lat, depth in
+                  zip(new_corner_lons, new_corner_lats, new_corner_depths)]
+        new_surface = PlanarSurface(self.MESH_SPACING, self.STRIKE, self.DIP,
+                                    points[0], points[1], points[3], points[2])
+        self.fault.modify_set_geometry(new_surface, "XYZ")
+        self.assertEqual(self.fault.surface_node, "XYZ")
+        numpy.testing.assert_array_almost_equal(self.fault.surface.corner_lons,
+                                                new_corner_lons)
+        numpy.testing.assert_array_almost_equal(self.fault.surface.corner_lats,
+                                                new_corner_lats)
+        numpy.testing.assert_array_almost_equal(
+            self.fault.surface.corner_depths,
+            new_corner_depths)

--- a/openquake/hazardlib/tests/source/complex_fault_test.py
+++ b/openquake/hazardlib/tests/source/complex_fault_test.py
@@ -22,6 +22,8 @@ from openquake.hazardlib.source.complex_fault import (ComplexFaultSource,
 from openquake.hazardlib.geo import Line, Point
 from openquake.hazardlib.geo.surface.simple_fault import SimpleFaultSurface
 from openquake.hazardlib.scalerel.peer import PeerMSR
+from openquake.hazardlib.mfd import EvenlyDiscretizedMFD
+from openquake.hazardlib.tom import PoissonTOM
 
 from openquake.hazardlib.tests.source import simple_fault_test
 from openquake.hazardlib.tests.source import \
@@ -334,3 +336,59 @@ class FloatRupturesTestCase(unittest.TestCase):
         self.assertEqual(bl, (slice(1, 4), slice(0, 2)))
         self.assertEqual(bm, (slice(1, 4), slice(1, 3)))
         self.assertEqual(br, (slice(1, 4), slice(2, 4)))
+
+
+class ModifyComplexFaultGeometryTestCase(unittest.TestCase):
+    """
+
+    """
+    def setUp(self):
+        top_edge_1 = Line([Point(30.0, 30.0, 1.0), Point(31.0, 30.0, 1.0)])
+        bottom_edge_1 = Line([Point(29.7, 29.9, 30.0),
+                              Point(31.3, 29.9, 32.0)])
+        self.edges = [top_edge_1, bottom_edge_1]
+        self.mfd = EvenlyDiscretizedMFD(7.0, 0.1, [1.0])
+        self.aspect = 1.0
+        self.spacing = 5.0
+        self.rake = 90.
+
+    def _make_source(self, edges):
+        source_id = name = 'test-source'
+        trt = "Subduction Interface"
+        tom = PoissonTOM(50.0)
+        magnitude_scaling_relationship = PeerMSR()
+        cfs = ComplexFaultSource(
+            source_id, name, trt, self.mfd, self.spacing,
+            magnitude_scaling_relationship, self.aspect, tom,
+            edges, self.rake
+        )
+        assert_pickleable(cfs)
+        return cfs
+
+    def test_modify_geometry(self):
+        fault = self._make_source(self.edges)
+        # Modify the edges
+        top_edge_2 = Line([Point(29.9, 30.0, 2.0), Point(31.1, 30.0, 2.1)])
+        bottom_edge_2 = Line([Point(29.6, 29.9, 29.0),
+                              Point(31.4, 29.9, 33.0)])
+        fault.modify_set_geometry([top_edge_2, bottom_edge_2])
+        exp_lons_top = [29.9, 31.1]
+        exp_lats_top = [30.0, 30.0]
+        exp_depths_top = [2.0, 2.1]
+        exp_lons_bot = [29.6, 31.4]
+        exp_lats_bot = [29.9, 29.9]
+        exp_depths_bot = [29.0, 33.0]
+        for iloc in range(len(fault.edges[0])):
+            self.assertAlmostEqual(fault.edges[0].points[iloc].longitude,
+                                   exp_lons_top[iloc])
+            self.assertAlmostEqual(fault.edges[0].points[iloc].latitude,
+                                   exp_lats_top[iloc])
+            self.assertAlmostEqual(fault.edges[0].points[iloc].depth,
+                                   exp_depths_top[iloc])
+        for iloc in range(len(fault.edges[1])):
+            self.assertAlmostEqual(fault.edges[1].points[iloc].longitude,
+                                   exp_lons_bot[iloc])
+            self.assertAlmostEqual(fault.edges[1].points[iloc].latitude,
+                                   exp_lats_bot[iloc])
+            self.assertAlmostEqual(fault.edges[1].points[iloc].depth,
+                                   exp_depths_bot[iloc])

--- a/openquake/hazardlib/tests/source/complex_fault_test.py
+++ b/openquake/hazardlib/tests/source/complex_fault_test.py
@@ -362,7 +362,6 @@ class ModifyComplexFaultGeometryTestCase(unittest.TestCase):
             magnitude_scaling_relationship, self.aspect, tom,
             edges, self.rake
         )
-        assert_pickleable(cfs)
         return cfs
 
     def test_modify_geometry(self):
@@ -371,7 +370,7 @@ class ModifyComplexFaultGeometryTestCase(unittest.TestCase):
         top_edge_2 = Line([Point(29.9, 30.0, 2.0), Point(31.1, 30.0, 2.1)])
         bottom_edge_2 = Line([Point(29.6, 29.9, 29.0),
                               Point(31.4, 29.9, 33.0)])
-        fault.modify_set_geometry([top_edge_2, bottom_edge_2])
+        fault.modify_set_geometry([top_edge_2, bottom_edge_2], self.spacing)
         exp_lons_top = [29.9, 31.1]
         exp_lats_top = [30.0, 30.0]
         exp_depths_top = [2.0, 2.1]

--- a/openquake/hazardlib/tests/source/simple_fault_test.py
+++ b/openquake/hazardlib/tests/source/simple_fault_test.py
@@ -648,3 +648,78 @@ class HypoLocSlipRupture(unittest.TestCase):
             self.assertAlmostEqual(rup.rupture_slip_direction,
                                    slip[i], delta=0.1)
             self.assertAlmostEqual(rup.occurrence_rate, rate[i], delta=0.01)
+
+
+class ModifySimpleFaultTestCase(_BaseFaultSourceTestCase):
+    """
+    Tests all of the geometry modification methods
+    """
+    def setUp(self):
+        self.basic_trace = Line([Point(30.0, 30.0), Point(30.0, 32.0)])
+        self.mfd = EvenlyDiscretizedMFD(7.0, 0.1, [1.0])
+        self.aspect = 1.0
+        self.dip = 45.0
+        self.fault = self._make_source(self.mfd, self.aspect, self.basic_trace,
+                                       self.dip)
+        self.fault.lower_seismogenic_depth = 10.0
+
+    def test_modify_set_geometry_trace(self):
+        new_trace = Line([Point(30.0, 30.0), Point(30.2, 32.25)])
+        self.fault.modify_set_geometry(new_trace, 0., 10., 45.)
+        exp_lons = [30.0, 30.2]
+        exp_lats = [30.0, 32.25]
+        for iloc in range(len(self.fault.fault_trace)):
+            self.assertAlmostEqual(
+                self.fault.fault_trace.points[iloc].longitude,
+                exp_lons[iloc]
+                )
+            self.assertAlmostEqual(
+                self.fault.fault_trace.points[iloc].latitude,
+                exp_lats[iloc]
+                )
+        # Verify that the dip and seismogenic depths were not modified
+        self.assertAlmostEqual(self.fault.dip, 45.0)
+        self.assertAlmostEqual(self.fault.upper_seismogenic_depth, 0.0)
+        self.assertAlmostEqual(self.fault.lower_seismogenic_depth, 10.0)
+        # Return trace back to original state
+        self.fault = self._make_source(self.mfd, self.aspect, self.basic_trace,
+                                       self.dip)
+        self.fault.lower_seismogenic_depth = 10.0
+
+    def test_modify_set_geometry_other_params(self):
+        self.fault.modify_set_geometry(self.basic_trace, 1., 12., 60.)
+        self.assertAlmostEqual(self.fault.dip, 60.)
+        self.assertAlmostEqual(self.fault.upper_seismogenic_depth, 1.0)
+        self.assertAlmostEqual(self.fault.lower_seismogenic_depth, 12.0)
+        # Return fault to original format
+        self.fault = self._make_source(self.mfd, self.aspect, self.basic_trace,
+                                       self.dip)
+        self.fault.lower_seismogenic_depth = 10.0
+
+    def test_modify_adjust_dip(self):
+        # Increase dip
+        self.fault.modify_adjust_dip(15.0)
+        self.assertAlmostEqual(self.fault.dip, 60.0)
+        self.fault = self._make_source(self.mfd, self.aspect, self.basic_trace,
+                                       self.dip)
+        self.fault.lower_seismogenic_depth = 10.0
+        # Decrease dip
+        self.fault.modify_adjust_dip(-15.0)
+        self.assertAlmostEqual(self.fault.dip, 30.0)
+        self.fault = self._make_source(self.mfd, self.aspect, self.basic_trace,
+                                       self.dip)
+        self.fault.lower_seismogenic_depth = 10.0
+
+    def test_modify_adjust_dip_bad(self):
+        with self.assertRaises(ValueError) as ar:
+            # Adjustment would put dip out of 0 - 90 degree range
+            self.fault.modify_adjust_dip(70.0)
+        self.assertEqual(str(ar.exception), "dip must be between 0.0 and 90.0")
+
+    def test_modify_set_dip(self):
+        self.fault.modify_set_dip(72.0)
+        self.assertAlmostEqual(self.fault.dip, 72.0)
+        # Return fault to original configuration
+        self.fault = self._make_source(self.mfd, self.aspect, self.basic_trace,
+                                       self.dip)
+        self.fault.lower_seismogenic_depth = 10.0

--- a/openquake/hazardlib/tests/source/simple_fault_test.py
+++ b/openquake/hazardlib/tests/source/simple_fault_test.py
@@ -16,7 +16,7 @@
 import unittest
 
 import numpy
-
+from copy import deepcopy
 from openquake.baselib.python3compat import range
 from openquake.hazardlib.const import TRT
 from openquake.hazardlib.source.simple_fault import SimpleFaultSource
@@ -664,51 +664,41 @@ class ModifySimpleFaultTestCase(_BaseFaultSourceTestCase):
         self.fault.lower_seismogenic_depth = 10.0
 
     def test_modify_set_geometry_trace(self):
+        new_fault = deepcopy(self.fault) 
         new_trace = Line([Point(30.0, 30.0), Point(30.2, 32.25)])
-        self.fault.modify_set_geometry(new_trace, 0., 10., 45.)
+        new_fault.modify_set_geometry(new_trace, 0., 10., 45., 1.)
         exp_lons = [30.0, 30.2]
         exp_lats = [30.0, 32.25]
-        for iloc in range(len(self.fault.fault_trace)):
+        for iloc in range(len(new_fault.fault_trace)):
             self.assertAlmostEqual(
-                self.fault.fault_trace.points[iloc].longitude,
+                new_fault.fault_trace.points[iloc].longitude,
                 exp_lons[iloc]
                 )
             self.assertAlmostEqual(
-                self.fault.fault_trace.points[iloc].latitude,
+                new_fault.fault_trace.points[iloc].latitude,
                 exp_lats[iloc]
                 )
         # Verify that the dip and seismogenic depths were not modified
-        self.assertAlmostEqual(self.fault.dip, 45.0)
-        self.assertAlmostEqual(self.fault.upper_seismogenic_depth, 0.0)
-        self.assertAlmostEqual(self.fault.lower_seismogenic_depth, 10.0)
-        # Return trace back to original state
-        self.fault = self._make_source(self.mfd, self.aspect, self.basic_trace,
-                                       self.dip)
-        self.fault.lower_seismogenic_depth = 10.0
+        self.assertAlmostEqual(new_fault.dip, 45.0)
+        self.assertAlmostEqual(new_fault.upper_seismogenic_depth, 0.0)
+        self.assertAlmostEqual(new_fault.lower_seismogenic_depth, 10.0)
 
     def test_modify_set_geometry_other_params(self):
-        self.fault.modify_set_geometry(self.basic_trace, 1., 12., 60.)
-        self.assertAlmostEqual(self.fault.dip, 60.)
-        self.assertAlmostEqual(self.fault.upper_seismogenic_depth, 1.0)
-        self.assertAlmostEqual(self.fault.lower_seismogenic_depth, 12.0)
-        # Return fault to original format
-        self.fault = self._make_source(self.mfd, self.aspect, self.basic_trace,
-                                       self.dip)
-        self.fault.lower_seismogenic_depth = 10.0
+        new_fault = deepcopy(self.fault) 
+        new_fault.modify_set_geometry(self.basic_trace, 1., 12., 60., 1.)
+        self.assertAlmostEqual(new_fault.dip, 60.)
+        self.assertAlmostEqual(new_fault.upper_seismogenic_depth, 1.0)
+        self.assertAlmostEqual(new_fault.lower_seismogenic_depth, 12.0)
 
     def test_modify_adjust_dip(self):
         # Increase dip
-        self.fault.modify_adjust_dip(15.0)
-        self.assertAlmostEqual(self.fault.dip, 60.0)
-        self.fault = self._make_source(self.mfd, self.aspect, self.basic_trace,
-                                       self.dip)
-        self.fault.lower_seismogenic_depth = 10.0
+        new_fault = deepcopy(self.fault) 
+        new_fault.modify_adjust_dip(15.0)
+        self.assertAlmostEqual(new_fault.dip, 60.0)
         # Decrease dip
-        self.fault.modify_adjust_dip(-15.0)
-        self.assertAlmostEqual(self.fault.dip, 30.0)
-        self.fault = self._make_source(self.mfd, self.aspect, self.basic_trace,
-                                       self.dip)
-        self.fault.lower_seismogenic_depth = 10.0
+        new_fault = deepcopy(self.fault) 
+        new_fault.modify_adjust_dip(-15.0)
+        self.assertAlmostEqual(new_fault.dip, 30.0)
 
     def test_modify_adjust_dip_bad(self):
         with self.assertRaises(ValueError) as ar:
@@ -717,9 +707,6 @@ class ModifySimpleFaultTestCase(_BaseFaultSourceTestCase):
         self.assertEqual(str(ar.exception), "dip must be between 0.0 and 90.0")
 
     def test_modify_set_dip(self):
-        self.fault.modify_set_dip(72.0)
-        self.assertAlmostEqual(self.fault.dip, 72.0)
-        # Return fault to original configuration
-        self.fault = self._make_source(self.mfd, self.aspect, self.basic_trace,
-                                       self.dip)
-        self.fault.lower_seismogenic_depth = 10.0
+        new_fault = deepcopy(self.fault) 
+        new_fault.modify_set_dip(72.0)
+        self.assertAlmostEqual(new_fault.dip, 72.0)


### PR DESCRIPTION
Adds methods to three fault source classes (SimpleFaultSource, ComplexFaultSource, CharacteristicFaultSource) to modify/update the geometry of the source. These anticipate support for this option in the logic trees.