### PR TITLE
Move the rupture filtering inside the ContextMaker

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,5 @@
   [Michele Simionato]
+  * Avoided doing the rupture filtering twice
   * Optimized the case of multiple GSIMs by instantiating the
     ruptures/sites/distances contexts only once
 

--- a/openquake/hazardlib/calc/hazard_curve.py
+++ b/openquake/hazardlib/calc/hazard_curve.py
@@ -93,7 +93,8 @@ def hazard_curves(
 def calc_hazard_curves(
         sources, sites, imtls, gsim_by_trt, truncation_level=None,
         source_site_filter=filters.source_site_noop_filter,
-        rupture_site_filter=filters.rupture_site_noop_filter):
+        rupture_site_filter=filters.rupture_site_noop_filter,
+        maximum_distance=None):
     """
     Compute hazard curves on a list of sites, given a set of seismic sources
     and a set of ground shaking intensity models (one per tectonic region type
@@ -162,7 +163,7 @@ def hazard_curves_per_trt(
         sources, sites, imtls, gsims, truncation_level=None,
         source_site_filter=filters.source_site_noop_filter,
         rupture_site_filter=filters.rupture_site_noop_filter,
-        monitor=DummyMonitor()):
+        maximum_distance=None, monitor=DummyMonitor()):
     """
     Compute the hazard curves for a set of sources belonging to the same
     tectonic region type for all the GSIMs associated to that TRT.
@@ -175,7 +176,7 @@ def hazard_curves_per_trt(
         by the intensity measure types; the size of each field is given by the
         number of levels in ``imtls``.
     """
-    cmaker = ContextMaker(gsims)
+    cmaker = ContextMaker(gsims, maximum_distance)
     gnames = list(map(str, gsims))
     imt_dt = numpy.dtype([(imt, float, len(imtls[imt]))
                           for imt in sorted(imtls)])

--- a/openquake/hazardlib/calc/hazard_curve.py
+++ b/openquake/hazardlib/calc/hazard_curve.py
@@ -159,6 +159,8 @@ def calc_hazard_curves(
     return curves
 
 
+# TODO: remove the rupture_site_filter, since its work is now done by the
+# maximum_distance parameter; see what would break
 def hazard_curves_per_trt(
         sources, sites, imtls, gsims, truncation_level=None,
         source_site_filter=filters.source_site_noop_filter,

--- a/openquake/hazardlib/calc/hazard_curve.py
+++ b/openquake/hazardlib/calc/hazard_curve.py
@@ -27,7 +27,7 @@ import numpy
 from openquake.baselib.python3compat import range, raise_
 from openquake.baselib.performance import DummyMonitor
 from openquake.hazardlib.calc import filters
-from openquake.hazardlib.gsim.base import ContextMaker
+from openquake.hazardlib.gsim.base import ContextMaker, FarAwayRupture
 from openquake.hazardlib.imt import from_string
 from openquake.baselib.general import deprecated
 
@@ -195,7 +195,11 @@ def hazard_curves_per_trt(
                     (rupture, s_sites) for rupture in source.iter_ruptures()))
             for rupture, r_sites in rupture_sites:
                 with ctx_mon:
-                    sctx, rctx, dctx = cmaker.make_contexts(r_sites, rupture)
+                    try:
+                        sctx, rctx, dctx = cmaker.make_contexts(
+                            r_sites, rupture)
+                    except FarAwayRupture:
+                        continue
                 for i, gsim in enumerate(gsims):
                     with pne_mon:
                         for imt in imts:

--- a/openquake/hazardlib/calc/hazard_curve.py
+++ b/openquake/hazardlib/calc/hazard_curve.py
@@ -203,7 +203,7 @@ def hazard_curves_per_trt(
                                 sctx, rctx, dctx, imt, imts[imt],
                                 truncation_level)
                             pno = rupture.get_probability_no_exceedance(poes)
-                            expanded_pno = r_sites.expand(pno, placeholder=1)
+                            expanded_pno = sctx.sites.expand(pno, 1.0)
                             curves[i][str(imt)] *= expanded_pno
         except Exception as err:
             etype, err, tb = sys.exc_info()

--- a/openquake/hazardlib/gsim/base.py
+++ b/openquake/hazardlib/gsim/base.py
@@ -134,6 +134,10 @@ def get_distances(rupture, mesh, param='rjb'):
     return dist
 
 
+class FarAwayRupture(Exception):
+    """Raised if the rupture is outside the maximum distance for all sites"""
+
+
 class ContextMaker(object):
     """
     A class to manage the creation of contexts for distances, sites, rupture.
@@ -283,10 +287,12 @@ class ContextMaker(object):
         sites = site_collection
         if self.maximum_distance:
             mask = distances <= self.maximum_distance
-            r_sites = site_collection.filter(mask)
-            if r_sites is not None:
-                sites = r_sites
+            if mask.any():
+                sites = site_collection.filter(mask)
                 distances = distances[mask]
+            else:
+                raise FarAwayRupture
+
         sctx = self.make_sites_context(sites)
         dctx = self.make_distances_context(sites, rupture, {'rjb': distances})
         return (sctx, rctx, dctx)

--- a/openquake/hazardlib/tests/calc/hazard_curve_test.py
+++ b/openquake/hazardlib/tests/calc/hazard_curve_test.py
@@ -26,6 +26,12 @@ from openquake.hazardlib.calc.hazard_curve import calc_hazard_curves
 from openquake.hazardlib.gsim.base import ContextMaker
 
 
+class FakeSiteContext(object):
+    def __init__(self, sites):
+        self.sites = sites
+        self.mesh = sites.mesh
+
+
 class HazardCurvesTestCase(unittest.TestCase):
     class FakeRupture(object):
         def __init__(self, probability, tectonic_region_type):
@@ -71,7 +77,7 @@ class HazardCurvesTestCase(unittest.TestCase):
     def setUp(self):
         self.orig_make_contexts = ContextMaker.make_contexts
         ContextMaker.make_contexts = lambda self, sites, rupture: (
-            sites, rupture, None)
+            FakeSiteContext(sites), rupture, None)
         self.truncation_level = 3.4
         self.imts = {'PGA': [1, 2, 3], 'PGD': [2, 4]}
         self.time_span = 49.2

--- a/openquake/hazardlib/tests/gsim/base_test.py
+++ b/openquake/hazardlib/tests/gsim/base_test.py
@@ -426,6 +426,7 @@ class MakeContextsTestCase(_FakeGSIMTestCase):
             site_collection, rupture)
 
     def test_unknown_site_param_error(self):
+        raise unittest.SkipTest  # non-interesting test
         self.gsim_class.REQUIRES_SITES_PARAMETERS.add('unknown!')
         err = "ContextMaker requires unknown site parameter 'unknown!'"
         sites = SiteCollection([self.site1])
@@ -433,15 +434,17 @@ class MakeContextsTestCase(_FakeGSIMTestCase):
                                  site_collection=sites, rupture=self.rupture)
 
     def test_unknown_rupture_param_error(self):
+        raise unittest.SkipTest  # non-interesting test
         self.gsim_class.REQUIRES_RUPTURE_PARAMETERS.add('stuff')
         err = "ContextMaker requires unknown rupture parameter 'stuff'"
         sites = SiteCollection([self.site1])
+        self.make_contexts(sites, self.rupture)
         self._assert_value_error(self.make_contexts, err,
                                  site_collection=sites, rupture=self.rupture)
 
     def test_unknown_distance_error(self):
         self.gsim_class.REQUIRES_DISTANCES.add('jump height')
-        err = "ContextMaker requires unknown distance measure 'jump height'"
+        err = "Unknown distance measure 'jump height'"
         sites = SiteCollection([self.site1])
         self._assert_value_error(self.make_contexts, err,
                                  site_collection=sites, rupture=self.rupture)

--- a/openquake/hazardlib/tests/gsim/base_test.py
+++ b/openquake/hazardlib/tests/gsim/base_test.py
@@ -426,26 +426,23 @@ class MakeContextsTestCase(_FakeGSIMTestCase):
             site_collection, rupture)
 
     def test_unknown_site_param_error(self):
-        raise unittest.SkipTest  # non-interesting test
         self.gsim_class.REQUIRES_SITES_PARAMETERS.add('unknown!')
         err = "ContextMaker requires unknown site parameter 'unknown!'"
-        sites = SiteCollection([self.site1])
+        sites = SiteCollection([self.site1, self.site2])
         self._assert_value_error(self.make_contexts, err,
                                  site_collection=sites, rupture=self.rupture)
 
     def test_unknown_rupture_param_error(self):
-        raise unittest.SkipTest  # non-interesting test
         self.gsim_class.REQUIRES_RUPTURE_PARAMETERS.add('stuff')
         err = "ContextMaker requires unknown rupture parameter 'stuff'"
         sites = SiteCollection([self.site1])
-        self.make_contexts(sites, self.rupture)
         self._assert_value_error(self.make_contexts, err,
                                  site_collection=sites, rupture=self.rupture)
 
     def test_unknown_distance_error(self):
         self.gsim_class.REQUIRES_DISTANCES.add('jump height')
         err = "Unknown distance measure 'jump height'"
-        sites = SiteCollection([self.site1])
+        sites = SiteCollection([self.site1, self.site2])
         self._assert_value_error(self.make_contexts, err,
                                  site_collection=sites, rupture=self.rupture)
 


### PR DESCRIPTION
The goal is to compute the distances only once.