### PR TITLE
Fixed the filtering in calc_hazard_curves

### DIFF
--- a/openquake/hazardlib/calc/filters.py
+++ b/openquake/hazardlib/calc/filters.py
@@ -169,7 +169,7 @@ class RuptureSitesFilter(object):
         Returns the ruptures within the integration distance from the source,
         or None.
         """
-        rupture_sites = list(self([rupture], sites))
+        rupture_sites = list(self([source], sites))
         if rupture_sites:
             return rupture_sites[0][1]
 
@@ -189,6 +189,7 @@ def source_site_noop_filter(sources, sites):
     return ((src, sites) for src in sources)
 source_site_noop_filter.affected = lambda src, sites: sites
 source_site_noop_filter.integration_distance = None
+
 
 #: Rupture-site "no-op" filter, same as :func:`source_site_noop_filter`.
 def rupture_site_noop_filter(ruptures, sites):

--- a/openquake/hazardlib/calc/filters.py
+++ b/openquake/hazardlib/calc/filters.py
@@ -125,6 +125,7 @@ class SourceSitesFilter(object):
         which is what is actually used for filtering.
     """
     def __init__(self, integration_distance):
+        assert integration_distance, 'Must be set'
         self.integration_distance = integration_distance
 
     def affected(self, source, sites):

--- a/openquake/hazardlib/calc/hazard_curve.py
+++ b/openquake/hazardlib/calc/hazard_curve.py
@@ -66,8 +66,7 @@ def agg_curves(acc, curves):
 
 def calc_hazard_curves(
         sources, sites, imtls, gsim_by_trt, truncation_level=None,
-        source_site_filter=filters.source_site_noop_filter,
-        maximum_distance=None):
+        source_site_filter='SourceSitesFilter', maximum_distance=None):
     """
     Compute hazard curves on a list of sites, given a set of seismic sources
     and a set of ground shaking intensity models (one per tectonic region type
@@ -210,6 +209,7 @@ def pmap_from_grp(
     :returns: a ProbabilityMap instance
     """
     if source_site_filter == 'SourceSitesFilter':
+        assert maximum_distance, maximum_distance
         source_site_filter = filters.SourceSitesFilter(maximum_distance)
     with GroundShakingIntensityModel.forbid_instantiation():
         imtls = DictArray(imtls)

--- a/openquake/hazardlib/calc/hazard_curve.py
+++ b/openquake/hazardlib/calc/hazard_curve.py
@@ -66,7 +66,7 @@ def agg_curves(acc, curves):
 
 def calc_hazard_curves(
         sources, sites, imtls, gsim_by_trt, truncation_level=None,
-        source_site_filter='SourceSitesFilter', maximum_distance=None):
+        source_site_filter=filters.source_site_noop_filter):
     """
     Compute hazard curves on a list of sites, given a set of seismic sources
     and a set of ground shaking intensity models (one per tectonic region type
@@ -209,8 +209,9 @@ def pmap_from_grp(
     :returns: a ProbabilityMap instance
     """
     if source_site_filter == 'SourceSitesFilter':
-        assert maximum_distance, maximum_distance
-        source_site_filter = filters.SourceSitesFilter(maximum_distance)
+        source_site_filter = (
+            filters.SourceSitesFilter(maximum_distance)
+            if maximum_distance else filters.source_site_noop_filter)
     with GroundShakingIntensityModel.forbid_instantiation():
         imtls = DictArray(imtls)
         cmaker = ContextMaker(gsims, maximum_distance)

--- a/openquake/hazardlib/calc/hazard_curve.py
+++ b/openquake/hazardlib/calc/hazard_curve.py
@@ -208,7 +208,7 @@ def pmap_from_grp(
 
     :returns: a ProbabilityMap instance
     """
-    if source_site_filter == 'SourceSitesFilter':
+    if source_site_filter == 'SourceSitesFilter':  # default
         source_site_filter = (
             filters.SourceSitesFilter(maximum_distance)
             if maximum_distance else filters.source_site_noop_filter)


### PR DESCRIPTION
By default there is no filtering, as in the past. If you want filtering, pass a SourceSitesFilter instance.