### PR TITLE
Fix rupture count in simple fault for near-fault directivity case

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,7 @@
 python-oq-hazardlib (0.20.0-0~precise01) precise; urgency=low
+  [Yen-Shin Chen]
+  * Fixed the rupture count in simple fault while multiple hypocenter locations
+  or slip directions assigned.
 
   [Michele Simionato]
   * Fixed the serialization on HDF5 of dictionaries with keys containing slashes

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,7 +1,7 @@
 python-oq-hazardlib (0.20.0-0~precise01) precise; urgency=low
   [Yen-Shin Chen]
   * Fixed the rupture count in simple fault while multiple hypocenter locations
-  or slip directions assigned.
+    or slip directions assigned.
 
   [Michele Simionato]
   * Fixed the serialization on HDF5 of dictionaries with keys containing slashes

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,7 +1,6 @@
 python-oq-hazardlib (0.20.0-0~precise01) precise; urgency=low
   [Yen-Shin Chen]
-  * Fixed the rupture count in simple fault while multiple hypocenter locations
-    or slip directions assigned.
+  * Fixed the rupture count in simple fault while multiple hypocenter locations or slip directions assigned.
 
   [Michele Simionato]
   * Fixed the serialization on HDF5 of dictionaries with keys containing slashes

--- a/openquake/hazardlib/source/simple_fault.py
+++ b/openquake/hazardlib/source/simple_fault.py
@@ -236,7 +236,9 @@ class SimpleFaultSource(ParametricSeismicSource):
             num_rup_along_length = mesh_cols - rup_cols + 1
             num_rup_along_width = mesh_rows - rup_rows + 1
             counts += num_rup_along_length * num_rup_along_width
-        return counts
+            n_hypo = len(self.hypo_list) or 1
+            n_slip = len(self.slip_list) or 1
+        return counts * n_hypo * n_slip
 
     def _get_rupture_dimensions(self, fault_length, fault_width, mag):
         """
@@ -298,7 +300,6 @@ class SimpleFaultSource(ParametricSeismicSource):
         self.lower_seismogenic_depth = lower_seismogenic_depth
         self.dip = dip
         self.rupture_mesh_spacing = spacing
-
 
     def modify_adjust_dip(self, increment):
         """


### PR DESCRIPTION
Thie pull request fixes the problem caused by the rupture counts in simple fault while multiple hypocenters and slip direction is set up for near-fault directivity assessment. 

The test shows green:
https://ci.openquake.org/job/zdevel_oq-hazardlib/608/