### PR TITLE
Optimized the distance computations

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,7 @@
+  [Michele Simionato]
+  * Removed the speedups and optimized the distance calculations at the
+    numpy level
+
 python-oq-hazardlib (0.21.0-0~precise01) precise; urgency=low
 
   [Trevor Allen/Graeme Weatherill]

--- a/openquake/hazardlib/geo/geodetic.py
+++ b/openquake/hazardlib/geo/geodetic.py
@@ -243,17 +243,14 @@ def min_geodetic_distance(mlons, mlats, slons, slats, diameter=2*EARTH_RADIUS):
         slats = slats.reshape((1, ))
     cos_mlats = numpy.cos(mlats)
     cos_slats = numpy.cos(slats)
-
-    result = numpy.array([
-            # next five lines are the same as in geodetic_distance()
-            numpy.arcsin(numpy.sqrt(
-                numpy.sin((mlats - slats[i]) / 2.0) ** 2.0
-                + cos_mlats * cos_slats[i]
-                * numpy.sin((mlons - slons[i]) / 2.0) ** 2.0
-            )).min()
-            for i in range(len(slats))
-        ]) * diameter
-
+    result = numpy.zeros_like(slons)
+    for i, slat in enumerate(slats):
+        # next five lines are the same as in geodetic_distance()
+        result[i] = numpy.arcsin(numpy.sqrt(
+            numpy.sin((mlats - slat) / 2.0) ** 2.0
+            + cos_mlats * cos_slats[i]
+            * numpy.sin((mlons - slons[i]) / 2.0) ** 2.0
+        )).min() * diameter
     return _reshape(result, orig_shape)
 
 

--- a/openquake/hazardlib/geo/geodetic.py
+++ b/openquake/hazardlib/geo/geodetic.py
@@ -230,7 +230,7 @@ def _reshape(array, orig_shape):
 def min_geodetic_distance(mlons, mlats, slons, slats, diameter=2*EARTH_RADIUS):
     """
     Same as :func:`min_distance`, but calculates only minimum geodetic distance
-    (doesn't accept depth values) and doesn't support ``indices=True`` mode.
+    (doesn't accept depth values).
 
     This is an optimized version of :meth:`min_distance` that is suitable
     for calculating the minimum distance between first mesh and each point
@@ -240,7 +240,7 @@ def min_geodetic_distance(mlons, mlats, slons, slats, diameter=2*EARTH_RADIUS):
     cos_mlats = numpy.cos(mlats)
     cos_slats = numpy.cos(slats)
     if mlons.shape == (4,):  # planar surface to mesh distance
-        result = numpy.zeros((len(mlons), len(slons)))
+        result = numpy.zeros((4, len(slons)))
         for j in range(len(mlons)):
             a = numpy.sin((mlats[j] - slats) / 2.0)
             b = numpy.sin((mlons[j] - slons) / 2.0)

--- a/openquake/hazardlib/geo/geodetic.py
+++ b/openquake/hazardlib/geo/geodetic.py
@@ -239,13 +239,13 @@ def min_geodetic_distance(mlons, mlats, slons, slats, diameter=2*EARTH_RADIUS):
     mlons, mlats, slons, slats = _prepare_coords(mlons, mlats, slons, slats)
     cos_mlats = numpy.cos(mlats)
     cos_slats = numpy.cos(slats)
-    result = numpy.zeros_like(slons)
-    for i, slat in enumerate(slats):
-        a = numpy.sin((mlats - slat) / 2.0)
-        b = numpy.sin((mlons - slons[i]) / 2.0)
-        result[i] = numpy.arcsin(
-            numpy.sqrt(a * a + cos_mlats * cos_slats[i] * b * b)).min()
-    return result * diameter
+    result = numpy.zeros((len(mlons), len(slons)))
+    for j in range(len(mlons)):
+        a = numpy.sin((mlats[j] - slats) / 2.0)
+        b = numpy.sin((mlons[j] - slons) / 2.0)
+        result[j, :] = numpy.arcsin(
+            numpy.sqrt(a * a + cos_mlats[j] * cos_slats * b * b))
+    return result.min(axis=0) * diameter
 
 
 def min_idx_dst(mlons, mlats, mdepths, slons, slats, sdepths=0,

--- a/openquake/hazardlib/geo/geodetic.py
+++ b/openquake/hazardlib/geo/geodetic.py
@@ -59,11 +59,7 @@ class GeographicObjects(object):
         :param max_distance: distance in km (or None)
         """
         zeros = numpy.zeros_like(self.lons)
-        # NB: it would be much cleaner if min_distance returned both
-        # the index and the min_dist, but we would need to work at C level :-(
-        index = min_distance(self.lons, self.lats, zeros, lon, lat, 0.,
-                             indices=True)
-        min_dist = min_distance(self.lons, self.lats, zeros, lon, lat, 0.)
+        index, min_dist = _min_idx_dst(self.lons, self.lats, zeros, lon, lat)
         if max_distance is not None:
             if min_dist > max_distance:
                 return None, None
@@ -252,8 +248,7 @@ def min_geodetic_distance(mlons, mlats, slons, slats, diameter=2*EARTH_RADIUS):
     return _reshape(result, orig_shape)
 
 
-def min_distance(mlons, mlats, mdepths, slons, slats, sdepths, indices=False,
-                 diameter=2*EARTH_RADIUS):
+def min_distance(mlons, mlats, mdepths, slons, slats, sdepths, indices=False):
     """
     Calculate the minimum distance between a collection of points and a point.
 
@@ -288,12 +283,13 @@ def min_distance(mlons, mlats, mdepths, slons, slats, sdepths, indices=False,
         of those three otherwise.
     """
     assert not indices or mlons.ndim > 0
-    min_idx, min_dst = _min_idx_dst(mlons, mlats, mdepths,
-                                    slons, slats, sdepths, diameter)
+    min_idx, min_dst = _min_idx_dst(
+        mlons, mlats, mdepths, slons, slats, sdepths)
     return min_idx if indices else min_dst
 
 
-def _min_idx_dst(mlons, mlats, mdepths, slons, slats, sdepths, diameter):
+def _min_idx_dst(mlons, mlats, mdepths, slons, slats, sdepths=0,
+                 diameter=2*EARTH_RADIUS):
     mlons, mlats, slons, slats = _prepare_coords(mlons, mlats, slons, slats)
     mdepths = numpy.array(mdepths, float)
     sdepths = numpy.array(sdepths, float)

--- a/openquake/hazardlib/geo/geodetic.py
+++ b/openquake/hazardlib/geo/geodetic.py
@@ -239,13 +239,21 @@ def min_geodetic_distance(mlons, mlats, slons, slats, diameter=2*EARTH_RADIUS):
     mlons, mlats, slons, slats = _prepare_coords(mlons, mlats, slons, slats)
     cos_mlats = numpy.cos(mlats)
     cos_slats = numpy.cos(slats)
-    result = numpy.zeros((len(mlons), len(slons)))
-    for j in range(len(mlons)):
-        a = numpy.sin((mlats[j] - slats) / 2.0)
-        b = numpy.sin((mlons[j] - slons) / 2.0)
-        result[j, :] = numpy.arcsin(
-            numpy.sqrt(a * a + cos_mlats[j] * cos_slats * b * b))
-    return result.min(axis=0) * diameter
+    if mlons.shape == (4,):  # planar surface to mesh distance
+        result = numpy.zeros((len(mlons), len(slons)))
+        for j in range(len(mlons)):
+            a = numpy.sin((mlats[j] - slats) / 2.0)
+            b = numpy.sin((mlons[j] - slons) / 2.0)
+            result[j, :] = numpy.arcsin(
+                numpy.sqrt(a * a + cos_mlats[j] * cos_slats * b * b))
+        return result.min(axis=0) * diameter
+    result = numpy.zeros_like(slons)
+    for i, slat in enumerate(slats):
+        a = numpy.sin((mlats - slat) / 2.0)
+        b = numpy.sin((mlons - slons[i]) / 2.0)
+        result[i] = numpy.arcsin(
+            numpy.sqrt(a * a + cos_mlats * cos_slats[i] * b * b)).min()
+    return result * diameter
 
 
 def min_idx_dst(mlons, mlats, mdepths, slons, slats, sdepths=0,

--- a/openquake/hazardlib/geo/geodetic.py
+++ b/openquake/hazardlib/geo/geodetic.py
@@ -217,10 +217,7 @@ def _reshape(array, orig_shape):
 
 def min_geodetic_distance(mlons, mlats, slons, slats, diameter=2*EARTH_RADIUS):
     """
-    Same as :func:`min_distance`, but calculates only minimum geodetic distance
-    (doesn't accept depth values).
-
-    This is an optimized version of :meth:`min_distance` that is suitable
+    Small wrapper around :func:`pure_distances`, suitable
     for calculating the minimum distance between first mesh and each point
     of the second mesh when both are defined on the earth surface.
     """

--- a/openquake/hazardlib/geo/geodetic.py
+++ b/openquake/hazardlib/geo/geodetic.py
@@ -308,7 +308,7 @@ def min_distance(mlons, mlats, mdepths, slons, slats, sdepths, indices=False):
     cos_mlats = numpy.cos(mlats)
     cos_slats = numpy.cos(slats)
 
-    dist_squares = (
+    dist_squares = numpy.array([
         # next five lines are the same as in geodetic_distance()
         (numpy.arcsin(numpy.sqrt(
             numpy.sin((mlats - slats[i]) / 2.0) ** 2.0
@@ -317,13 +317,11 @@ def min_distance(mlons, mlats, mdepths, slons, slats, sdepths, indices=False):
         ).clip(-1., 1.)) * (2 * EARTH_RADIUS)) ** 2
         + (mdepths - sdepths[i]) ** 2
         for i in range(len(slats))
-    )
+    ])
     if not indices:
-        result = numpy.array([numpy.sqrt(numpy.min(dist_sq))
-                              for dist_sq in dist_squares])
+        result = numpy.sqrt(dist_squares.min(axis=1))
     else:
-        result = numpy.array([numpy.argmin(dsq, axis=-1)
-                              for dsq in dist_squares])
+        result = dist_squares.argmin(axis=1)
 
     return reshape(result, orig_shape)
 

--- a/openquake/hazardlib/geo/geodetic.py
+++ b/openquake/hazardlib/geo/geodetic.py
@@ -239,7 +239,7 @@ def min_geodetic_distance(mlons, mlats, slons, slats, diameter=2*EARTH_RADIUS):
     mlons, mlats, slons, slats = _prepare_coords(mlons, mlats, slons, slats)
     cos_mlats = numpy.cos(mlats)
     cos_slats = numpy.cos(slats)
-    if len(mlons.shape) == 1:
+    if len(mlons.shape) == 1:  # fast lane
         result = numpy.zeros((len(mlons), len(slons)))
         for j in range(len(mlons)):
             a = numpy.sin((mlats[j] - slats) / 2.0)

--- a/openquake/hazardlib/geo/geodetic.py
+++ b/openquake/hazardlib/geo/geodetic.py
@@ -39,6 +39,12 @@ class GeographicObjects(object):
     to extract the closest object to a given location by calling the
     method .get_closest(lon, lat).
     """
+    @classmethod
+    def from_mesh(cls, mesh):
+        self = object.__new__(cls)
+        vars(self).update(vars(mesh))
+        return self
+
     def __init__(self, objects, getlon=operator.attrgetter('lon'),
                  getlat=operator.attrgetter('lat')):
         self.objects = list(objects)
@@ -63,7 +69,10 @@ class GeographicObjects(object):
         if max_distance is not None:
             if min_dist > max_distance:
                 return None, None
-        return self.objects[index], min_dist
+        if hasattr(self, 'objects'):
+            return self.objects[index], min_dist
+        else:
+            return index, min_dist
 
 
 def geodetic_distance(lons1, lats1, lons2, lats2, diameter=2*EARTH_RADIUS):
@@ -317,8 +326,8 @@ def _min_idx_dst(mlons, mlats, mdepths, slons, slats, sdepths=0,
         )) * diameter) ** 2 + (mdepths - sdepths[i]) ** 2
         for i in range(len(slats))
     ])
-    min_idx = dist_squares.argmin(axis=1)
-    min_dst = numpy.sqrt(dist_squares.min(axis=1))
+    min_idx = dist_squares.argmin(axis=1)  # (n, m) -> n
+    min_dst = numpy.sqrt(dist_squares.min(axis=1))  # (n, m) -> n
     return _reshape(min_idx, orig_shape), _reshape(min_dst, orig_shape)
 
 
@@ -597,10 +606,10 @@ def _prepare_coords(lons1, lats1, lons2, lats2):
     to numpy arrays of radians. Makes sure that respective coordinates
     in pairs have the same shape.
     """
-    lons1 = numpy.array(numpy.radians(lons1))
-    lats1 = numpy.array(numpy.radians(lats1))
+    lons1 = numpy.radians(lons1)
+    lats1 = numpy.radians(lats1)
     assert lons1.shape == lats1.shape
-    lons2 = numpy.array(numpy.radians(lons2))
-    lats2 = numpy.array(numpy.radians(lats2))
+    lons2 = numpy.radians(lons2)
+    lats2 = numpy.radians(lats2)
     assert lons2.shape == lats2.shape
     return lons1, lats1, lons2, lats2

--- a/openquake/hazardlib/geo/geodetic.py
+++ b/openquake/hazardlib/geo/geodetic.py
@@ -319,13 +319,11 @@ def min_distance(mlons, mlats, mdepths, slons, slats, sdepths, indices=False):
         for i in range(len(slats))
     )
     if not indices:
-        result = numpy.fromiter((numpy.sqrt(numpy.min(dist_sq))
-                                 for dist_sq in dist_squares),
-                                dtype=float, count=len(slats))
+        result = numpy.array([numpy.sqrt(numpy.min(dist_sq))
+                              for dist_sq in dist_squares])
     else:
-        result = numpy.fromiter((numpy.argmin(dsq, axis=-1)
-                                 for dsq in dist_squares),
-                                dtype=int, count=len(slats))
+        result = numpy.array([numpy.argmin(dsq, axis=-1)
+                              for dsq in dist_squares])
 
     return reshape(result, orig_shape)
 
@@ -373,8 +371,7 @@ def intervals_between(lon1, lat1, depth1, lon2, lat2, depth2, length):
     dist_factor = (length * num_intervals) / total_distance
     return npoints_towards(
         lon1, lat1, depth1, azimuth(lon1, lat1, lon2, lat2),
-        hdist * dist_factor, vdist * dist_factor, num_intervals + 1
-    )
+        hdist * dist_factor, vdist * dist_factor, num_intervals + 1)
 
 
 def npoints_between(lon1, lat1, depth1, lon2, lat2, depth2, npoints):

--- a/openquake/hazardlib/geo/geodetic.py
+++ b/openquake/hazardlib/geo/geodetic.py
@@ -216,6 +216,12 @@ def min_distance_to_segment(seglons, seglats, lons, lats):
     return dists
 
 
+def reshape(array, orig_shape):
+    if orig_shape:
+        return array.reshape(orig_shape)
+    return array[0]  # scalar array
+
+
 def min_geodetic_distance(mlons, mlats, slons, slats):
     """
     Same as :func:`min_distance`, but calculates only minimum geodetic distance
@@ -246,12 +252,7 @@ def min_geodetic_distance(mlons, mlats, slons, slats):
         dtype=float, count=len(slats)
     ) * (2 * EARTH_RADIUS)
 
-    if not orig_shape:
-        # original target point was a scalar, so return scalar as well
-        [result] = result
-        return result
-    else:
-        return result.reshape(orig_shape)
+    return reshape(result, orig_shape)
 
 
 def min_distance(mlons, mlats, mdepths, slons, slats, sdepths, indices=False):
@@ -326,12 +327,7 @@ def min_distance(mlons, mlats, mdepths, slons, slats, sdepths, indices=False):
                                  for dsq in dist_squares),
                                 dtype=int, count=len(slats))
 
-    if not orig_shape:
-        # original target point was a scalar, so return scalar as well
-        [result] = result
-        return result
-    else:
-        return result.reshape(orig_shape)
+    return reshape(result, orig_shape)
 
 
 def intervals_between(lon1, lat1, depth1, lon2, lat2, depth2, length):

--- a/openquake/hazardlib/geo/geodetic.py
+++ b/openquake/hazardlib/geo/geodetic.py
@@ -241,17 +241,15 @@ def min_geodetic_distance(mlons, mlats, slons, slats, diameter=2*EARTH_RADIUS):
     cos_slats = numpy.cos(slats)
     result = numpy.zeros_like(slons)
     for i, slat in enumerate(slats):
-        # next five lines are the same as in geodetic_distance()
-        result[i] = numpy.arcsin(numpy.sqrt(
-            numpy.sin((mlats - slat) / 2.0) ** 2.0
-            + cos_mlats * cos_slats[i]
-            * numpy.sin((mlons - slons[i]) / 2.0) ** 2.0
-        )).min() * diameter
-    return result
+        a = numpy.sin((mlats - slat) / 2.0)
+        b = numpy.sin((mlons - slons[i]) / 2.0)
+        result[i] = numpy.arcsin(
+            numpy.sqrt(a * a + cos_mlats * cos_slats[i] * b * b)).min()
+    return result * diameter
 
 
 def min_idx_dst(mlons, mlats, mdepths, slons, slats, sdepths=0,
-                 diameter=2*EARTH_RADIUS):
+                diameter=2*EARTH_RADIUS):
     """
     Calculate the minimum distance between a collection of points and a point.
 

--- a/openquake/hazardlib/geo/geodetic.py
+++ b/openquake/hazardlib/geo/geodetic.py
@@ -239,8 +239,8 @@ def min_geodetic_distance(mlons, mlats, slons, slats, diameter=2*EARTH_RADIUS):
     mlons, mlats, slons, slats = _prepare_coords(mlons, mlats, slons, slats)
     cos_mlats = numpy.cos(mlats)
     cos_slats = numpy.cos(slats)
-    if mlons.shape == (4,):  # planar surface to mesh distance
-        result = numpy.zeros((4, len(slons)))
+    if len(mlons.shape) == 1:
+        result = numpy.zeros((len(mlons), len(slons)))
         for j in range(len(mlons)):
             a = numpy.sin((mlats[j] - slats) / 2.0)
             b = numpy.sin((mlons[j] - slons) / 2.0)

--- a/openquake/hazardlib/geo/geodetic.py
+++ b/openquake/hazardlib/geo/geodetic.py
@@ -442,7 +442,6 @@ def npoints_towards(lon, lat, depth, azimuth, hdist, vdist, npoints):
     cos_lat = numpy.cos(rlat)
 
     sin_lats = sin_lat * cos_dists + cos_lat * sin_dists * numpy.cos(tc)
-    sin_lats = sin_lats.clip(-1., 1.)
     lats = numpy.degrees(numpy.arcsin(sin_lats))
 
     dlon = numpy.arctan2(numpy.sin(tc) * sin_dists * cos_lat,
@@ -488,7 +487,6 @@ def point_at(lon, lat, azimuth, distance):
     cos_lat = numpy.cos(lat)
 
     sin_lats = sin_lat * cos_dists + cos_lat * sin_dists * numpy.cos(tc)
-    sin_lats = sin_lats.clip(-1., 1.)
     lats = numpy.degrees(numpy.arcsin(sin_lats))
 
     dlon = numpy.arctan2(numpy.sin(tc) * sin_dists * cos_lat,
@@ -539,7 +537,7 @@ def distance_to_semi_arc(alon, alat, aazimuth, plons, plats):
         t_angle = (azimuth_to_target[idx] - aazimuth + 360) % 360
         angle = numpy.arccos((numpy.sin(numpy.radians(t_angle)) *
                               numpy.sin(distance_to_target /
-                                        EARTH_RADIUS)).clip(-1, 1))
+                                        EARTH_RADIUS)))
         distance[idx] = (numpy.pi / 2 - angle) * EARTH_RADIUS
 
     # Compute the distance between the reference point and the set of sites
@@ -588,7 +586,7 @@ def distance_to_arc(alon, alat, aazimuth, plons, plats):
     # http://en.wikipedia.org/wiki/Spherical_trigonometry#Napier.27s_Pentagon
     angle = numpy.arccos(
         (numpy.sin(numpy.radians(t_angle))
-         * numpy.sin(distance_to_target / EARTH_RADIUS)).clip(-1, 1)
+         * numpy.sin(distance_to_target / EARTH_RADIUS))
     )
     return (numpy.pi / 2 - angle) * EARTH_RADIUS
 

--- a/openquake/hazardlib/geo/geodetic.py
+++ b/openquake/hazardlib/geo/geodetic.py
@@ -39,12 +39,6 @@ class GeographicObjects(object):
     to extract the closest object to a given location by calling the
     method .get_closest(lon, lat).
     """
-    @classmethod
-    def from_mesh(cls, mesh):
-        self = object.__new__(cls)
-        vars(self).update(vars(mesh))
-        return self
-
     def __init__(self, objects, getlon=operator.attrgetter('lon'),
                  getlat=operator.attrgetter('lat')):
         self.objects = list(objects)
@@ -69,10 +63,7 @@ class GeographicObjects(object):
         if max_distance is not None:
             if min_dist > max_distance:
                 return None, None
-        if hasattr(self, 'objects'):
-            return self.objects[index], min_dist
-        else:
-            return index, min_dist
+        return self.objects[index], min_dist
 
 
 def geodetic_distance(lons1, lats1, lons2, lats2, diameter=2*EARTH_RADIUS):

--- a/openquake/hazardlib/geo/geodetic.py
+++ b/openquake/hazardlib/geo/geodetic.py
@@ -237,10 +237,6 @@ def min_geodetic_distance(mlons, mlats, slons, slats, diameter=2*EARTH_RADIUS):
     of the second mesh when both are defined on the earth surface.
     """
     mlons, mlats, slons, slats = _prepare_coords(mlons, mlats, slons, slats)
-    orig_shape = slons.shape
-    if not orig_shape:
-        slons = slons.reshape((1, ))
-        slats = slats.reshape((1, ))
     cos_mlats = numpy.cos(mlats)
     cos_slats = numpy.cos(slats)
     result = numpy.zeros_like(slons)
@@ -251,7 +247,7 @@ def min_geodetic_distance(mlons, mlats, slons, slats, diameter=2*EARTH_RADIUS):
             + cos_mlats * cos_slats[i]
             * numpy.sin((mlons - slons[i]) / 2.0) ** 2.0
         )).min() * diameter
-    return _reshape(result, orig_shape)
+    return result
 
 
 def min_distance(mlons, mlats, mdepths, slons, slats, sdepths, indices=False):

--- a/openquake/hazardlib/geo/geodetic.py
+++ b/openquake/hazardlib/geo/geodetic.py
@@ -65,7 +65,7 @@ class GeographicObjects(object):
         :param max_distance: distance in km (or None)
         """
         zeros = numpy.zeros_like(self.lons)
-        index, min_dist = _min_idx_dst(self.lons, self.lats, zeros, lon, lat)
+        index, min_dist = min_idx_dst(self.lons, self.lats, zeros, lon, lat)
         if max_distance is not None:
             if min_dist > max_distance:
                 return None, None
@@ -250,7 +250,8 @@ def min_geodetic_distance(mlons, mlats, slons, slats, diameter=2*EARTH_RADIUS):
     return result
 
 
-def min_distance(mlons, mlats, mdepths, slons, slats, sdepths, indices=False):
+def min_idx_dst(mlons, mlats, mdepths, slons, slats, sdepths=0,
+                 diameter=2*EARTH_RADIUS):
     """
     Calculate the minimum distance between a collection of points and a point.
 
@@ -271,27 +272,11 @@ def min_distance(mlons, mlats, mdepths, slons, slats, sdepths, indices=False):
         Scalars, python lists or tuples or numpy arrays of the same shape,
         representing a second collection: a list of points to find a minimum
         distance from for.
-    :param indices:
-        If ``True`` -- return indices of closest points from first triple
-        of coordinates instead of the actual distances. Indices are always
-        scalar integers -- they represent indices of a point from flattened
-        form of ``mlons``, ``mlats`` and ``mdepths`` that is closest to a
-        point from ``slons``, ``slats`` and ``sdepths``. There is one integer
-        index per point in second triple of coordinates.
     :returns:
-        Minimum distance in km or indices of closest points, depending on
-        ``indices`` parameter. Result value is a scalar if ``slons``, ``slats``
-        and ``sdepths`` are scalars and numpy array of the same shape
-        of those three otherwise.
+        Indices and distances in km of the closest points. The result value is
+        a scalar if ``slons``, ``slats`` and ``sdepths`` are scalars and numpy
+        array of the same shape of those three otherwise.
     """
-    assert not indices or mlons.ndim > 0
-    min_idx, min_dst = _min_idx_dst(
-        mlons, mlats, mdepths, slons, slats, sdepths)
-    return min_idx if indices else min_dst
-
-
-def _min_idx_dst(mlons, mlats, mdepths, slons, slats, sdepths=0,
-                 diameter=2*EARTH_RADIUS):
     mlons, mlats, slons, slats = _prepare_coords(mlons, mlats, slons, slats)
     mdepths = numpy.array(mdepths, float)
     sdepths = numpy.array(sdepths, float)

--- a/openquake/hazardlib/geo/geodetic.py
+++ b/openquake/hazardlib/geo/geodetic.py
@@ -238,8 +238,15 @@ def min_geodetic_distance(mlons, mlats, slons, slats, diameter=2*EARTH_RADIUS):
     return pure_distances(mlons, mlats, slons, slats).min(axis=0) * diameter
 
 
-# distances in units of the Earth diameter
+# used to compute distances site-rupture for all sites
 def pure_distances(mlons, mlats, slons, slats):
+    """
+    :param mlons: array of m longitudes (for the rupture)
+    :param mlats: array of m latitudes (for the rupture)
+    :param slons: array of s longitudes (for the sites)
+    :param slats: array of s latitudes (for the sites)
+    :returns: array of (m, s) distances to be multiplied by the Earth diameter
+    """
     cos_mlats = numpy.cos(mlats)
     cos_slats = numpy.cos(slats)
     result = numpy.zeros((len(mlons), len(slons)))

--- a/openquake/hazardlib/geo/mesh.py
+++ b/openquake/hazardlib/geo/mesh.py
@@ -173,24 +173,6 @@ class Mesh(object):
                 return numpy.allclose(self.lons, mesh.lons, atol=tol) and\
                     numpy.allclose(self.lats, mesh.lats, atol=tol)
 
-    def get_min_distance(self, mesh):
-        """
-        Compute and return the minimum distance from the mesh to each point
-        in another mesh.
-
-        :returns:
-            numpy array of distances in km of the same shape as ``mesh``.
-
-        Method doesn't make any assumptions on arrangement of the points
-        in either mesh and instead calculates the distance from each point of
-        this mesh to each point of the target mesh and returns the lowest found
-        for each.
-
-        Uses :func:`openquake.hazardlib.geo.geodetic.min_distance`.
-        """
-        self._geodetic_min_distance(mesh)
-        return self.min_dst
-
     def get_joyner_boore_distance(self, mesh):
         """
         Compute and return Joyner-Boore distance to each point of ``mesh``.
@@ -263,13 +245,31 @@ class Mesh(object):
             polygon = polygon.buffer(self.DIST_TOLERANCE, 1)
         mesh_lons, mesh_lats = mesh.lons.take(idxs), mesh.lats.take(idxs)
         mesh_xx, mesh_yy = proj(mesh_lons, mesh_lats)
-        distances_2d = geo_utils.point_to_polygon_distance(polygon,
-                                                           mesh_xx, mesh_yy)
+        distances_2d = geo_utils.point_to_polygon_distance(
+            polygon, mesh_xx, mesh_yy)
 
         # replace geodetic distance values for points-closer-than-the-threshold
         # by more accurate point-to-polygon distance values.
         distances.put(idxs, distances_2d)
         return distances.reshape(mesh.shape)
+
+    def get_min_distance(self, mesh):
+        """
+        Compute and return the minimum distance from the mesh to each point
+        in another mesh.
+
+        :returns:
+            numpy array of distances in km of the same shape as ``mesh``.
+
+        Method doesn't make any assumptions on arrangement of the points
+        in either mesh and instead calculates the distance from each point of
+        this mesh to each point of the target mesh and returns the lowest found
+        for each.
+
+        Uses :func:`openquake.hazardlib.geo.geodetic.min_distance`.
+        """
+        self._set_idx_dst(mesh)
+        return self.min_dst
 
     def get_closest_points(self, mesh):
         """
@@ -278,12 +278,8 @@ class Mesh(object):
         :returns:
             :class:`Mesh` object of the same shape as ``mesh`` with closest
             points from this one at respective indices.
-
-        This method is in general very similar to :meth:`get_min_distance`
-        and uses the same :func:`openquake.hazardlib.geo.geodetic.min_distance`
-        internally.
         """
-        self._geodetic_min_distance(mesh)
+        self._set_idx_dst(mesh)
         lons = self.lons.take(self.min_idx)
         lats = self.lats.take(self.min_idx)
         if self.depths is None:
@@ -292,13 +288,7 @@ class Mesh(object):
             depths = self.depths.take(self.min_idx)
         return Mesh(lons, lats, depths)
 
-    def _geodetic_min_distance(self, mesh):
-        """
-        Wrapper around :func:`openquake.hazardlib.geo.geodetic.min_distance`
-        for two meshes: either (or both, or neither) can have empty depths.
-        """
-        if self.min_dst is not None:
-            return
+    def _set_idx_dst(self, mesh):
         if self.depths is None:
             depths1 = numpy.zeros_like(self.lons)
         else:
@@ -529,8 +519,8 @@ class RectangularMesh(Mesh):
             else:
                 # even number of columns, need to take two middle
                 # points on the middle row
-                lon1, lon2 = self.lons[mid_row][mid_col - 1 : mid_col + 1]
-                lat1, lat2 = self.lats[mid_row][mid_col - 1 : mid_col + 1]
+                lon1, lon2 = self.lons[mid_row][mid_col - 1: mid_col + 1]
+                lat1, lat2 = self.lats[mid_row][mid_col - 1: mid_col + 1]
                 if self.depths is not None:
                     depth1 = self.depths[mid_row][mid_col - 1]
                     depth2 = self.depths[mid_row][mid_col]
@@ -538,8 +528,8 @@ class RectangularMesh(Mesh):
             # there are even number of rows. take the row just above
             # and the one just below the middle and find middle point
             # of each
-            submesh1 = self[mid_row - 1 : mid_row]
-            submesh2 = self[mid_row : mid_row + 1]
+            submesh1 = self[mid_row - 1: mid_row]
+            submesh2 = self[mid_row: mid_row + 1]
             p1, p2 = submesh1.get_middle_point(), submesh2.get_middle_point()
             lon1, lat1, depth1 = p1.longitude, p1.latitude, p1.depth
             lon2, lat2, depth2 = p2.longitude, p2.latitude, p2.depth
@@ -776,10 +766,9 @@ class RectangularMesh(Mesh):
         in a same column), and the mean value (weighted by the mean cell
         length in each column) is returned.
         """
-        assert not 1 in self.lons.shape, (
+        assert 1 not in self.lons.shape, (
             "mean width is only defined for mesh of more than "
-            "one row and more than one column of points"
-        )
+            "one row and more than one column of points")
 
         _, cell_length, cell_width, cell_area = self.get_cell_dimensions()
 

--- a/openquake/hazardlib/geo/mesh.py
+++ b/openquake/hazardlib/geo/mesh.py
@@ -263,8 +263,6 @@ class Mesh(object):
         in either mesh and instead calculates the distance from each point of
         this mesh to each point of the target mesh and returns the lowest found
         for each.
-
-        Uses :func:`openquake.hazardlib.geo.geodetic.min_distance`.
         """
         return self._min_idx_dst(mesh)[1]
 

--- a/openquake/hazardlib/geo/mesh.py
+++ b/openquake/hazardlib/geo/mesh.py
@@ -64,8 +64,6 @@ class Mesh(object):
         self.lons = lons
         self.lats = lats
         self.depths = depths
-        self.min_idx = None
-        self.min_dst = None
 
     @classmethod
     def from_points_list(cls, points):
@@ -268,8 +266,7 @@ class Mesh(object):
 
         Uses :func:`openquake.hazardlib.geo.geodetic.min_distance`.
         """
-        self._set_idx_dst(mesh)
-        return self.min_dst
+        return self._min_idx_dst(mesh)[1]
 
     def get_closest_points(self, mesh):
         """
@@ -279,16 +276,16 @@ class Mesh(object):
             :class:`Mesh` object of the same shape as ``mesh`` with closest
             points from this one at respective indices.
         """
-        self._set_idx_dst(mesh)
-        lons = self.lons.take(self.min_idx)
-        lats = self.lats.take(self.min_idx)
+        min_idx, min_dst = self._min_idx_dst(mesh)
+        lons = self.lons.take(min_idx)
+        lats = self.lats.take(min_idx)
         if self.depths is None:
             depths = None
         else:
-            depths = self.depths.take(self.min_idx)
+            depths = self.depths.take(min_idx)
         return Mesh(lons, lats, depths)
 
-    def _set_idx_dst(self, mesh):
+    def _min_idx_dst(self, mesh):
         if self.depths is None:
             depths1 = numpy.zeros_like(self.lons)
         else:
@@ -297,7 +294,7 @@ class Mesh(object):
             depths2 = numpy.zeros_like(mesh.lons)
         else:
             depths2 = mesh.depths
-        self.min_idx, self.min_dst = geodetic.min_idx_dst(
+        return geodetic.min_idx_dst(
             self.lons, self.lats, depths1, mesh.lons, mesh.lats, depths2)
 
     def get_distance_matrix(self):

--- a/openquake/hazardlib/geo/polygon.py
+++ b/openquake/hazardlib/geo/polygon.py
@@ -108,6 +108,8 @@ class Polygon(object):
         # need to cut off the last point -- it repeats the first one
         polygon.lons, polygon.lats = proj(xx[:-1], yy[:-1], reverse=True)
         # initialize the instance (as constructor would do)
+        polygon._bbox = utils.get_spherical_bounding_box(polygon.lons,
+                                                         polygon.lats)
         polygon._polygon2d = polygon2d
         polygon._projection = proj
         return polygon

--- a/openquake/hazardlib/geo/polygon.py
+++ b/openquake/hazardlib/geo/polygon.py
@@ -47,6 +47,7 @@ class Polygon(object):
         perimeter intersects itself.
     """
     _slots_ = 'lons lats _bbox _projection _polygon2d'.split()
+    _bbox = None
 
     def __init__(self, points):
         points = utils.clean_points(points)
@@ -60,8 +61,6 @@ class Polygon(object):
         if utils.line_intersects_itself(self.lons, self.lats,
                                         closed_shape=True):
             raise ValueError('polygon perimeter intersects itself')
-
-        self._bbox = None
         self._projection = None
         self._polygon2d = None
 
@@ -109,8 +108,6 @@ class Polygon(object):
         # need to cut off the last point -- it repeats the first one
         polygon.lons, polygon.lats = proj(xx[:-1], yy[:-1], reverse=True)
         # initialize the instance (as constructor would do)
-        polygon._bbox = utils.get_spherical_bounding_box(polygon.lons,
-                                                         polygon.lats)
         polygon._polygon2d = polygon2d
         polygon._projection = proj
         return polygon

--- a/openquake/hazardlib/geo/surface/base.py
+++ b/openquake/hazardlib/geo/surface/base.py
@@ -411,12 +411,10 @@ class BaseQuadrilateralSurface(with_metaclass(abc.ABCMeta, BaseSurface)):
                                                         azimuth,
                                                         mesh.lons, mesh.lats)
                 else:
-                    tmp = geodetic.min_distance_to_segment([p1.longitude,
-                                                            p2.longitude],
-                                                           [p1.latitude,
-                                                            p2.latitude],
-                                                           mesh.lons,
-                                                           mesh.lats)
+                    tmp = geodetic.min_distance_to_segment(
+                        numpy.array([p1.longitude, p2.longitude]),
+                        numpy.array([p1.latitude, p2.latitude]),
+                        mesh.lons, mesh.lats)
                 # Correcting the sign of the distance
                 if i == 0:
                     tmp *= -1

--- a/openquake/hazardlib/source/rupture.py
+++ b/openquake/hazardlib/source/rupture.py
@@ -417,7 +417,6 @@ class ParametricProbabilisticRupture(BaseProbabilisticRupture):
         target_rup = self.surface.get_min_distance(target)
         mesh = RectangularMesh(lons=lons, lats=lats, depths=None)
         mesh_rup = self.surface.get_min_distance(mesh)
-
         target_lons = target.lons
         target_lats = target.lats
         cdpp = numpy.empty(len(target_lons))
@@ -427,10 +426,10 @@ class ParametricProbabilisticRupture(BaseProbabilisticRupture):
 
             cdpp_sites_lats = mesh.lats[(mesh_rup <= target_rup[iloc] + space)
                                         & (mesh_rup >= target_rup[iloc]
-                                           - space)]
+                                        - space)]
             cdpp_sites_lons = mesh.lons[(mesh_rup <= target_rup[iloc] + space)
                                         & (mesh_rup >= target_rup[iloc]
-                                           - space)]
+                                        - space)]
 
             dpp_sum = []
             dpp_target = self.get_dppvalue(Point(target_lon, target_lat))

--- a/openquake/hazardlib/tests/geo/geodetic_test.py
+++ b/openquake/hazardlib/tests/geo/geodetic_test.py
@@ -215,8 +215,8 @@ class GeographicObjectsTest(unittest.TestCase):
 class MinDistanceToSegmentTest(unittest.TestCase):
 
     def setUp(self):
-        self.slons = [-1.2, 1.4]
-        self.slats = [-0.3, 0.5]
+        self.slons = numpy.array([-1.2, 1.4])
+        self.slats = numpy.array([-0.3, 0.5])
 
     def test_one(self):
         # Positive distance halfspace - within segment

--- a/openquake/hazardlib/tests/geo/geodetic_test.py
+++ b/openquake/hazardlib/tests/geo/geodetic_test.py
@@ -140,12 +140,9 @@ class MinDistanceTest(unittest.TestCase):
                                  for arr in (mlons, mlats, mdepths)]
         slons, slats, sdepths = [numpy.array(arr, float)
                                  for arr in (slons, slats, sdepths)]
-        actual_indices = geodetic.min_distance(mlons, mlats, mdepths,
-                                               slons, slats, sdepths,
-                                               indices=True)
+        actual_indices, dists = geodetic.min_idx_dst(mlons, mlats, mdepths,
+                                                     slons, slats, sdepths)
         numpy.testing.assert_equal(actual_indices, expected_mpoint_indices)
-        dists = geodetic.min_distance(mlons, mlats, mdepths,
-                                      slons, slats, sdepths)
         expected_closest_mlons = mlons.flat[expected_mpoint_indices]
         expected_closest_mlats = mlats.flat[expected_mpoint_indices]
         expected_closest_mdepths = mdepths.flat[expected_mpoint_indices]
@@ -159,8 +156,8 @@ class MinDistanceTest(unittest.TestCase):
         # testing min_geodetic_distance with the same lons and lats
         min_geod_distance = geodetic.min_geodetic_distance(mlons, mlats,
                                                            slons, slats)
-        min_geo_distance2 = geodetic.min_distance(mlons, mlats, mdepths * 0,
-                                                  slons, slats, sdepths * 0)
+        min_geo_distance2 = geodetic.min_idx_dst(mlons, mlats, mdepths * 0,
+                                                 slons, slats, sdepths * 0)[1]
         numpy.testing.assert_almost_equal(min_geod_distance, min_geo_distance2)
 
     def test_one_point(self):
@@ -168,7 +165,7 @@ class MinDistanceTest(unittest.TestCase):
         mlats = numpy.array([0.0, 0.0, 0.0])
         mdepths = numpy.array([0.0, 10.0, 20.0])
 
-        self._test(mlons, mlats, mdepths, -0.05, 0.0, 0,
+        self._test(mlons, mlats, mdepths, [-0.05], [0.0], [0],
                    expected_mpoint_indices=0)
         self._test(mlons, mlats, mdepths, [-0.1], [0.0], [20.0],
                    expected_mpoint_indices=1)

--- a/openquake/hazardlib/tests/geo/geodetic_test.py
+++ b/openquake/hazardlib/tests/geo/geodetic_test.py
@@ -154,11 +154,11 @@ class MinDistanceTest(unittest.TestCase):
         self.assertTrue((dists == expected_distances).all())
 
         # testing min_geodetic_distance with the same lons and lats
-        min_geod_distance = geodetic.min_geodetic_distance(mlons, mlats,
-                                                           slons, slats)
-        min_geo_distance2 = geodetic.min_idx_dst(mlons, mlats, mdepths * 0,
-                                                 slons, slats, sdepths * 0)[1]
-        numpy.testing.assert_almost_equal(min_geod_distance, min_geo_distance2)
+        min_geo_distance = geodetic.min_geodetic_distance(mlons, mlats,
+                                                          slons, slats)
+        min_distance = geodetic.min_idx_dst(mlons, mlats, mdepths * 0,
+                                            slons, slats, sdepths * 0)[1]
+        numpy.testing.assert_almost_equal(min_geo_distance, min_distance)
 
     def test_one_point(self):
         mlons = numpy.array([-0.1, 0.0, 0.1])

--- a/openquake/hazardlib/tests/gsim/chiou_youngs_2014_test.py
+++ b/openquake/hazardlib/tests/gsim/chiou_youngs_2014_test.py
@@ -16,16 +16,15 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with OpenQuake. If not, see <http://www.gnu.org/licenses/>.
 
-from openquake.hazardlib.gsim.chiou_youngs_2014 import (ChiouYoungs2014,
-                                                        ChiouYoungs2014PEER,
-                                                        ChiouYoungs2014NearFaultEffect)
+from openquake.hazardlib.gsim.chiou_youngs_2014 import (
+    ChiouYoungs2014, ChiouYoungs2014PEER, ChiouYoungs2014NearFaultEffect)
 
 from openquake.hazardlib.tests.gsim.utils import BaseGSIMTestCase
 from openquake.hazardlib.calc import ground_motion_fields
 from openquake.hazardlib import const
 from openquake.hazardlib.imt import PGV
 from openquake.hazardlib.site import Site, SiteCollection
-from openquake.hazardlib.source.rupture import Rupture, ParametricProbabilisticRupture
+from openquake.hazardlib.source.rupture import ParametricProbabilisticRupture
 from openquake.hazardlib.tom import PoissonTOM
 from openquake.hazardlib.geo.surface import SimpleFaultSurface
 from openquake.hazardlib.geo.line import Line


### PR DESCRIPTION
Having removed the speedups, it is easy to optimize the distance computations so that we are faster than before while remaining pure Python. The trick is on the function `pure_distances`: there is an `if len(mlons) < len(slons)` that makes sure that the short loop in made in Python and the long loop in numpy (before it was the opposite).

Here are some numbers for a computation dominated by `make_context` (a reduces classical PSHA USA model with 1000 sites) which is representative of the worst case scenario:

```
master
making contexts  1,041 s
total runtime 275s

no-speedups
making contexts  1948 s
total runtime 334s

no-speedups-2
making contexts  1,032 s
total runtime 256s
```

Most large calculations are dominated by the PoEs computation, not by `making context`, so the distance computations make little difference (this is even more true for disaggregation).