### PR TITLE
Saved LiteralAttrs as variable length byte strings

### DIFF
--- a/openquake/baselib/hdf5.py
+++ b/openquake/baselib/hdf5.py
@@ -85,10 +85,11 @@ def extend(dset, array):
 
 class LiteralAttrs(object):
     """
-    A class to serialize attributes to HDF5. The goal is to store simple
-    parameters as an HDF5 table in a readable way. The implementation treats
-    specially dictionary attributes, by storing them as `attrname.keyname`
-    byte arrays, see the example below:
+    A class to serialize a set of parameters to HDF5. The goal is to
+    store simple parameters as an HDF5 table in a readable way. Each
+    parameter can be retrieved as an attribute, given its name. The
+    implementation treats specially dictionary attributes, by storing
+    them as `attrname.keyname` strings, see the example below:
 
     >>> class Ser(LiteralAttrs):
     ...     def __init__(self, a, b):
@@ -110,9 +111,10 @@ class LiteralAttrs(object):
 
     The implementation is not recursive, i.e. there will be at most
     one dot in the serialized names (in the example here `a`, `b.x`, `b.y`).
+
     """
     def __toh5__(self):
-        info_dt = numpy.dtype([('key', vbytes), ('value', vbytes)])
+        info_dt = numpy.dtype([('par_name', vbytes), ('par_value', vbytes)])
         attrnames = sorted(a for a in vars(self) if not a.startswith('_'))
         lst = []
         for attr in attrnames:

--- a/openquake/baselib/hdf5.py
+++ b/openquake/baselib/hdf5.py
@@ -113,7 +113,7 @@ class LiteralAttrs(object):
     one dot in the serialized names (in the example here `a`, `b.x`, `b.y`).
     """
     KEYLEN = 50
-    VALUELEN = 200
+    VALUELEN = 1000
 
     def _check_len(self, key, value):
         """

--- a/openquake/baselib/hdf5.py
+++ b/openquake/baselib/hdf5.py
@@ -97,7 +97,7 @@ class LiteralAttrs(object):
     >>> ser = Ser(1, dict(x='xxx', y='yyy'))
     >>> arr, attrs = ser.__toh5__()
     >>> for k, v in arr:
-    ...     print('%s=%s' % (k.decode('utf8'), v.decode('utf8')))
+    ...     print('%s=%s' % (k, v))
     a=1
     b.x='xxx'
     b.y='yyy'
@@ -128,12 +128,14 @@ class LiteralAttrs(object):
     def __fromh5__(self, array, attrs):
         dd = collections.defaultdict(dict)
         for (name, literal) in array:
-            name = name.decode('utf8')
+            if isinstance(literal, numpy.object_):
+                # needed for Python3 compatibility
+                literal = repr(literal)
             if '.' in name:
                 k1, k2 = name.split('.', 1)
-                dd[k1][k2] = ast.literal_eval(literal.decode('utf8'))
+                dd[k1][k2] = ast.literal_eval(literal)
             else:
-                dd[name] = ast.literal_eval(literal.decode('utf8'))
+                dd[name] = ast.literal_eval(literal)
         vars(self).update(dd)
 
 

--- a/openquake/hazardlib/gsim/base.py
+++ b/openquake/hazardlib/gsim/base.py
@@ -59,7 +59,8 @@ def gsim_imt_dt(sorted_gsims, sorted_imts):
     :param sorted_gsims: a list of GSIM instances, sorted lexicographically
     :param sorted_imts: a list of intensity measure type strings
     """
-    imt_dt = numpy.dtype([(bytes(imt), numpy.float32) for imt in sorted_imts])
+    dtlist = [(imt, numpy.float32) for imt in sorted_imts]
+    imt_dt = numpy.dtype(dtlist)
     return numpy.dtype([(str(gsim), imt_dt) for gsim in sorted_gsims])
 
 

--- a/openquake/hazardlib/gsim/base.py
+++ b/openquake/hazardlib/gsim/base.py
@@ -59,7 +59,7 @@ def gsim_imt_dt(sorted_gsims, sorted_imts):
     :param sorted_gsims: a list of GSIM instances, sorted lexicographically
     :param sorted_imts: a list of intensity measure type strings
     """
-    imt_dt = numpy.dtype([(imt, numpy.float32) for imt in sorted_imts])
+    imt_dt = numpy.dtype([(bytes(imt), numpy.float32) for imt in sorted_imts])
     return numpy.dtype([(str(gsim), imt_dt) for gsim in sorted_gsims])
 
 


### PR DESCRIPTION
This should have been done from the beginning, but I was under the misconception that the `h5py.special_dtype(vlen=bytes)` was not understood by numpy. Instead, it is a perfectly valid dtype so there is no reason not to use it.
The tests are green: https://ci.openquake.org/job/zdevel_oq-hazardlib/517/