### PR TITLE
Fixed ProbabilityMap.convert

### DIFF
--- a/openquake/hazardlib/probability_map.py
+++ b/openquake/hazardlib/probability_map.py
@@ -174,7 +174,7 @@ class ProbabilityMap(dict):
         for imt in curves.dtype.names:
             curves_by_imt = curves[imt]
             for i, sid in enumerate(sorted(self)):
-                curves_by_imt[i] = self[sid].array[imtls.slicedic[imt], idx]
+                curves_by_imt[sid] = self[sid].array[imtls.slicedic[imt], idx]
         return curves
 
     def filter(self, sids):

--- a/openquake/hazardlib/probability_map.py
+++ b/openquake/hazardlib/probability_map.py
@@ -173,7 +173,7 @@ class ProbabilityMap(dict):
         curves = numpy.zeros(nsites, imtls.imt_dt)
         for imt in curves.dtype.names:
             curves_by_imt = curves[imt]
-            for i, sid in enumerate(sorted(self)):
+            for sid in self:
                 curves_by_imt[sid] = self[sid].array[imtls.slicedic[imt], idx]
         return curves
 


### PR DESCRIPTION
As a consequence of this bug, the classical_risk calculator is giving bogus results. See the companion on the engine.