### PR TITLE
Added a h5py.File subclass to manage the serialization of objects

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,6 @@
   [Michele Simionato]
+  * Added a h5py.File subclass to manage the serialization of objects
+    satisfying the HDF5 protocol used by the OpenQuake software
   * Added a LiteralAttrs class to serialize literal attributes on HDF5
   * Added to the Monitor the ability to send commands
 

--- a/openquake/baselib/hdf5.py
+++ b/openquake/baselib/hdf5.py
@@ -152,8 +152,8 @@ class LiteralAttrs(object):
 class File(h5py.File):
     """
     Subclass of :class:`h5py.File` able to store and retrieve objects
-    conform to the HDF5 protocol used by the OpenQuake software.
-    It works recursively also for dictionaries name->obj.
+    conforming to the HDF5 protocol used by the OpenQuake software.
+    It works recursively also for dictionaries of the form name->obj.
 
     >>> f = File('/tmp/x.h5', 'w')
     >>> f['dic'] = dict(a=dict(x=1, y=2), b=3)

--- a/openquake/baselib/hdf5.py
+++ b/openquake/baselib/hdf5.py
@@ -189,6 +189,9 @@ class File(h5py.File):
         if '__pyclass__' in h5attrs:
             cls = pydoc.locate(h5attrs.pop('__pyclass__'))
             obj = cls.__new__(cls)
+            if not hasattr(h5obj, 'shape'):  # is group
+                h5obj = {k: self['%s/%s' % (path, k)]
+                         for k, v in h5obj.items()}
             obj.__fromh5__(h5obj, h5attrs)
             return obj
         else:

--- a/openquake/baselib/hdf5.py
+++ b/openquake/baselib/hdf5.py
@@ -187,7 +187,7 @@ class File(h5py.File):
         h5obj = super(File, self).__getitem__(path)
         h5attrs = h5obj.attrs
         if '__pyclass__' in h5attrs:
-            cls = pydoc.locate(h5attrs.pop('__pyclass__'))
+            cls = pydoc.locate(h5attrs['__pyclass__'])
             obj = cls.__new__(cls)
             if not hasattr(h5obj, 'shape'):  # is group
                 h5obj = {k: self['%s/%s' % (path, k)]

--- a/openquake/hazardlib/tests/site_test.py
+++ b/openquake/hazardlib/tests/site_test.py
@@ -108,11 +108,9 @@ class SiteCollectionCreationTestCase(unittest.TestCase):
         fd, fpath = tempfile.mkstemp(suffix='.hdf5')
         os.close(fd)
         with hdf5.File(fpath, 'w') as f:
-            f['sitecol'] = cll
-            f['folder'] = dict(a=1, b=[2, 3])
-            newcll = f['sitecol']
+            f['folder'] = dict(sitecol=cll, b=[2, 3])
+            newcll = f['folder/sitecol']
             self.assertEqual(newcll, cll)
-            self.assertEqual(f['folder/a'].value, 1)
             self.assertEqual(list(f['folder/b']), [2, 3])
         os.remove(fpath)
 

--- a/openquake/hazardlib/tests/site_test.py
+++ b/openquake/hazardlib/tests/site_test.py
@@ -13,11 +13,14 @@
 #
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
+import os
 import pickle
 import unittest
+import tempfile
 
 import numpy
 
+from openquake.baselib import hdf5
 from openquake.hazardlib.site import \
     Site, SiteCollection, FilteredSiteCollection
 from openquake.hazardlib.geo.point import Point
@@ -101,11 +104,17 @@ class SiteCollectionCreationTestCase(unittest.TestCase):
             self.assertEqual(arr.dtype, bool)
         self.assertEqual(len(cll), 2)
 
-        # test __toh5__ and __fromh5__
-        array, attrs = cll.__toh5__()
-        newcll = cll.__new__(cll.__class__)
-        newcll.__fromh5__(array, attrs)
-        self.assertEqual(newcll, cll)
+        # test serialization to hdf5
+        fd, fpath = tempfile.mkstemp(suffix='.hdf5')
+        os.close(fd)
+        with hdf5.File(fpath, 'w') as f:
+            f['sitecol'] = cll
+            f['folder'] = dict(a=1, b=[2, 3])
+            newcll = f['sitecol']
+            self.assertEqual(newcll, cll)
+            self.assertEqual(f['folder/a'].value, 1)
+            self.assertEqual(list(f['folder/b']), [2, 3])
+        os.remove(fpath)
 
     def test_from_points(self):
         lons = [10, -1.2]


### PR DESCRIPTION
This allows some simplification in the datastore that will be implemented in a second pull request.
