### PR TITLE
Renamed Imtls -> DictArray

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,5 @@
   [Michele Simionato]
+  * Renamed Imtls -> DictArray
   * Removed the .id attribute from the Site class
 
   [Graeme Weatherill]

--- a/openquake/baselib/general.py
+++ b/openquake/baselib/general.py
@@ -36,6 +36,8 @@ import collections
 import numpy
 from decorator import decorator
 
+F64 = numpy.float64
+
 
 class WeightedSequence(collections.MutableSequence):
     """
@@ -564,6 +566,56 @@ class AccumDict(dict):
         """
         return self.__class__({key: func(value, *extras)
                                for key, value in self.items()})
+
+
+# return a dict imt -> slice and the total number of levels
+def _slicedict_n(imt_dt):
+    n = 0
+    slicedic = {}
+    for imt in imt_dt.names:
+        shp = imt_dt[imt].shape
+        n1 = n + shp[0] if shp else 1
+        slicedic[imt] = slice(n, n1)
+        n = n1
+    return slicedic, n
+
+
+class DictArray(collections.Mapping):
+    """
+    A small wrapper over a dictionary of arrays:
+
+    >>> DictArray({'PGA': [0.01, 0.02, 0.04], 'PGV': [0.1, 0.2]})
+    <DictArray
+    PGA: [ 0.01  0.02  0.04]
+    PGV: [ 0.1  0.2]>
+
+    The DictArray maintains the lexicographic order of the keys.
+    """
+    def __init__(self, imtls):
+        self.imt_dt = dt = numpy.dtype(
+            [(imt, F64, len(imls) if hasattr(imls, '__len__') else 1)
+             for imt, imls in sorted(imtls.items())])
+        self.slicedic, num_levels = _slicedict_n(dt)
+        self.array = numpy.zeros(num_levels, F64)
+        for imt, imls in imtls.items():
+            self[imt] = imls
+
+    def __getitem__(self, imt):
+        return self.array[self.slicedic[imt]]
+
+    def __setitem__(self, imt, array):
+        self.array[self.slicedic[imt]] = array
+
+    def __iter__(self):
+        for imt in self.imt_dt.names:
+            yield imt
+
+    def __len__(self):
+        return len(self.imt_dt.names)
+
+    def __repr__(self):
+        data = ['%s: %s' % (imt, self[imt]) for imt in self]
+        return '<%s\n%s>' % (self.__class__.__name__, '\n'.join(data))
 
 
 def groupby(objects, key, reducegroup=list):

--- a/openquake/hazardlib/calc/hazard_curve.py
+++ b/openquake/hazardlib/calc/hazard_curve.py
@@ -28,8 +28,8 @@ import numpy
 
 from openquake.baselib.python3compat import raise_, zip
 from openquake.baselib.performance import Monitor
-from openquake.baselib.general import groupby
-from openquake.hazardlib.probability_map import ProbabilityMap, Imtls
+from openquake.baselib.general import groupby, DictArray
+from openquake.hazardlib.probability_map import ProbabilityMap
 from openquake.hazardlib.calc import filters
 from openquake.hazardlib.gsim.base import ContextMaker, FarAwayRupture
 from openquake.hazardlib.imt import from_string
@@ -150,7 +150,7 @@ def calc_hazard_curves(
         are records with fields given by the intensity measure types; the
         size of each field is given by the number of levels in ``imtls``.
     """
-    imtls = Imtls(imtls)
+    imtls = DictArray(imtls)
     sources_by_trt = groupby(
         sources, operator.attrgetter('tectonic_region_type'))
     pmap = ProbabilityMap()
@@ -245,7 +245,7 @@ def hazard_curves_per_trt(
 
     :returns: a ProbabilityMap instance
     """
-    imtls = Imtls(imtls)
+    imtls = DictArray(imtls)
     cmaker = ContextMaker(gsims, maximum_distance)
     sources_sites = ((source, sites) for source in sources)
     ctx_mon = monitor('making contexts', measuremem=False)

--- a/openquake/hazardlib/probability_map.py
+++ b/openquake/hazardlib/probability_map.py
@@ -16,59 +16,9 @@
 #  You should have received a copy of the GNU Affero General Public License
 #  along with OpenQuake.  If not, see <http://www.gnu.org/licenses/>.
 from openquake.baselib.python3compat import zip
-import collections
 import numpy
 
 F64 = numpy.float64
-
-
-# return a dict imt -> slice and the total number of levels
-def _slicedict_n(imt_dt):
-    n = 0
-    slicedic = {}
-    for imt in imt_dt.names:
-        shp = imt_dt[imt].shape
-        n1 = n + shp[0] if shp else 1
-        slicedic[imt] = slice(n, n1)
-        n = n1
-    return slicedic, n
-
-
-class Imtls(collections.Mapping):
-    """
-    A small wrapper over an ordered dictionary of intensity measure types
-    and levels.
-
-    >>> Imtls({'PGA': [0.01, 0.02, 0.04], 'PGV': [0.1, 0.2]})
-    <Imtls
-    PGA: [ 0.01  0.02  0.04]
-    PGV: [ 0.1  0.2]>
-    """
-    def __init__(self, imtls):
-        self.imt_dt = dt = numpy.dtype(
-            [(imt, F64, len(imls) if hasattr(imls, '__len__') else 1)
-             for imt, imls in sorted(imtls.items())])
-        self.slicedic, num_levels = _slicedict_n(dt)
-        self.array = numpy.zeros(num_levels, F64)
-        for imt, imls in imtls.items():
-            self[imt] = imls
-
-    def __getitem__(self, imt):
-        return self.array[self.slicedic[imt]]
-
-    def __setitem__(self, imt, array):
-        self.array[self.slicedic[imt]] = array
-
-    def __iter__(self):
-        for imt in self.imt_dt.names:
-            yield imt
-
-    def __len__(self):
-        return len(self.imt_dt.names)
-
-    def __repr__(self):
-        data = ['%s: %s' % (imt, self[imt]) for imt in self]
-        return '<Imtls\n%s>' % '\n'.join(data)
 
 
 class ProbabilityCurve(object):


### PR DESCRIPTION
... and moved it inside baselib.general. The concept of a DictArray is general and not tied to the Intensity Measure Types and Levels. In particular, in the engine it is also useful for the loss ratios per loss type. The previous name was too specific.