### PR TITLE
Use a default fillvalue of zero

### DIFF
--- a/openquake/baselib/hdf5.py
+++ b/openquake/baselib/hdf5.py
@@ -32,7 +32,7 @@ vstr = h5py.special_dtype(vlen=str)
 
 
 def create(hdf5, name, dtype, shape=(None,), compression=None,
-           attrs=None):
+           fillvalue=0, attrs=None):
     """
     :param hdf5: a h5py.File object
     :param name: an hdf5 key string
@@ -46,7 +46,7 @@ def create(hdf5, name, dtype, shape=(None,), compression=None,
         dset = hdf5.create_dataset(
             name, (0,) + shape[1:], dtype, chunks=True, maxshape=shape)
     else:  # fixed-shape dataset
-        dset = hdf5.create_dataset(name, shape, dtype)
+        dset = hdf5.create_dataset(name, shape, dtype, fillvalue=fillvalue)
     if attrs:
         for k, v in attrs.items():
             dset.attrs[k] = v


### PR DESCRIPTION
When creating a dataset the values should be initialized to zero, not left as garbage. This is required for 
https://github.com/gem/oq-engine/pull/2197. The tests are green: https://ci.openquake.org/job/zdevel_oq-hazardlib/621/