### PR TITLE
Simplified the output of the GmfComputer

### DIFF
--- a/openquake/hazardlib/calc/gmf.py
+++ b/openquake/hazardlib/calc/gmf.py
@@ -190,6 +190,23 @@ class GmfComputer(object):
                         gmfa[i, j][gs][imt] = gmv
         return gmfa
 
+    def calcgmfs(self, multiplicity, seed):
+        """
+        Compute the ground motion field for the given sites and seeds.
+
+        :param multiplicity:
+            the number of GMFs to return
+        :param seed:
+            seed for the numpy random number generator
+        :returns:
+            a numpy array of dtype gmf_dt and shape (multiplicity, num_sites)
+        """
+        gmfa = numpy.zeros((multiplicity, len(self.sites)), self.gmf_dt)
+        for gsim in self.gsims:
+            for imt, gmv in self._compute(seed, gsim, multiplicity).items():
+                gmfa[str(gsim)][imt] = gmv.T  # from N x M -> M x N
+        return gmfa
+
 
 # this is not used in the engine; it is still useful for usage in IPython
 # when demonstrating hazardlib capabilities

--- a/openquake/hazardlib/calc/gmf.py
+++ b/openquake/hazardlib/calc/gmf.py
@@ -190,21 +190,21 @@ class GmfComputer(object):
                         gmfa[i, j][gs][imt] = gmv
         return gmfa
 
-    def calcgmfs(self, multiplicity, seed):
+    def calcgmfs(self, multiplicity, seeds):
         """
         Compute the ground motion field for the given sites and seeds.
 
         :param multiplicity:
             the number of GMFs to return
-        :param seed:
-            seed for the numpy random number generator
+        :param seeds:
+            seeds for the numpy random number generator, one per GSIM
         :returns:
             a numpy array of dtype gmf_dt and shape (multiplicity, num_sites)
         """
         gmfa = numpy.zeros((multiplicity, len(self.sites)), self.gmf_dt)
-        for gsim in self.gsims:
+        for seed, gsim in zip(seeds, self.gsims):
             for imt, gmv in self._compute(seed, gsim, multiplicity).items():
-                gmfa[str(gsim)][imt] = gmv.T  # from N x M -> M x N
+                gmfa[str(gsim)][imt] = gmv.T
         return gmfa
 
 

--- a/openquake/hazardlib/calc/gmf.py
+++ b/openquake/hazardlib/calc/gmf.py
@@ -172,12 +172,10 @@ class GmfComputer(object):
         :param seeds:
             S seeds for the numpy random number generator
         :returns:
-            a list of numpy arrays of dtype gmf_dt and length num_sites
+            a numpy array of dtype gmf_dt and shape (num_seeds, num_sites)
         """
-        n = len(self.sites)
-        gmfs = []
-        for seed in seeds:
-            gmfa = numpy.zeros(n, self.gmf_dt)
+        gmfa = numpy.zeros((len(seeds), len(self.sites)), self.gmf_dt)
+        for i, seed in enumerate(seeds):
             for gsim in self.gsims:
                 gs = str(gsim)
                 for imt, value in self._compute(
@@ -188,10 +186,9 @@ class GmfComputer(object):
                     # not an array, flatten does not work and the only
                     # way to extract the numbers is the map before!
                     # something is wrong and must be fixed in the future
-                    for i, gmv in enumerate(array):
-                        gmfa[i][gs][imt] = gmv
-            gmfs.append(gmfa)
-        return gmfs
+                    for j, gmv in enumerate(array):
+                        gmfa[i, j][gs][imt] = gmv
+        return gmfa
 
 
 # this is not used in the engine; it is still useful for usage in IPython

--- a/openquake/hazardlib/calc/gmf.py
+++ b/openquake/hazardlib/calc/gmf.py
@@ -175,7 +175,6 @@ class GmfComputer(object):
             a list of numpy arrays of dtype gmf_dt and length num_sites
         """
         n = len(self.sites)
-        indices = self.sites.indices
         gmfs = []
         for seed in seeds:
             gmfa = numpy.zeros(n, self.gmf_dt)
@@ -190,7 +189,6 @@ class GmfComputer(object):
                     # way to extract the numbers is the map before!
                     # something is wrong and must be fixed in the future
                     for i, gmv in enumerate(array):
-                        gmfa[i]['idx'] = indices[i]
                         gmfa[i][gs][imt] = gmv
             gmfs.append(gmfa)
         return gmfs

--- a/openquake/hazardlib/geo/mesh.py
+++ b/openquake/hazardlib/geo/mesh.py
@@ -128,6 +128,8 @@ class Mesh(object):
             A new object of the same type that borrows a portion of geometry
             from this mesh (doesn't copy the array, just references it).
         """
+        if isinstance(item, int):
+            raise ValueError('You must pass a slice, not an index: %s' % item)
         lons = self.lons[item]
         lats = self.lats[item]
         depths = None
@@ -388,7 +390,7 @@ class RectangularMesh(Mesh):
             objects.
         """
         assert points is not None and len(points) > 0 and len(points[0]) > 0, \
-               'list of at least one non-empty list of points is required'
+            'list of at least one non-empty list of points is required'
         lons = numpy.zeros((len(points), len(points[0])), dtype=float)
         lats = lons.copy()
         depths = lons.copy()

--- a/openquake/hazardlib/geo/mesh.py
+++ b/openquake/hazardlib/geo/mesh.py
@@ -128,11 +128,6 @@ class Mesh(object):
             A new object of the same type that borrows a portion of geometry
             from this mesh (doesn't copy the array, just references it).
         """
-        assert (isinstance(item, slice) or
-                (isinstance(item, (list, tuple)) and
-                 all(isinstance(subitem, slice) for subitem in item))
-                ), '%s objects can only be indexed by slices' % \
-            type(self).__name__
         lons = self.lons[item]
         lats = self.lats[item]
         depths = None

--- a/openquake/hazardlib/gsim/base.py
+++ b/openquake/hazardlib/gsim/base.py
@@ -60,10 +60,7 @@ def gsim_imt_dt(sorted_gsims, sorted_imts):
     :param sorted_imts: a list of intensity measure type strings
     """
     imt_dt = numpy.dtype([(imt, numpy.float32) for imt in sorted_imts])
-    gsim_imt_dt = numpy.dtype(
-        [('idx', numpy.uint32)] +
-        [(str(gsim), imt_dt) for gsim in sorted_gsims])
-    return gsim_imt_dt
+    return numpy.dtype([(str(gsim), imt_dt) for gsim in sorted_gsims])
 
 
 class MetaGSIM(abc.ABCMeta):

--- a/openquake/hazardlib/tests/geo/mesh_test.py
+++ b/openquake/hazardlib/tests/geo/mesh_test.py
@@ -157,13 +157,13 @@ class MeshSlicingTestCase(_BaseMeshTestCase):
     def test_wrong_indexing(self):
         coords = numpy.arange(16)
         mesh = self._make_mesh(coords, coords, coords)
-        with self.assertRaises(AssertionError):
+        with self.assertRaises(ValueError):
             mesh[1]
         coords = coords.reshape((4, 4))
         mesh = self._make_mesh(coords, coords, coords)
-        with self.assertRaises(AssertionError):
+        with self.assertRaises(ValueError):
             mesh[1]
-        with self.assertRaises(AssertionError):
+        with self.assertRaises(IndexError):
             mesh[1:, 5]
 
     def test_preserving_the_type(self):


### PR DESCRIPTION
By removing the `idx` field from the composite array. I am also relaxing the check on `Mesh.__getitem__`. All that is needed for https://github.com/gem/oq-risklib/issues/743. This PR must be merged together with https://github.com/gem/oq-risklib/pull/744.