### PR TITLE
Reduced the GMFs to 32 bits

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,6 @@
+  [Michele Simionato]
+  * Using 32 bit floats for the GMFs, instead of 64, to save memory
+
 python-oq-hazardlib (0.18.0-0~precise01) precise; urgency=low
 
   [Daniele Viganò, Matteo Nastasi]

--- a/openquake/hazardlib/gsim/base.py
+++ b/openquake/hazardlib/gsim/base.py
@@ -59,7 +59,7 @@ def gsim_imt_dt(sorted_gsims, sorted_imts):
     :param sorted_gsims: a list of GSIM instances, sorted lexicographically
     :param sorted_imts: a list of intensity measure type strings
     """
-    imt_dt = numpy.dtype([(imt, float) for imt in sorted_imts])
+    imt_dt = numpy.dtype([(imt, numpy.float32) for imt in sorted_imts])
     gsim_imt_dt = numpy.dtype(
         [('idx', numpy.uint32)] +
         [(str(gsim), imt_dt) for gsim in sorted_gsims])


### PR DESCRIPTION
This should save a significant amount of memory especially for the event based risk.
This is the companion of https://github.com/gem/oq-risklib/pull/698 and MUST be merged together.