### PR TITLE
Made the RtreeFilter optional, i.e. used only if the rtree library is available

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,6 @@
   [Michele Simionato]
-  * Introduced an RtreeFilter for fast filtering of the sites by point sources,
-    based on the source bounding box
+  * Introduced an optional RtreeFilter for fast filtering of the sites by
+    point sources, based on the source bounding box
 
   [Graeme Weatherill]
   * Adds/Modifies Ry0 and Rx calculator for multi-surface typology using the Generalized Coordinate System (GC2)


### PR DESCRIPTION
This is mostly for the benefit of Mac users, since installing rtree there can be nontrivial.