### PR TITLE
Use rtree wheels made by us

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,11 +9,9 @@ addons:
   apt:
     packages:
     - parallel
-    - libspatialindex-dev
 
 install:
   - pip install -r requirements-py35-linux64.txt
-  - pip install Rtree==0.8.2
   - python setup.py develop
 
 script:

--- a/requirements-py27-linux64.txt
+++ b/requirements-py27-linux64.txt
@@ -20,3 +20,5 @@ http://ftp.openquake.org/python-new-wheels/decorator-4.0.6-py2.py3-none-any.whl
 http://ftp.openquake.org/python-new-wheels/funcsigs-1.0.2-py2.py3-none-any.whl
 http://ftp.openquake.org/python-new-wheels/pbr-1.8.0-py2.py3-none-any.whl
 http://ftp.openquake.org/python-new-wheels/six-1.10.0-py2.py3-none-any.whl
+# Experimental wheel
+http://ftp.openquake.org/python-new-wheels/Rtree-0.8.2-cp27-cp27mu-manylinux1_x86_64.whl

--- a/requirements-py35-linux64.txt
+++ b/requirements-py35-linux64.txt
@@ -20,3 +20,5 @@ http://ftp.openquake.org/python-new-wheels/decorator-4.0.6-py2.py3-none-any.whl
 http://ftp.openquake.org/python-new-wheels/funcsigs-1.0.2-py2.py3-none-any.whl
 http://ftp.openquake.org/python-new-wheels/pbr-1.8.0-py2.py3-none-any.whl
 http://ftp.openquake.org/python-new-wheels/six-1.10.0-py2.py3-none-any.whl
+# Experimental wheel
+http://ftp.openquake.org/python-new-wheels/Rtree-0.8.2-cp35-cp35m-manylinux1_x86_64.whl


### PR DESCRIPTION
This wheels are experimental, but should work. These are not generated automatically because .so lib requires some patchwork using `patchelf`:

```bash
patchelf --set-rpath \$ORIGIN/.libs --force-rpath _wrapper_lib.so
```

An mock extension is used to be compatible with the `manylinux1` profile.

