### PR TITLE
Removed the deprecated function `hazard_curve.hazard_curves`

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,6 @@
   [Michele Simionato]
+  * Removed the function `hazard_curve.hazard_curves` that has been
+    deprecated from November 2014
   * Fixed the string representation of GSIM instances: this solves a serious
     bug in the GMPETable
   * Removed the rupture_site_filter where it was not used

--- a/openquake/hazardlib/calc/__init__.py
+++ b/openquake/hazardlib/calc/__init__.py
@@ -20,7 +20,6 @@
 Package :mod:`openquake.hazardlib.calc` contains hazard calculator modules
 and utilities for them, such as :mod:`~openquake.hazardlib.calc.filters`.
 """
-from openquake.hazardlib.calc.hazard_curve import hazard_curves
 from openquake.hazardlib.calc.gmf import ground_motion_fields
 from openquake.hazardlib.calc.stochastic import stochastic_event_set
 # from disagg we want to import main calc function

--- a/openquake/hazardlib/calc/hazard_curve.py
+++ b/openquake/hazardlib/calc/hazard_curve.py
@@ -31,7 +31,6 @@ from openquake.baselib.performance import Monitor
 from openquake.hazardlib.calc import filters
 from openquake.hazardlib.gsim.base import ContextMaker, FarAwayRupture
 from openquake.hazardlib.imt import from_string
-from openquake.baselib.general import deprecated
 
 
 def zero_curves(num_sites, imtls):
@@ -74,23 +73,6 @@ def agg_curves(acc, curves):
     for imt in curves.dtype.fields:
         new[imt] = 1. - (1. - curves[imt]) * (1. - acc[imt])
     return new
-
-
-@deprecated('Use calc_hazard_curves instead')
-def hazard_curves(
-        sources, sites, imtls, gsim_by_trt, truncation_level=None,
-        source_site_filter=filters.source_site_noop_filter):
-    """
-    Deprecated. It does the same job of
-    :func:`openquake.hazardlib.calc.hazard_curve.calc_hazard_curves`,
-    with the only difference that the intensity measure types in input
-    and output are hazardlib objects instead of simple strings.
-    """
-    imtls = {str(imt): imls for imt, imls in imtls.items()}
-    curves_by_imt = calc_hazard_curves(
-        sources, sites, imtls, gsim_by_trt, truncation_level,
-        source_site_filter=filters.source_site_noop_filter)
-    return {from_string(imt): curves_by_imt[imt] for imt in imtls}
 
 
 def calc_hazard_curves(


### PR DESCRIPTION
This was deprecated 18 months ago and it is time for it to go, with the coming of engine 2.0.