### PR TITLE
Showing the `calc_id` in Monitor instances string representation

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,5 @@
   [Michele Simionato]
+  * Showing the `calc_id` in Monitor instances string representation
   * Added a LiteralAttrs class to serialize literal attributes on HDF5
   * Added to the Monitor the ability to send commands
 

--- a/openquake/baselib/performance.py
+++ b/openquake/baselib/performance.py
@@ -216,9 +216,12 @@ class Monitor(object):
         return new
 
     def __repr__(self):
+        calc_id = ' #%s ' % self.calc_id if self.calc_id else ' '
+        msg = '%s%s%s' % (self.__class__.__name__, calc_id, self.operation)
         if self.measuremem:
-            return '<%s %s, duration=%ss, memory=%s>' % (
-                self.__class__.__name__, self.operation, self.duration,
-                humansize(self.mem))
-        return '<%s %s, duration=%ss>' % (self.__class__.__name__,
-                                          self.operation, self.duration)
+            return '<%s, duration=%ss, memory=%s>' % (
+                msg, self.duration, humansize(self.mem))
+        elif self.duration:
+            return '<%s, duration=%ss>' % (msg, self.duration)
+        else:
+            return '<%s>' % msg


### PR DESCRIPTION
Just for clarity.