### PR TITLE
Better monitoring

### DIFF
--- a/openquake/baselib/performance.py
+++ b/openquake/baselib/performance.py
@@ -204,9 +204,8 @@ class DummyMonitor(PerformanceMonitor):
     def __init__(self, operation='dummy', *args, **kw):
         self.operation = operation
         self.hdf5path = None
-
-    def __call__(self, operation, **kw):
-        return self.__class__(operation)
+        self.children = []
+        self.counts = 0
 
     def __enter__(self):
         return self

--- a/openquake/baselib/tests/performance_test.py
+++ b/openquake/baselib/tests/performance_test.py
@@ -1,6 +1,7 @@
 import time
 import unittest
 import pickle
+import numpy
 from openquake.baselib.performance import PerformanceMonitor
 
 
@@ -38,7 +39,8 @@ class MonitorTestCase(unittest.TestCase):
         with mon2:  # called twice on purpose
             time.sleep(0.1)
 
-        data = self.mon.get_data()
+        data = numpy.concatenate([mon.get_data() for mon in self.mon.children])
+        self.assertEqual(list(data['counts']), [1, 2])
         total_time = data['time_sec'].sum()
         self.assertGreaterEqual(total_time, 0.3)
         self.mon.flush()


### PR DESCRIPTION
I am improving the PerformanceMonitor in two ways:

1. I haved added a method .new which allows to instantiate a copy of a monitor which is not its child
2. the .flush method now works recursively on all children.

Feature 1) is needed when you want a decoupled monitor, to be flushed manually; feature 2) is needed in the opposite case, when one wants to make sure that all of the children are automagically flushed.