### PR TITLE
Removed python3compat.dtype

### DIFF
--- a/openquake/baselib/general.py
+++ b/openquake/baselib/general.py
@@ -643,7 +643,8 @@ class DictArray(collections.Mapping):
     def __fromh5__(self, carray, attrs):
         self.array = carray[:].view(F64)
         self.imt_dt = dt = numpy.dtype(
-            [(imt, F64, len(carray[0][imt])) for imt in carray.dtype.names])
+            [(str(imt), F64, len(carray[0][imt]))
+             for imt in carray.dtype.names])
         self.slicedic, num_levels = _slicedict_n(dt)
         for imt in carray.dtype.names:
             self[imt] = carray[0][imt]

--- a/openquake/baselib/general.py
+++ b/openquake/baselib/general.py
@@ -35,7 +35,6 @@ import collections
 
 import numpy
 from decorator import decorator
-from openquake.baselib.python3compat import dtype
 
 F64 = numpy.float64
 
@@ -597,8 +596,8 @@ class DictArray(collections.Mapping):
     The DictArray maintains the lexicographic order of the keys.
     """
     def __init__(self, imtls):
-        self.imt_dt = dt = dtype(
-            [(imt, F64, len(imls) if hasattr(imls, '__len__') else 1)
+        self.imt_dt = dt = numpy.dtype(
+            [(str(imt), F64, len(imls) if hasattr(imls, '__len__') else 1)
              for imt, imls in sorted(imtls.items())])
         self.slicedic, num_levels = _slicedict_n(dt)
         self.array = numpy.zeros(num_levels, F64)
@@ -626,7 +625,7 @@ class DictArray(collections.Mapping):
 
     def __fromh5__(self, carray, attrs):
         self.array = carray[:].view(F64)
-        self.imt_dt = dt = dtype(
+        self.imt_dt = dt = numpy.dtype(
             [(imt, F64, len(carray[0][imt])) for imt in carray.dtype.names])
         self.slicedic, num_levels = _slicedict_n(dt)
         for imt in carray.dtype.names:

--- a/openquake/baselib/python3compat.py
+++ b/openquake/baselib/python3compat.py
@@ -155,24 +155,5 @@ def check_syntax(pkg):
     print('Checked %d ok, %d wrong modules' % (ok, err))
 
 
-def dtype(arglist):
-    """
-    Version of numpy.dtype working both in Python 2 and 3.
-
-    :param arglist:
-         list of pairs (name, dtype) where name must be bytes in Python 2 and
-         str in Python 3
-    :returns: a numpy dtype
-    """
-    lst = []
-    for arg in arglist:
-        if PY2:
-            newarg = (encode(arg[0]),) + arg[1:]
-        else:  # Python 3
-            newarg = (decode(arg[0]),) + arg[1:]
-        lst.append(newarg)
-    return numpy.dtype(lst)
-
-
 if __name__ == '__main__':
     check_syntax(importlib.import_module(sys.argv[1]))


### PR DESCRIPTION
It can be removed; the only trick is to make sure that the name of each datatype is converted with `str` (i.e. to bytes in Python 2 and to unicode in Python 3).