### PR TITLE
Made the GSIM.DEFINED_* class variables into instance variables

### DIFF
--- a/openquake/hazardlib/gsim/gsim_table.py
+++ b/openquake/hazardlib/gsim/gsim_table.py
@@ -385,8 +385,13 @@ class GMPETable(GMPE):
         self.amplification = AmplificationTable(fle["Amplification"],
                                                 self.m_w,
                                                 self.distances)
-        if self.amplification.element in ("Sites", "Rupture"):
+        if self.amplification.element == "Sites":
             self.REQUIRES_SITES_PARAMETERS = set(
+                [self.amplification.parameter])
+        elif self.amplification.element == "Rupture":
+            # Re-set the site parameters
+            self.REQUIRES_SITES_PARAMETERS = set()
+            self.REQUIRES_RUPTURE_PARAMETERS = set(
                 [self.amplification.parameter])
 
     def _supported_imts(self):

--- a/openquake/hazardlib/gsim/gsim_table.py
+++ b/openquake/hazardlib/gsim/gsim_table.py
@@ -391,8 +391,8 @@ class GMPETable(GMPE):
         elif self.amplification.element == "Rupture":
             # Re-set the site parameters
             self.REQUIRES_SITES_PARAMETERS = set()
-            self.REQUIRES_RUPTURE_PARAMETERS = set(
-                [self.amplification.parameter])
+            self.REQUIRES_RUPTURE_PARAMETERS.add(
+                self.amplification.parameter)
 
     def _supported_imts(self):
         """

--- a/openquake/hazardlib/tests/gsim/gsim_table_test.py
+++ b/openquake/hazardlib/tests/gsim/gsim_table_test.py
@@ -627,7 +627,7 @@ class GSIMTableTestCaseRupture(unittest.TestCase):
                             expected_rupture_set)
         self.assertEqual(gsim.amplification.parameter, "rake")
         self.assertEqual(gsim.amplification.element, "Rupture")
-        self.assertSetEqual(gsim.REQUIRES_SITES_PARAMETERS, set(()))
+        self.assertSetEqual(gsim.REQUIRES_SITES_PARAMETERS, set())
 
     def test_get_mean_and_stddevs_good(self):
         """

--- a/openquake/hazardlib/tests/gsim/utils.py
+++ b/openquake/hazardlib/tests/gsim/utils.py
@@ -27,32 +27,28 @@ class BaseGSIMTestCase(unittest.TestCase):
     GSIM_CLASS = None
 
     def get_context_attributes(self, ctx):
-        att = inspect.getmembers(ctx, lambda a: not(inspect.isroutine(a)))
+        att = inspect.getmembers(ctx, lambda a: not inspect.isroutine(a))
         att = [
             k for k, v in att if not ('_abc' in k)
             and not ((k.startswith('_') and k.endswith('_')))
         ]
-
         return set(att)
 
     def check(self, filename, max_discrep_percentage):
-        assert self.GSIM_CLASS is not None
+        gsim = self.GSIM_CLASS()
         filename = os.path.join(self.BASE_DATA_PATH, filename)
         errors, stats, sctx, rctx, dctx, ctxs = check_gsim(
-            self.GSIM_CLASS, open(filename),
-            max_discrep_percentage
-        )
+            gsim.__class__, open(filename), max_discrep_percentage)
         s_att = self.get_context_attributes(sctx)
         r_att = self.get_context_attributes(rctx)
         d_att = self.get_context_attributes(dctx)
-        self.assertEqual(self.GSIM_CLASS.REQUIRES_SITES_PARAMETERS, s_att)
-        self.assertEqual(self.GSIM_CLASS.REQUIRES_RUPTURE_PARAMETERS, r_att)
-        self.assertEqual(self.GSIM_CLASS.REQUIRES_DISTANCES, d_att)
+        self.assertEqual(gsim.REQUIRES_SITES_PARAMETERS, s_att)
+        self.assertEqual(gsim.REQUIRES_RUPTURE_PARAMETERS, r_att)
+        self.assertEqual(gsim.REQUIRES_DISTANCES, d_att)
         self.assertTrue(
             numpy.all(ctxs),
-            msg='Contexts objects have been changed by method '\
-                'get_mean_and_stddevs'
-        )
+            msg='Contexts objects have been changed by method '
+                'get_mean_and_stddevs')
         if errors:
             raise AssertionError(stats)
         print()


### PR DESCRIPTION
This avoids strange interferences between tests: now not only the case_18 tests in isolation, but it also runs when executed together with other tests. This is required for https://github.com/gem/oq-risklib/pull/617/