### PR TITLE
Improved the validity check on the Intensity Measure Type

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,5 @@
   [Michele Simionato]
+  * Improved the validity check on the Intensity Measure Type
   * Showing the `calc_id` in Monitor instances string representation
   * Added a h5py.File subclass to manage the serialization of objects
     satisfying the HDF5 protocol used by the OpenQuake software

--- a/openquake/hazardlib/imt.py
+++ b/openquake/hazardlib/imt.py
@@ -40,7 +40,7 @@ def from_string(imt):
     :param str imt:
         Intensity Measure Type.
     """
-    if 'SA' in imt:
+    if imt.startswith('SA'):
         match = re.match(r'^SA\(([^)]+?)\)$', imt)
         period = float(match.group(1))
         return SA(period, DEFAULT_SA_DAMPING)


### PR DESCRIPTION
Catalina had a vulnerability function ' SA(1.0)', with an initial space, and was getting the error

```python
  File "/home/michele/oqcode/oq-risklib/openquake/calculators/base.py", line 428, in read_risk_data
    self.load_riskmodel()  # must be called *after* read_exposure
  File "/home/michele/oqcode/oq-risklib/openquake/calculators/base.py", line 385, in load_riskmodel
    self.oqparam.set_risk_imtls(rmdict)
  File "/home/michele/oqcode/oq-risklib/openquake/commonlib/oqvalidation.py", line 243, in set_risk_imtls
    from_string(imt)  # make sure it is a valid IMT
  File "/home/michele/oq-hazardlib/openquake/hazardlib/imt.py", line 45, in from_string
    period = float(match.group(1))
AttributeError: 'NoneType' object has no attribute 'group'
```

With this pull request the error become clear:

```python
ValueError: Unknown IMT: ' SA(1.0)'
```