### PR TITLE
Removing `__slots__`

### DIFF
--- a/openquake/baselib/general.py
+++ b/openquake/baselib/general.py
@@ -300,9 +300,9 @@ def assert_close(a, b, rtol=1e-07, atol=0, context=None):
         return
     if a == b:  # another shortcut
         return
-    if hasattr(a, '__slots__'):  # record-like objects
-        assert_close_seq(a.__slots__, b.__slots__, rtol, atol, a)
-        for x, y in zip(a.__slots__, b.__slots__):
+    if hasattr(a, '_slots_'):  # record-like objects
+        assert_close_seq(a._slots_, b._slots_, rtol, atol, a)
+        for x, y in zip(a._slots_, b._slots_):
             assert_close(getattr(a, x), getattr(b, y), rtol, atol, x)
         return
     if isinstance(a, collections.Mapping):  # dict-like objects

--- a/openquake/baselib/slots.py
+++ b/openquake/baselib/slots.py
@@ -23,7 +23,7 @@ import numpy
 def with_slots(cls):
     """
     Decorator for a class with _slots_. It automatically defines
-    the methods __eq__, __ne__, assert_equal, __getstate__ and __setstate__
+    the methods __eq__, __ne__, assert_equal.
     """
     def _compare(self, other):
         for slot in self.__class__._slots_:
@@ -48,18 +48,8 @@ def with_slots(cls):
                 raise AssertionError('slot %s: %s is different from %s' %
                                      (slot, source, target))
 
-    def __getstate__(self):
-        return dict((slot, getattr(self, slot))
-                    for slot in self.__class__._slots_)
-
-    def __setstate__(self, state):
-        for slot in self.__class__._slots_:
-            setattr(self, slot, state[slot])
-
     cls._slots_  # raise an AttributeError for missing slots
     cls.__eq__ = __eq__
     cls.__ne__ = __ne__
     cls.assert_equal = assert_equal
-    cls.__getstate__ = __getstate__
-    cls.__setstate__ = __setstate__
     return cls

--- a/openquake/baselib/slots.py
+++ b/openquake/baselib/slots.py
@@ -22,11 +22,11 @@ import numpy
 
 def with_slots(cls):
     """
-    Decorator for a class with __slots__. It automatically defines
+    Decorator for a class with _slots_. It automatically defines
     the methods __eq__, __ne__, assert_equal, __getstate__ and __setstate__
     """
     def _compare(self, other):
-        for slot in self.__class__.__slots__:
+        for slot in self.__class__._slots_:
             attr = operator.attrgetter(slot)
             source = attr(self)
             target = attr(other)
@@ -50,13 +50,13 @@ def with_slots(cls):
 
     def __getstate__(self):
         return dict((slot, getattr(self, slot))
-                    for slot in self.__class__.__slots__)
+                    for slot in self.__class__._slots_)
 
     def __setstate__(self, state):
-        for slot in self.__class__.__slots__:
+        for slot in self.__class__._slots_:
             setattr(self, slot, state[slot])
 
-    cls.__slots__  # raise an AttributeError for missing slots
+    cls._slots_  # raise an AttributeError for missing slots
     cls.__eq__ = __eq__
     cls.__ne__ = __ne__
     cls.assert_equal = assert_equal

--- a/openquake/hazardlib/geo/nodalplane.py
+++ b/openquake/hazardlib/geo/nodalplane.py
@@ -38,7 +38,7 @@ class NodalPlane(object):
     :raises ValueError:
         If any of parameters exceeds the definition range.
     """
-    __slots__ = ['strike', 'dip', 'rake']
+    _slots_ = ['strike', 'dip', 'rake']
 
     def __init__(self, strike, dip, rake):
         self.check_dip(dip)

--- a/openquake/hazardlib/geo/polygon.py
+++ b/openquake/hazardlib/geo/polygon.py
@@ -43,7 +43,7 @@ class Polygon(object):
         If ``points`` contains less than three unique points or if polygon
         perimeter intersects itself.
     """
-    __slots__ = 'lons lats _bbox _projection _polygon2d'.split()
+    _slots_ = 'lons lats _bbox _projection _polygon2d'.split()
 
     def __init__(self, points):
         points = utils.clean_points(points)

--- a/openquake/hazardlib/geo/surface/planar.py
+++ b/openquake/hazardlib/geo/surface/planar.py
@@ -67,14 +67,14 @@ class PlanarSurface(BaseQuadrilateralSurface):
     IMPERFECT_RECTANGLE_TOLERANCE = 0.0008
 
     _slots_ = ('mesh_spacing strike dip width length '
-                 'corner_lons corner_lats corner_depths '
-                 'normal d uv1 uv2 zero_zero').split()
+               'corner_lons corner_lats corner_depths '
+               'normal d uv1 uv2 zero_zero').split()
 
     def __init__(self, mesh_spacing, strike, dip,
                  top_left, top_right, bottom_right, bottom_left):
         super(PlanarSurface, self).__init__()
-        if not (top_left.depth == top_right.depth
-                and bottom_left.depth == bottom_right.depth):
+        if not (top_left.depth == top_right.depth and
+                bottom_left.depth == bottom_right.depth):
             raise ValueError("top and bottom edges must be parallel "
                              "to the earth surface")
 
@@ -112,8 +112,8 @@ class PlanarSurface(BaseQuadrilateralSurface):
         self.length = (length1 + length2) / 2.0
         # calculate the imperfect rectangle tolerance
         # relative to surface's area
-        tolerance = (self.width * self.length
-                     * self.IMPERFECT_RECTANGLE_TOLERANCE)
+        tolerance = (self.width * self.length *
+                     self.IMPERFECT_RECTANGLE_TOLERANCE)
         if numpy.max(numpy.abs(dists)) > tolerance:
             raise ValueError("corner points do not lie on the same plane")
         if length2 < 0:
@@ -315,10 +315,10 @@ class PlanarSurface(BaseQuadrilateralSurface):
         :return:
             Tuple of longitudes, latitudes and depths numpy arrays.
         """
-        vectors = (self.zero_zero
-                   + self.uv1 * xx.reshape(xx.shape + (1, ))
-                   + self.uv2 * yy.reshape(yy.shape + (1, ))
-                   + self.normal * dists.reshape(dists.shape + (1, )))
+        vectors = (self.zero_zero +
+                   self.uv1 * xx.reshape(xx.shape + (1, )) +
+                   self.uv2 * yy.reshape(yy.shape + (1, )) +
+                   self.normal * dists.reshape(dists.shape + (1, )))
         return geo_utils.cartesian_to_spherical(vectors)
 
     def get_min_distance(self, mesh):

--- a/openquake/hazardlib/geo/surface/planar.py
+++ b/openquake/hazardlib/geo/surface/planar.py
@@ -66,7 +66,7 @@ class PlanarSurface(BaseQuadrilateralSurface):
     #: as a fraction of the surface's area.
     IMPERFECT_RECTANGLE_TOLERANCE = 0.0008
 
-    __slots__ = ('mesh_spacing strike dip width length '
+    _slots_ = ('mesh_spacing strike dip width length '
                  'corner_lons corner_lats corner_depths '
                  'normal d uv1 uv2 zero_zero').split()
 

--- a/openquake/hazardlib/geo/utils.py
+++ b/openquake/hazardlib/geo/utils.py
@@ -133,7 +133,7 @@ class OrthographicProjection(object):
     Callable object to compute orthographic projections. See the docstring
     of get_orthographic_projection.
     """
-    __slots__ = ('west east north south lambda0 phi0 '
+    _slots_ = ('west east north south lambda0 phi0 '
                  'cos_phi0 sin_phi0 sin_pi_over_4').split()
 
     def __init__(self, west, east, north, south):

--- a/openquake/hazardlib/gsim/base.py
+++ b/openquake/hazardlib/gsim/base.py
@@ -741,12 +741,12 @@ class BaseContext(with_metaclass(abc.ABCMeta)):
         Return True if ``other`` has same attributes with same values.
         """
         if isinstance(other, self.__class__):
-            if self.__slots__ == other.__slots__:
+            if self._slots_ == other._slots_:
                 self_other = [
                     numpy.all(
                         getattr(self, s, None) == getattr(other, s, None)
                     )
-                    for s in self.__slots__
+                    for s in self._slots_
                 ]
                 return numpy.all(self_other)
 
@@ -765,7 +765,7 @@ class SitesContext(BaseContext):
     Only those required parameters are made available in a result context
     object.
     """
-    __slots__ = ('vs30', 'vs30measured', 'z1pt0', 'z2pt5', 'backarc',
+    _slots_ = ('vs30', 'vs30measured', 'z1pt0', 'z2pt5', 'backarc',
         'lons', 'lats')
 
 
@@ -781,7 +781,7 @@ class DistancesContext(BaseContext):
     does it need. Only those required values are calculated and made available
     in a result context object.
     """
-    __slots__ = ('rrup', 'rx', 'rjb', 'rhypo', 'repi', 'ry0', 'rcdpp',
+    _slots_ = ('rrup', 'rx', 'rjb', 'rhypo', 'repi', 'ry0', 'rcdpp',
         'azimuth', 'hanging_wall')
 
 
@@ -797,7 +797,7 @@ class RuptureContext(BaseContext):
     Only those required parameters are made available in a result context
     object.
     """
-    __slots__ = (
+    _slots_ = (
         'mag', 'strike', 'dip', 'rake', 'ztor', 'hypo_lon', 'hypo_lat',
         'hypo_depth', 'width', 'hypo_loc'
     )

--- a/openquake/hazardlib/gsim/gsim_table.py
+++ b/openquake/hazardlib/gsim/gsim_table.py
@@ -70,7 +70,7 @@ class AmplificationTable(object):
         Distance values for the tables
     :attr parameter:
         Parameter to which the amplification applies. Must be an element
-        inside the __slots__ defines in the :class: openquake.hazardlib.
+        inside the _slots_ defines in the :class: openquake.hazardlib.
         gsim.base.RuptureContext or the :class: openquake.hazardlib.gsim.base.
         SitesContext
     :attr values:
@@ -100,9 +100,9 @@ class AmplificationTable(object):
         self.values = numpy.array([float(key) for key in amplification_group])
         self.argidx = numpy.argsort(self.values)
         self.values = self.values[self.argidx]
-        if self.parameter in RuptureContext.__slots__:
+        if self.parameter in RuptureContext._slots_:
             self.element = "Rupture"
-        elif self.parameter in SitesContext.__slots__:
+        elif self.parameter in SitesContext._slots_:
             self.element = "Sites"
         else:
             raise ValueError("Amplification parameter %s not recognised!"

--- a/openquake/hazardlib/imt.py
+++ b/openquake/hazardlib/imt.py
@@ -52,7 +52,7 @@ def from_string(imt):
 class IMTMeta(type):
     """Metaclass setting the _slots_ and the properties of IMT classes"""
     def __new__(mcs, name, bases, dct):
-        dct['_slots_'] = ()
+        dct['__slots__'] = ()
         cls = type.__new__(mcs, name, bases, dct)
         for index, field in enumerate(cls._fields):
             setattr(cls, field, property(operator.itemgetter(index + 1)))

--- a/openquake/hazardlib/imt.py
+++ b/openquake/hazardlib/imt.py
@@ -50,9 +50,9 @@ def from_string(imt):
 
 
 class IMTMeta(type):
-    """Metaclass setting the __slots__ and the properties of IMT classes"""
+    """Metaclass setting the _slots_ and the properties of IMT classes"""
     def __new__(mcs, name, bases, dct):
-        dct['__slots__'] = ()
+        dct['_slots_'] = ()
         cls = type.__new__(mcs, name, bases, dct)
         for index, field in enumerate(cls._fields):
             setattr(cls, field, property(operator.itemgetter(index + 1)))

--- a/openquake/hazardlib/mfd/evenly_discretized.py
+++ b/openquake/hazardlib/mfd/evenly_discretized.py
@@ -37,7 +37,7 @@ class EvenlyDiscretizedMFD(BaseMFD):
         as this list length.
     """
     MODIFICATIONS = set(('set_mfd',))
-    __slots__ = 'min_mag bin_width occurrence_rates'.split()
+    _slots_ = 'min_mag bin_width occurrence_rates'.split()
 
     def __init__(self, min_mag, bin_width, occurrence_rates):
         self.min_mag = min_mag

--- a/openquake/hazardlib/mfd/truncated_gr.py
+++ b/openquake/hazardlib/mfd/truncated_gr.py
@@ -67,7 +67,7 @@ class TruncatedGRMFD(BaseMFD):
                          'increment_b',
                          'set_ab'))
 
-    __slots__ = 'min_mag max_mag bin_width a_val b_val'.split()
+    _slots_ = 'min_mag max_mag bin_width a_val b_val'.split()
 
     def __init__(self, min_mag, max_mag, bin_width, a_val, b_val):
         self.min_mag = min_mag

--- a/openquake/hazardlib/pmf.py
+++ b/openquake/hazardlib/pmf.py
@@ -47,7 +47,7 @@ class PMF(object):
     NB: in the engine the sum is checked to be exactly one by using
     Decimal numbers.
     """
-    __slots__ = ['data']
+    _slots_ = ['data']
 
     def __init__(self, data, epsilon=1E-15):
         probs, values = list(zip(*data))

--- a/openquake/hazardlib/scalerel/ceus2011.py
+++ b/openquake/hazardlib/scalerel/ceus2011.py
@@ -32,7 +32,7 @@ class CEUS2011(BaseMSR):
         - CEUS SSC Final Report - Chapter 5, page 5-57
 
     """
-    __slots__ = []
+    _slots_ = []
 
     def get_median_area(self, mag, rake):
         """

--- a/openquake/hazardlib/scalerel/peer.py
+++ b/openquake/hazardlib/scalerel/peer.py
@@ -28,7 +28,7 @@ class PeerMSR(BaseMSRSigma):
     See "Verification of Probabilistic Seismic Hazard Analysis Computer
     Programs", Patricia Thomas and Ivan Wong, PEER Report 2010/106, May 2010.
     """
-    __slots__ = []
+    _slots_ = []
 
     def get_median_area(self, mag, rake):
         """

--- a/openquake/hazardlib/site.py
+++ b/openquake/hazardlib/site.py
@@ -57,7 +57,7 @@ class Site(object):
 
         :class:`Sites <Site>` are pickleable
     """
-    __slots__ = 'location vs30 vs30measured z1pt0 z2pt5 backarc id'.split()
+    _slots_ = 'location vs30 vs30measured z1pt0 z2pt5 backarc id'.split()
 
     def __init__(self, location, vs30, vs30measured, z1pt0, z2pt5,
                  backarc=False, id=0):
@@ -302,7 +302,7 @@ class FilteredSiteCollection(object):
     get a different FilteredSiteCollection referring to the complete
     SiteCollection `fsc.complete`, not to the filtered collection `fsc`.
     """
-    __slots__ = 'indices complete'.split()
+    _slots_ = 'indices complete'.split()
 
     def __init__(self, indices, complete):
         if complete is not complete.complete:

--- a/openquake/hazardlib/source/area.py
+++ b/openquake/hazardlib/source/area.py
@@ -39,7 +39,7 @@ class AreaSource(PointSource):
     Other parameters (except ``location``) are the same as for
     :class:`~openquake.hazardlib.source.point.PointSource`.
     """
-    __slots__ = PointSource.__slots__ + 'polygon area_discretization'.split()
+    _slots_ = PointSource._slots_ + 'polygon area_discretization'.split()
 
     MODIFICATIONS = set(())
 

--- a/openquake/hazardlib/source/base.py
+++ b/openquake/hazardlib/source/base.py
@@ -37,7 +37,7 @@ class BaseSeismicSource(with_metaclass(abc.ABCMeta)):
         Source's tectonic regime. See :class:`openquake.hazardlib.const.TRT`.
     """
 
-    __slots__ = ['source_id', 'name', 'tectonic_region_type',
+    _slots_ = ['source_id', 'name', 'tectonic_region_type',
                  'trt_model_id', 'weight', 'seed', 'id']
 
     MODIFICATIONS = abc.abstractproperty()
@@ -194,7 +194,7 @@ class ParametricSeismicSource(with_metaclass(abc.ABCMeta, BaseSeismicSource)):
         (if not None).
     """
 
-    __slots__ = BaseSeismicSource.__slots__ + '''mfd rupture_mesh_spacing
+    _slots_ = BaseSeismicSource._slots_ + '''mfd rupture_mesh_spacing
     magnitude_scaling_relationship rupture_aspect_ratio
     temporal_occurrence_model'''.split()
 

--- a/openquake/hazardlib/source/characteristic.py
+++ b/openquake/hazardlib/source/characteristic.py
@@ -55,7 +55,7 @@ class CharacteristicFaultSource(ParametricSeismicSource):
     its attribute `surface_node` to an explicit representation of the surface
     as a LiteralNode object.
     """
-    __slots__ = ParametricSeismicSource.__slots__ + (
+    _slots_ = ParametricSeismicSource._slots_ + (
         'surface surface_node rake').split()
 
     MODIFICATIONS = set(('set_geometry',))

--- a/openquake/hazardlib/source/complex_fault.py
+++ b/openquake/hazardlib/source/complex_fault.py
@@ -48,7 +48,7 @@ class ComplexFaultSource(ParametricSeismicSource):
         fails or if rake value is invalid.
     """
 
-    __slots__ = ParametricSeismicSource.__slots__ + '''edges rake'''.split()
+    _slots_ = ParametricSeismicSource._slots_ + '''edges rake'''.split()
 
     MODIFICATIONS = set(('set_geometry',))
 

--- a/openquake/hazardlib/source/non_parametric.py
+++ b/openquake/hazardlib/source/non_parametric.py
@@ -44,7 +44,7 @@ class NonParametricSeismicSource(BaseSeismicSource):
         rupture to occur N times (the PMF must be defined from a minimum number
         of occurrences equal to 0)
     """
-    __slots__ = BaseSeismicSource.__slots__ + ['data']
+    _slots_ = BaseSeismicSource._slots_ + ['data']
 
     MODIFICATIONS = set(())
 

--- a/openquake/hazardlib/source/point.py
+++ b/openquake/hazardlib/source/point.py
@@ -58,7 +58,7 @@ class PointSource(ParametricSeismicSource):
         depth,  if one or more of hypocenter depth values is shallower
         than upper seismogenic depth or deeper than lower seismogenic depth.
     """
-    __slots__ = ParametricSeismicSource.__slots__ + '''upper_seismogenic_depth
+    _slots_ = ParametricSeismicSource._slots_ + '''upper_seismogenic_depth
     lower_seismogenic_depth location nodal_plane_distribution
     hypocenter_distribution
     '''.split()

--- a/openquake/hazardlib/source/rupture.py
+++ b/openquake/hazardlib/source/rupture.py
@@ -71,7 +71,8 @@ class Rupture(object):
     surface_nodes source_typology rupture_slip_direction'''.split()
 
     def __init__(self, mag, rake, tectonic_region_type, hypocenter,
-                 surface, source_typology, rupture_slip_direction=None, surface_nodes=()):
+                 surface, source_typology, rupture_slip_direction=None,
+                 surface_nodes=()):
         if not mag > 0:
             raise ValueError('magnitude must be positive')
         if not hypocenter.depth > 0:

--- a/openquake/hazardlib/source/rupture.py
+++ b/openquake/hazardlib/source/rupture.py
@@ -67,7 +67,7 @@ class Rupture(object):
     NB: if you want to convert the rupture into XML, you should set the
     attribute surface_nodes to an appropriate value.
     """
-    __slots__ = '''mag rake tectonic_region_type hypocenter surface
+    _slots_ = '''mag rake tectonic_region_type hypocenter surface
     surface_nodes source_typology rupture_slip_direction'''.split()
 
     def __init__(self, mag, rake, tectonic_region_type, hypocenter,
@@ -231,7 +231,7 @@ class ParametricProbabilisticRupture(BaseProbabilisticRupture):
     :raises ValueError:
         If occurrence rate is not positive.
     """
-    __slots__ = Rupture.__slots__ + [
+    _slots_ = Rupture._slots_ + [
         'occurrence_rate', 'temporal_occurrence_model']
 
     def __init__(self, mag, rake, tectonic_region_type, hypocenter, surface,

--- a/openquake/hazardlib/source/simple_fault.py
+++ b/openquake/hazardlib/source/simple_fault.py
@@ -81,7 +81,7 @@ class SimpleFaultSource(ParametricSeismicSource):
         fails, if rake value is invalid and if rupture mesh spacing is too high
         for the lowest magnitude value.
     """
-    __slots__ = ParametricSeismicSource.__slots__ + '''upper_seismogenic_depth
+    _slots_ = ParametricSeismicSource._slots_ + '''upper_seismogenic_depth
     lower_seismogenic_depth fault_trace dip rake hypo_list
     slip_list'''.split()
 

--- a/openquake/hazardlib/tests/gsim/check_gsim.py
+++ b/openquake/hazardlib/tests/gsim/check_gsim.py
@@ -182,8 +182,8 @@ def _parse_csv(datafile, debug):
     headers = [param_name.lower() for param_name in next(reader)]
     sctx, rctx, dctx, stddev_types, expected_results, result_type \
         = _parse_csv_line(headers, next(reader))
-    sattrs = [slot for slot in SitesContext.__slots__ if hasattr(sctx, slot)]
-    dattrs = [slot for slot in DistancesContext.__slots__
+    sattrs = [slot for slot in SitesContext._slots_ if hasattr(sctx, slot)]
+    dattrs = [slot for slot in DistancesContext._slots_
               if hasattr(dctx, slot)]
     for line in reader:
         (sctx2, rctx2, dctx2, stddev_types2, expected_results2, result_type2) \
@@ -192,7 +192,7 @@ def _parse_csv(datafile, debug):
                 and stddev_types2 == stddev_types \
                 and result_type2 == result_type \
                 and all(getattr(rctx2, slot, None) == getattr(rctx, slot, None)
-                        for slot in RuptureContext.__slots__):
+                        for slot in RuptureContext._slots_):
             for slot in sattrs:
                 setattr(sctx, slot, numpy.hstack((getattr(sctx, slot),
                                                   getattr(sctx2, slot))))

--- a/openquake/hazardlib/tests/gsim/utils.py
+++ b/openquake/hazardlib/tests/gsim/utils.py
@@ -30,7 +30,7 @@ class BaseGSIMTestCase(unittest.TestCase):
         att = inspect.getmembers(ctx, lambda a: not(inspect.isroutine(a)))
         att = [
             k for k, v in att if not ('_abc' in k)
-            and not ((k.startswith('__') and k.endswith('__')))
+            and not ((k.startswith('_') and k.endswith('_')))
         ]
 
         return set(att)

--- a/openquake/hazardlib/tests/imt_test.py
+++ b/openquake/hazardlib/tests/imt_test.py
@@ -26,7 +26,7 @@ class BaseIMTTestCase(unittest.TestCase):
             return imt_module._IMT.__new__(cls, foo, bar)
 
     def test_base(self):
-        self.assertEqual(getattr(self.TestIMT, '__slots__'), ())
+        self.assertEqual(getattr(self.TestIMT, '_slots_'), ())
         self.assertFalse(hasattr(self.TestIMT(1, 2), '__dict__'))
         imt = self.TestIMT(bar=2, foo=1)
         self.assertEqual(str(imt), 'TestIMT')

--- a/openquake/hazardlib/tests/imt_test.py
+++ b/openquake/hazardlib/tests/imt_test.py
@@ -26,7 +26,7 @@ class BaseIMTTestCase(unittest.TestCase):
             return imt_module._IMT.__new__(cls, foo, bar)
 
     def test_base(self):
-        self.assertEqual(getattr(self.TestIMT, '_slots_'), ())
+        self.assertEqual(getattr(self.TestIMT, '__slots__'), ())
         self.assertFalse(hasattr(self.TestIMT(1, 2), '__dict__'))
         imt = self.TestIMT(bar=2, foo=1)
         self.assertEqual(str(imt), 'TestIMT')

--- a/openquake/hazardlib/tom.py
+++ b/openquake/hazardlib/tom.py
@@ -35,7 +35,7 @@ class PoissonTOM(object):
     :raises ValueError:
         If ``time_span`` is not positive.
     """
-    __slots__ = ['time_span']
+    _slots_ = ['time_span']
 
     def __init__(self, time_span):
         if time_span <= 0:


### PR DESCRIPTION
This is a preliminary step towards the elimination of `__slots__` (https://github.com/gem/oq-risklib/issues/541). By simply renaming `__slots__ -> _slots_` I am removing the "feature" and solving the error reported by an user. In subsequent pull requests I will remove `_slots_` completely. This must be done with care, because the `_slots_` attribute is used in the tests, when comparing two sources. A brutal removal of `_slots_` right now would break several tests.

The tests are running here: https://ci.openquake.org/job/zdevel_oq-hazardlib/426/