### PR TITLE
Fixed the SiteCollection equality check

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,7 @@
+  [Michele Simionato]
+  * Fixed the equality check for SiteCollections: now all of the parameters
+    are compared, not only lons and lats.
+
 python-oq-hazardlib (0.17.0-0~precise01) precise; urgency=low
 
   [Michele Simionato]
@@ -19,7 +23,7 @@ python-oq-hazardlib (0.16.0-0~precise01) precise; urgency=low
   [Matteo Nastasi]
   * Imposed version for python-h5py dependency, Ubuntu 12.04 will use
     backported version from GEM repository
-  
+
   [Graeme Weatherill]
   * Adds Montalva et al. (2015) GMPE
 

--- a/openquake/hazardlib/site.py
+++ b/openquake/hazardlib/site.py
@@ -101,13 +101,7 @@ Backarc=False>'
         return self.__str__()
 
 
-def eq(array1, array2):
-    """
-    Compare two numpy arrays for equality and return a boolean
-    """
-    return array1.shape == array2.shape and (array1 == array2).all()
-
-
+@with_slots
 class SiteCollection(object):
     """
     A collection of :class:`sites <Site>`.
@@ -127,6 +121,9 @@ class SiteCollection(object):
     :param sites:
         A list of instances of :class:`Site` class.
     """
+    _slots_ = (
+        'sids lons lats _vs30 _vs30measured _z1pt0 _z2pt5 _backarc'.split())
+
     @classmethod
     def from_points(cls, lons, lats, site_ids, sitemodel):
         """
@@ -263,12 +260,6 @@ class SiteCollection(object):
         Return the number of sites in the collection.
         """
         return self.total_sites
-
-    def __eq__(self, other):
-        return eq(self.lons, other.lons) and eq(self.lats, other.lats)
-
-    def __ne__(self, other):
-        return not self.__eq__(other)
 
     def __repr__(self):
         return '<SiteCollection with %d sites>' % self.total_sites


### PR DESCRIPTION
This was the source of the issue https://github.com/gem/oq-risklib/issues/596
The risk site collection was considered equal to the hazard one even it was not, since the differences in the site model parameters were ignored, and then the risk site collection was incorrectly used instead of the hazard one.