### PR TITLE
Added a class PickleableSequence

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,6 @@
+  [Michele Simionato]
+  * Added a PickleableSequence class to serialize Python objects on HDF5
+
   [Graeme Weatherill]
   * Fixes Z1.0 units bug in Abrahamson, Silva and Kamai (2014)
 

--- a/openquake/baselib/hdf5.py
+++ b/openquake/baselib/hdf5.py
@@ -140,17 +140,25 @@ class LiteralAttrs(object):
                 dd[name] = ast.literal_eval(literal)
         vars(self).update(dd)
 
+    def __repr__(self):
+        names = sorted(n for n in vars(self) if not n.startswith('_'))
+        nameval = ', '.join('%s=%r' % (n, getattr(self, n)) for n in names)
+        return '<%s %s>' % (self.__class__.__name__, nameval)
+
 
 class PickleableSequence(collections.Sequence):
     """
     An immutable sequence of pickleable objects that can be serialized
-    into HDF5 format as an array of variable-length bytes.
+    into HDF5 format as an array of variable-length bytes. Here is an
+    example, using the LiteralAttrs class defined in this module, but
+    any class would do:
 
+    >>> seq = PickleableSequence([LiteralAttrs(), LiteralAttrs()])
     >>> with File('/tmp/x.h5', 'w') as f:
-    ...     f['data'] = PickleableSequence([dict, list])
+    ...     f['data'] = seq
     >>> with File('/tmp/x.h5') as f:
     ...     f['data']
-    (<type 'dict'>, <type 'list'>)
+    (<LiteralAttrs >, <LiteralAttrs >)
     """
     def __init__(self, objects):
         self._objects = tuple(objects)

--- a/openquake/baselib/hdf5.py
+++ b/openquake/baselib/hdf5.py
@@ -85,7 +85,7 @@ def extend(dset, array):
 
 class LiteralAttrs(object):
     """
-    A class to serialize a set of parameters to HDF5. The goal is to
+    A class to serialize a set of parameters in HDF5 format. The goal is to
     store simple parameters as an HDF5 table in a readable way. Each
     parameter can be retrieved as an attribute, given its name. The
     implementation treats specially dictionary attributes, by storing
@@ -149,9 +149,8 @@ class LiteralAttrs(object):
 class PickleableSequence(collections.Sequence):
     """
     An immutable sequence of pickleable objects that can be serialized
-    into HDF5 format as an array of variable-length bytes. Here is an
-    example, using the LiteralAttrs class defined in this module, but
-    any class would do:
+    in HDF5 format. Here is an example, using the LiteralAttrs class defined
+    in this module, but any pickleable class would do:
 
     >>> seq = PickleableSequence([LiteralAttrs(), LiteralAttrs()])
     >>> with File('/tmp/x.h5', 'w') as f:

--- a/openquake/baselib/hdf5.py
+++ b/openquake/baselib/hdf5.py
@@ -146,6 +146,11 @@ class LiteralAttrs(object):
         return '<%s %s>' % (self.__class__.__name__, nameval)
 
 
+# the implementation below stores a dataset per each object; it would be nicer
+# to store an array, however I am not able to do that with the current version
+# of h5py; the best I could do is to store an array of variable length ASCII
+# strings, but then I would have to use the ASCII format of pickle, which is
+# the least efficient. The current solution looks like a decent compromise.
 class PickleableSequence(collections.Sequence):
     """
     An immutable sequence of pickleable objects that can be serialized

--- a/openquake/baselib/hdf5.py
+++ b/openquake/baselib/hdf5.py
@@ -165,8 +165,9 @@ class PickleableSequence(collections.Sequence):
         return repr(self._objects)
 
     def __toh5__(self):
-        dic = {i: numpy.array(pickle.dumps(obj, pickle.HIGHEST_PROTOCOL))
-               for i, obj in enumerate(self._objects)}
+        dic = {
+            '%06d' % i: numpy.array(pickle.dumps(obj, pickle.HIGHEST_PROTOCOL))
+            for i, obj in enumerate(self._objects)}
         return dic, {}
 
     def __fromh5__(self, dic, attrs):

--- a/openquake/baselib/hdf5.py
+++ b/openquake/baselib/hdf5.py
@@ -173,13 +173,17 @@ class PickleableSequence(collections.Sequence):
         return repr(self._objects)
 
     def __toh5__(self):
-        dic = {
-            '%06d' % i: numpy.array(pickle.dumps(obj, pickle.HIGHEST_PROTOCOL))
-            for i, obj in enumerate(self._objects)}
-        return dic, {}
+        dic = {}
+        nbytes = 0
+        for i, obj in enumerate(self._objects):
+            pik = pickle.dumps(obj, pickle.HIGHEST_PROTOCOL)
+            dic['%06d' % i] = numpy.array(pik)
+            nbytes += len(pik)
+        return dic, dict(nbytes=nbytes)
 
     def __fromh5__(self, dic, attrs):
         self._objects = tuple(pickle.loads(dic[k].value) for k in sorted(dic))
+        vars(self).update(attrs)
 
 
 class File(h5py.File):

--- a/openquake/baselib/hdf5.py
+++ b/openquake/baselib/hdf5.py
@@ -153,7 +153,7 @@ class PickleableSequence(collections.Sequence):
     (<type 'dict'>, <type 'list'>)
     """
     def __init__(self, objects):
-        self._objects = objects
+        self._objects = tuple(objects)
 
     def __getitem__(self, i):
         return self._objects[i]
@@ -162,16 +162,15 @@ class PickleableSequence(collections.Sequence):
         return len(self._objects)
 
     def __repr__(self):
-        return repr(tuple(self._objects))
+        return repr(self._objects)
 
     def __toh5__(self):
-        array = numpy.zeros(len(self._objects), vbytes)
-        for i, obj in enumerate(self._objects):
-            array[i] = pickle.dumps(obj)
-        return array, {}
+        dic = {i: numpy.array(pickle.dumps(obj, pickle.HIGHEST_PROTOCOL))
+               for i, obj in enumerate(self._objects)}
+        return dic, {}
 
-    def __fromh5__(self, array, attrs):
-        self._objects = map(pickle.loads, array)
+    def __fromh5__(self, dic, attrs):
+        self._objects = tuple(pickle.loads(dic[k].value) for k in sorted(dic))
 
 
 class File(h5py.File):


### PR DESCRIPTION
This is needed to store big sequences of objects in HDF5 format. The problem is that HDF5 truncated big binary blobs, so that they cannot be read back and unpickled. This is the cause of issue https://github.com/gem/oq-risklib/issues/639, when storing the ruptures.