### PR TITLE
Added .weight and .num_ruptures to sources

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,5 @@
   [Michele Simionato]
+  * Added a .weight property to sources, as well as a .num_ruptures attribute
   * The GMPETable now understands paths relative to a directory GMPE_DIR
 
   [Graeme Weatherill]

--- a/openquake/hazardlib/source/area.py
+++ b/openquake/hazardlib/source/area.py
@@ -43,6 +43,8 @@ class AreaSource(PointSource):
 
     MODIFICATIONS = set(())
 
+    POINT_SOURCE_WEIGHT = 1 / 40.
+
     def __init__(self, source_id, name, tectonic_region_type,
                  mfd, rupture_mesh_spacing,
                  magnitude_scaling_relationship, rupture_aspect_ratio,

--- a/openquake/hazardlib/source/area.py
+++ b/openquake/hazardlib/source/area.py
@@ -43,7 +43,7 @@ class AreaSource(PointSource):
 
     MODIFICATIONS = set(())
 
-    POINT_SOURCE_WEIGHT = 1 / 40.
+    RUPTURE_WEIGHT = 1 / 40.
 
     def __init__(self, source_id, name, tectonic_region_type,
                  mfd, rupture_mesh_spacing,

--- a/openquake/hazardlib/source/base.py
+++ b/openquake/hazardlib/source/base.py
@@ -38,16 +38,22 @@ class BaseSeismicSource(with_metaclass(abc.ABCMeta)):
     """
 
     _slots_ = ['source_id', 'name', 'tectonic_region_type',
-                 'trt_model_id', 'weight', 'seed', 'id']
+               'trt_model_id', 'num_ruptures', 'seed', 'id']
 
     MODIFICATIONS = abc.abstractproperty()
+
+    POINT_SOURCE_WEIGHT = 1.  # overridden in PointSource and AreaSource
+
+    @property
+    def weight(self):
+        return self.num_ruptures * self.POINT_SOURCE_WEIGHT
 
     def __init__(self, source_id, name, tectonic_region_type):
         self.source_id = source_id
         self.name = name
         self.tectonic_region_type = tectonic_region_type
         self.trt_model_id = None  # set by the engine
-        self.weight = 1  # set by the engine
+        self.num_ruptures = 0  # set by the engine
         self.seed = None  # set by the engine
         self.id = None  # set by the engine
 

--- a/openquake/hazardlib/source/base.py
+++ b/openquake/hazardlib/source/base.py
@@ -1,5 +1,5 @@
 # The Hazard Library
-# Copyright (C) 2012-2014, GEM Foundation
+# Copyright (C) 2012-2016, GEM Foundation
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as
@@ -42,11 +42,15 @@ class BaseSeismicSource(with_metaclass(abc.ABCMeta)):
 
     MODIFICATIONS = abc.abstractproperty()
 
-    POINT_SOURCE_WEIGHT = 1.  # overridden in PointSource and AreaSource
+    RUPTURE_WEIGHT = 1.  # overridden in PointSource and AreaSource
 
     @property
     def weight(self):
-        return self.num_ruptures * self.POINT_SOURCE_WEIGHT
+        """
+        Determine the source weight from the number of ruptures, by
+        multiplying with the scale factor RUPTURE_WEIGHT
+        """
+        return self.num_ruptures * self.RUPTURE_WEIGHT
 
     def __init__(self, source_id, name, tectonic_region_type):
         self.source_id = source_id

--- a/openquake/hazardlib/source/point.py
+++ b/openquake/hazardlib/source/point.py
@@ -65,6 +65,8 @@ class PointSource(ParametricSeismicSource):
 
     MODIFICATIONS = set(())
 
+    POINT_SOURCE_WEIGHT = 1 / 40.
+
     def __init__(self, source_id, name, tectonic_region_type,
                  mfd, rupture_mesh_spacing,
                  magnitude_scaling_relationship, rupture_aspect_ratio,
@@ -182,8 +184,8 @@ class PointSource(ParametricSeismicSource):
                     hypocenter = Point(latitude=location.latitude,
                                        longitude=location.longitude,
                                        depth=hc_depth)
-                    occurrence_rate = (mag_occ_rate
-                                       * float(np_prob) * float(hc_prob))
+                    occurrence_rate = (
+                        mag_occ_rate * float(np_prob) * float(hc_prob))
                     occurrence_rate *= rate_scaling_factor
                     surface = self._get_rupture_surface(mag, np, hypocenter)
                     yield ParametricProbabilisticRupture(

--- a/openquake/hazardlib/source/point.py
+++ b/openquake/hazardlib/source/point.py
@@ -65,7 +65,7 @@ class PointSource(ParametricSeismicSource):
 
     MODIFICATIONS = set(())
 
-    POINT_SOURCE_WEIGHT = 1 / 40.
+    RUPTURE_WEIGHT = 1 / 40.
 
     def __init__(self, source_id, name, tectonic_region_type,
                  mfd, rupture_mesh_spacing,


### PR DESCRIPTION
This is fairly minor. It looks better to move the management of the weight from oq-risklib to oq-hazardlib.