### PR TITLE
Serialize a bunch of simple parameters in an HDF5 table

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,5 @@
   [Michele Simionato]
+  * Added a LiteralAttrs class to serialize literal attributes on HDF5
   * Added to the Monitor the ability to send commands
 
 python-oq-hazardlib (0.19.0-0~precise01) precise; urgency=low

--- a/openquake/baselib/hdf5.py
+++ b/openquake/baselib/hdf5.py
@@ -97,7 +97,7 @@ class LiteralAttrs(object):
     >>> s.b['x']
     'xxx'
 
-    The implentation is not recursive, i.e. there will be at most
+    The implementation is not recursive, i.e. there will be at most
     one dot in the serialized names (in the example here `a`, `b.x`, `b.y`).
     """
     KEYLEN = 50


### PR DESCRIPTION
This PR will be used later in oq-risklib to serialize the parameters of the job.ini file which currently as saved as attributes of the root of the HDF5 file. Using a table is a lot more readable.