### PR TITLE
Increased the weight of point source ruptures

### DIFF
--- a/openquake/hazardlib/source/area.py
+++ b/openquake/hazardlib/source/area.py
@@ -43,7 +43,7 @@ class AreaSource(PointSource):
 
     MODIFICATIONS = set(())
 
-    RUPTURE_WEIGHT = 1 / 40.
+    RUPTURE_WEIGHT = 1 / 10.
 
     def __init__(self, source_id, name, tectonic_region_type,
                  mfd, rupture_mesh_spacing,

--- a/openquake/hazardlib/source/point.py
+++ b/openquake/hazardlib/source/point.py
@@ -67,7 +67,7 @@ class PointSource(ParametricSeismicSource):
 
     MODIFICATIONS = set(())
 
-    RUPTURE_WEIGHT = 1 / 40.
+    RUPTURE_WEIGHT = 1 / 10.
 
     def __init__(self, source_id, name, tectonic_region_type,
                  mfd, rupture_mesh_spacing,


### PR DESCRIPTION
Yesterday a computation by Graeme (PACNW) involving only point sources spawned only 48 tasks. This because the weight of the model was small. Point sources must be heavier to produce more tasks and to make better usage of our cluster, because the computation was heavy indeed. Several tests with different models show that weight larger than before has the additional benefit of making more uniform the tasks even in presence of fault sources. Therefore I am increasing the relative weight of point sources (and area sources) with respect to fault sources/characteric sources by a factor of 4.