### PR TITLE
Small simplification of hazard_curves_per_trt

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,6 @@
+  [Michele Simionato]
+  * Removed the rupture_site_filter where it was not used
+
   [Daniele Viganò]
   * Added support for Ubuntu 16.04 (xenial) packages
 

--- a/openquake/hazardlib/calc/hazard_curve.py
+++ b/openquake/hazardlib/calc/hazard_curve.py
@@ -256,12 +256,13 @@ def hazard_curves_per_trt(
                 for i, gsim in enumerate(gsims):
                     with pne_mon:
                         for imt in imts:
+                            the_curves = curves[i][str(imt)]
                             poes = gsim.get_poes(
                                 sctx, rctx, dctx, imt, imts[imt],
                                 truncation_level)
                             pno = rupture.get_probability_no_exceedance(poes)
-                            expanded_pno = sctx.sites.expand(pno, 1.0)
-                            curves[i][str(imt)] *= expanded_pno
+                            the_curves[sctx.sites.indices, :] *= pno
+
         except Exception as err:
             etype, err, tb = sys.exc_info()
             msg = 'An error occurred with source id=%s. Error: %s'

--- a/openquake/hazardlib/calc/hazard_curve.py
+++ b/openquake/hazardlib/calc/hazard_curve.py
@@ -26,7 +26,7 @@ import collections
 
 import numpy
 
-from openquake.baselib.python3compat import range, raise_
+from openquake.baselib.python3compat import raise_
 from openquake.baselib.performance import Monitor
 from openquake.hazardlib.calc import filters
 from openquake.hazardlib.gsim.base import ContextMaker, FarAwayRupture
@@ -156,46 +156,6 @@ def calc_hazard_curves(
             sources_by_trt[trt], sites, imtls, [gsim_by_trt[trt]],
             truncation_level, source_site_filter)[0])
     return curves
-
-
-def expand(array, indices, n):
-    n1 = len(array)
-    if n1 != len(indices):
-        raise ValueError('The array has length %d, the indices %d' %
-                         (n1, len(indices)))
-    if n < n1:
-        raise ValueError('You cannot expand to a shorter array, n=%d < %d' %
-                         n, n1)
-    z = numpy.zeros(n, array.dtype)
-    z[indices] = array
-    return z
-
-
-def compose2(prob1, prob2):
-    """
-    >> compose2(0.1, 0.1)
-    0.19
-    """
-    return 1. - (1. - prob1) * (1. - prob2)
-
-
-def compose4(prob1, idx1, prob2, idx2):
-    """
-    >>> compose([0.1, 0.2], [0, 2], [0.3], [1])
-    """
-    if idx1 == idx2:
-        return compose2(prob1, prob2), idx1
-    dic1 = dict(zip(idx1, prob1))
-    dic2 = dict(zip(idx2, prob2))
-    dic = {}
-    for idx in dic1:
-        dic[idx] = compose2(dic1[idx], dic2.get(idx))
-    for idx in dic2:
-        dic[idx] = compose2(dic1.get(idx), dic2[idx])
-    z = numpy.zeros(len(dic), prob1.dtype)
-    idx = dic.keys()
-    z[idx] = dic.values()
-    return z, idx
 
 
 def hazard_curves_per_trt(

--- a/openquake/hazardlib/calc/hazard_curve.py
+++ b/openquake/hazardlib/calc/hazard_curve.py
@@ -79,8 +79,7 @@ def agg_curves(acc, curves):
 @deprecated('Use calc_hazard_curves instead')
 def hazard_curves(
         sources, sites, imtls, gsim_by_trt, truncation_level=None,
-        source_site_filter=filters.source_site_noop_filter,
-        rupture_site_filter=filters.rupture_site_noop_filter):
+        source_site_filter=filters.source_site_noop_filter):
     """
     Deprecated. It does the same job of
     :func:`openquake.hazardlib.calc.hazard_curve.calc_hazard_curves`,
@@ -90,15 +89,13 @@ def hazard_curves(
     imtls = {str(imt): imls for imt, imls in imtls.items()}
     curves_by_imt = calc_hazard_curves(
         sources, sites, imtls, gsim_by_trt, truncation_level,
-        source_site_filter=filters.source_site_noop_filter,
-        rupture_site_filter=filters.rupture_site_noop_filter)
+        source_site_filter=filters.source_site_noop_filter)
     return {from_string(imt): curves_by_imt[imt] for imt in imtls}
 
 
 def calc_hazard_curves(
         sources, sites, imtls, gsim_by_trt, truncation_level=None,
         source_site_filter=filters.source_site_noop_filter,
-        rupture_site_filter=filters.rupture_site_noop_filter,
         maximum_distance=None):
     """
     Compute hazard curves on a list of sites, given a set of seismic sources
@@ -144,9 +141,6 @@ def calc_hazard_curves(
     :param source_site_filter:
         Optional source-site filter function. See
         :mod:`openquake.hazardlib.calc.filters`.
-    :param rupture_site_filter:
-        Optional rupture-site filter function. See
-        :mod:`openquake.hazardlib.calc.filters`.
 
     :returns:
         An array of size N, where N is the number of sites, which elements
@@ -160,7 +154,7 @@ def calc_hazard_curves(
     for trt in sources_by_trt:
         curves = agg_curves(curves, hazard_curves_per_trt(
             sources_by_trt[trt], sites, imtls, [gsim_by_trt[trt]],
-            truncation_level, source_site_filter, rupture_site_filter)[0])
+            truncation_level, source_site_filter)[0])
     return curves
 
 
@@ -204,12 +198,9 @@ def compose4(prob1, idx1, prob2, idx2):
     return z, idx
 
 
-# TODO: remove the rupture_site_filter, since its work is now done by the
-# maximum_distance parameter; see what would break
 def hazard_curves_per_trt(
         sources, sites, imtls, gsims, truncation_level=None,
         source_site_filter=filters.source_site_noop_filter,
-        rupture_site_filter=filters.rupture_site_noop_filter,
         maximum_distance=None, bbs=(), monitor=Monitor()):
     """
     Compute the hazard curves for a set of sources belonging to the same
@@ -224,7 +215,6 @@ def hazard_curves_per_trt(
         number of levels in ``imtls``.
     """
     cmaker = ContextMaker(gsims, maximum_distance)
-    gnames = list(map(str, gsims))
     imt_dt = numpy.dtype([(imt, float, len(imtls[imt]))
                           for imt in sorted(imtls)])
     imts = {from_string(imt): imls for imt, imls in imtls.items()}
@@ -238,13 +228,11 @@ def hazard_curves_per_trt(
         t0 = time.time()
         curves = numpy.ones((len(gsims), len(sites)), imt_dt)
         try:
-            rupture_sites = rupture_site_filter(
-                (rupture, s_sites) for rupture in source.iter_ruptures())
-            for rupture, r_sites in rupture_sites:
+            for rupture in source.iter_ruptures():
                 with ctx_mon:
                     try:
                         sctx, rctx, dctx = cmaker.make_contexts(
-                            r_sites, rupture)
+                            s_sites, rupture)
                     except FarAwayRupture:
                         continue
 

--- a/openquake/hazardlib/tests/calc/hazard_curve_test.py
+++ b/openquake/hazardlib/tests/calc/hazard_curve_test.py
@@ -245,16 +245,10 @@ class HazardCurvesFiltersTestCase(unittest.TestCase):
 
         from openquake.hazardlib.calc import filters
         source_site_filter = self.SitesCounterSourceFilter(
-            filters.source_site_distance_filter(30)
-        )
-        rupture_site_filter = self.SitesCounterRuptureFilter(
-            filters.rupture_site_distance_filter(30)
-        )
+            filters.source_site_distance_filter(30))
         calc_hazard_curves(
             sources, sitecol, imts, gsims, truncation_level,
-            source_site_filter=source_site_filter,
-            rupture_site_filter=rupture_site_filter
-        )
+            source_site_filter=source_site_filter)
         # there are two sources and four sites. The first source contains only
         # one rupture, the second source contains three ruptures.
         #
@@ -287,5 +281,3 @@ class HazardCurvesFiltersTestCase(unittest.TestCase):
         # affect the 3rd and 4th sites.
         self.assertEqual(source_site_filter.counts,
                          [('point2', [1, 3, 4])])
-        self.assertEqual(rupture_site_filter.counts,
-                         [(6, [4]), (8, [3, 4])])


### PR DESCRIPTION
For a long time now, the rupture filtering has been done when computing the distances, in the lines

```python
                    try:
                        sctx, rctx, dctx = cmaker.make_contexts(
                            s_sites, rupture)
                    except FarAwayRupture:
                        continue
```

However, the was still a `rupture_site_filter` in the signature of the function, never used by the engine.
I am removing that remnant of the past. Also, there is a minor refactoring of the part doing the aggregation of the hazard curves.