### PR TITLE
Restored the sampling feature in the event based calculator

### DIFF
--- a/openquake/hazardlib/calc/gmf.py
+++ b/openquake/hazardlib/calc/gmf.py
@@ -204,7 +204,10 @@ class GmfComputer(object):
         imt_range = range(len(self.imts))
         for i, gsim in enumerate(self.gsims):
             for j, rlz in enumerate(rlzs_by_gsim[gsim]):
-                eids = get_array(events, sample=rlz.sampleid)['eid']
+                if isinstance(events, int):  # for scenario
+                    eids = range(events)
+                else:
+                    eids = get_array(events, sample=rlz.sampleid)['eid']
                 arr = self._compute(seed + j, gsim, len(eids)).transpose(
                     0, 2, 1)  # array of shape (I, E, S)
                 for imti in imt_range:

--- a/openquake/hazardlib/calc/gmf.py
+++ b/openquake/hazardlib/calc/gmf.py
@@ -205,7 +205,6 @@ class GmfComputer(object):
         for i, gsim in enumerate(self.gsims):
             for j, rlz in enumerate(rlzs_by_gsim[gsim]):
                 eids = get_array(events, sample=rlz.sampleid)['eid']
-                import pdb; pdb.set_trace()
                 arr = self._compute(seed + j, gsim, len(eids)).transpose(
                     0, 2, 1)  # array of shape (I, E, S)
                 for imti in imt_range:

--- a/openquake/hazardlib/calc/gmf.py
+++ b/openquake/hazardlib/calc/gmf.py
@@ -181,11 +181,11 @@ class GmfComputer(object):
         imt_range = range(len(self.imts))
         for i, gsim in enumerate(self.gsims):
             for j, rlz in enumerate(rlzs_by_gsim[gsim]):
-                if self.samples:
+                if self.samples > 1:
                     eids = get_array(events, sample=rlz.sampleid)['eid']
                 else:
                     eids = events['eid']
-                arr = self._compute(seed + j, gsim, len(eids)).transpose(
+                arr = self.compute(seed + j, gsim, len(eids)).transpose(
                     0, 2, 1)  # array of shape (I, E, S)
                 for imti in imt_range:
                     for eid, gmf in zip(eids, arr[imti]):


### PR DESCRIPTION
The line `eids = get_array(events, sample=rlz.sampleid)['eid']` is what is needed to have the sampling feature back. See the companion in risklib https://github.com/gem/oq-risklib/pull/815.