### PR TITLE
Removed redundant rupture_site_filter

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,5 @@
   [Michele Simionato]
+  * Removed the rupture_site_filter from the calculators
   * Removed the speedups and optimized the distance calculations at the
     numpy level
 

--- a/openquake/hazardlib/calc/disagg.py
+++ b/openquake/hazardlib/calc/disagg.py
@@ -201,7 +201,7 @@ def disaggregation(
 # TODO: remove the duplication
 def _collect_bins_data_old(sources, site, imt, iml, gsims,
                            truncation_level, n_epsilons,
-                           source_site_filter):
+                           source_site_filter=filters.source_site_noop_filter):
     """
     Extract values of magnitude, distance, closest point, tectonic region
     types and PoE distribution.

--- a/openquake/hazardlib/calc/disagg.py
+++ b/openquake/hazardlib/calc/disagg.py
@@ -114,8 +114,7 @@ def _collect_bins_data(trt_num, source_ruptures, site, curves, src_group_id,
 def disaggregation(
         sources, site, imt, iml, gsims, truncation_level,
         n_epsilons, mag_bin_width, dist_bin_width, coord_bin_width,
-        source_site_filter=filters.source_site_noop_filter,
-        rupture_site_filter=filters.rupture_site_noop_filter):
+        source_site_filter=filters.source_site_noop_filter):
     """
     Compute "Disaggregation" matrix representing conditional probability of an
     intensity mesaure type ``imt`` exceeding, at least once, an intensity
@@ -170,9 +169,6 @@ def disaggregation(
     :param source_site_filter:
         Optional source-site filter function. See
         :mod:`openquake.hazardlib.calc.filters`.
-    :param rupture_site_filter:
-        Optional rupture-site filter function. See
-        :mod:`openquake.hazardlib.calc.filters`.
 
     :returns:
         A tuple of two items. First is itself a tuple of bin edges information
@@ -186,7 +182,7 @@ def disaggregation(
     """
     bins_data = _collect_bins_data_old(sources, site, imt, iml, gsims,
                                        truncation_level, n_epsilons,
-                                       source_site_filter, rupture_site_filter)
+                                       source_site_filter)
     if all(len(x) == 0 for x in bins_data):
         # No ruptures have contributed to the hazard level at this site.
         warnings.warn(
@@ -205,7 +201,7 @@ def disaggregation(
 # TODO: remove the duplication
 def _collect_bins_data_old(sources, site, imt, iml, gsims,
                            truncation_level, n_epsilons,
-                           source_site_filter, rupture_site_filter):
+                           source_site_filter):
     """
     Extract values of magnitude, distance, closest point, tectonic region
     types and PoE distribution.
@@ -239,8 +235,7 @@ def _collect_bins_data_old(sources, site, imt, iml, gsims,
                 _next_trt_num += 1
             tect_reg = trt_nums[tect_reg]
 
-            for rupture, r_sites in rupture_site_filter(
-                    source.iter_ruptures(), s_sites):
+            for rupture in source.iter_ruptures():
                 # extract rupture parameters of interest
                 mags.append(rupture.mag)
                 [jb_dist] = rupture.surface.get_joyner_boore_distance(sitemesh)

--- a/openquake/hazardlib/calc/filters.py
+++ b/openquake/hazardlib/calc/filters.py
@@ -55,7 +55,8 @@ a "no operation" filter (:func:`source_site_noop_filter`). There are also
 two classes `SourceSitesFilter` and `RtreeFilter` to determine the sites
 affected by a given source: the second one uses an R-tree index and it is
 faster if there are a lot of sources, i.e. if the initial time to prepare
-the index can be compensed.
+the index can be compensed. Finally, there is a function
+`filter_sites_by_distance_to_rupture` based on the Joyner-Boore distance.
 """
 import sys
 import logging

--- a/openquake/hazardlib/calc/filters.py
+++ b/openquake/hazardlib/calc/filters.py
@@ -50,9 +50,12 @@ should also perform reasonably fast (filtering stage that takes longer than
 the actual calculation on unfiltered collection only decreases performance).
 
 Module :mod:`openquake.hazardlib.calc.filters` exports one distance-based
-filter function of each kind (see :func:`SourceSitesFilter` and
-:func:`RuptureSitesFilter`) as well as "no operation" filters
-(:func:`source_site_noop_filter` and :func:`rupture_site_noop_filter`).
+filter function (see :func:`filter_sites_by_distance_to_rupture`) as well as
+a "no operation" filter (:func:`source_site_noop_filter`). There are also
+two classes `SourceSitesFilter` and `RtreeFilter` to determine the sites
+affected by a given source: the second one uses an R-tree index and it is
+faster if there are a lot of sources, i.e. if the initial time to prepare
+the index can be compensed.
 """
 import sys
 import logging

--- a/openquake/hazardlib/calc/filters.py
+++ b/openquake/hazardlib/calc/filters.py
@@ -255,35 +255,6 @@ class RtreeFilter(object):
                     yield source, s_sites
 
 
-class RuptureSitesFilter(object):
-    """
-    Rupture-site filter based on distance.
-
-    :param integration_distance:
-        Threshold distance in km, this value gets passed straight to
-        :func:`openquake.hazardlib.calc.filters.filter_sites_by_distance_to_rupture`
-        which is what is actually used for filtering.
-    """
-    def __init__(self, integration_distance):
-        self.integration_distance = integration_distance
-
-    def affected(self, source, sites):
-        """
-        Returns the ruptures within the integration distance from the source,
-        or None.
-        """
-        rupture_sites = list(self([source], sites))
-        if rupture_sites:
-            return rupture_sites[0][1]
-
-    def __call__(self, ruptures_sites):
-        for rupture, sites in ruptures_sites:
-            r_sites = filter_sites_by_distance_to_rupture(
-                rupture, self.integration_distance, sites)
-            if r_sites is not None:
-                yield rupture, r_sites
-
-
 def source_site_noop_filter(sources, sites=None):
     """
     Transparent source-site "no-op" filter -- behaves like a real filter
@@ -292,14 +263,3 @@ def source_site_noop_filter(sources, sites=None):
     return ((src, sites) for src in sources)
 source_site_noop_filter.affected = lambda src, sites=None: sites
 source_site_noop_filter.integration_distance = None
-
-
-#: Rupture-site "no-op" filter, same as :func:`source_site_noop_filter`.
-def rupture_site_noop_filter(ruptures, sites):
-    """
-    Transparent rupture-site "no-op" filter -- behaves like a real filter
-    but never filters anything out and doesn't have any overhead.
-    """
-    return ((rup, sites) for rup in ruptures)
-rupture_site_noop_filter.affected = lambda rupture, sites: sites
-rupture_site_noop_filter.integration_distance = None

--- a/openquake/hazardlib/calc/gmf.py
+++ b/openquake/hazardlib/calc/gmf.py
@@ -194,9 +194,7 @@ class GmfComputer(object):
 # this is not used in the engine; it is still useful for usage in IPython
 # when demonstrating hazardlib capabilities
 def ground_motion_fields(rupture, sites, imts, gsim, truncation_level,
-                         realizations, correlation_model=None,
-                         rupture_site_filter=filters.rupture_site_noop_filter,
-                         seed=None):
+                         realizations, correlation_model=None, seed=None):
     """
     Given an earthquake rupture, the ground motion field calculator computes
     ground shaking over a set of sites, by randomly sampling a ground shaking
@@ -232,9 +230,6 @@ def ground_motion_fields(rupture, sites, imts, gsim, truncation_level,
         :mod:`openquake.hazardlib.correlation`. Can be ``None``, in which case
         non-correlated ground motion fields are calculated. Correlation model
         is not used if ``truncation_level`` is zero.
-    :param rupture_site_filter:
-        Optional rupture-site filter function. See
-        :mod:`openquake.hazardlib.calc.filters`.
     :param int seed:
         The seed used in the numpy random number generator
     :returns:
@@ -244,18 +239,10 @@ def ground_motion_fields(rupture, sites, imts, gsim, truncation_level,
         for all sites in the collection. First dimension represents
         sites and second one is for realizations.
     """
-    r_sites = rupture_site_filter.affected(rupture, sites)
-    if r_sites is None:
-        return dict((imt, numpy.zeros((len(sites), realizations)))
-                    for imt in imts)
-    gc = GmfComputer(rupture, r_sites, [str(imt) for imt in imts], [gsim],
+    gc = GmfComputer(rupture, sites, [str(imt) for imt in imts], [gsim],
                      truncation_level, correlation_model)
     res = gc.compute(gsim, realizations, seed)
     result = {}
     for imti, imt in enumerate(gc.imts):
-        # makes sure the lenght of the arrays in output is the same as sites
-        if rupture_site_filter is not filters.rupture_site_noop_filter:
-            result[imt] = r_sites.expand(res[imti], placeholder=0)
-        else:
-            result[imt] = res[imti]
+        result[imt] = res[imti]
     return result

--- a/openquake/hazardlib/calc/gmf.py
+++ b/openquake/hazardlib/calc/gmf.py
@@ -25,8 +25,6 @@ import collections
 import numpy
 import scipy.stats
 
-from openquake.baselib.python3compat import zip
-from openquake.baselib.general import get_array
 from openquake.hazardlib.const import StdDev
 from openquake.hazardlib.calc import filters
 from openquake.hazardlib.gsim.base import ContextMaker
@@ -242,7 +240,4 @@ def ground_motion_fields(rupture, sites, imts, gsim, truncation_level,
     gc = GmfComputer(rupture, sites, [str(imt) for imt in imts], [gsim],
                      truncation_level, correlation_model)
     res = gc.compute(gsim, realizations, seed)
-    result = {}
-    for imti, imt in enumerate(gc.imts):
-        result[imt] = res[imti]
-    return result
+    return {imt: res[imti] for imti, imt in enumerate(gc.imts)}

--- a/openquake/hazardlib/calc/stochastic.py
+++ b/openquake/hazardlib/calc/stochastic.py
@@ -29,8 +29,7 @@ from openquake.hazardlib.calc import filters
 def stochastic_event_set(
         sources,
         sites=None,
-        source_site_filter=filters.source_site_noop_filter,
-        rupture_site_filter=filters.rupture_site_noop_filter):
+        source_site_filter=filters.source_site_noop_filter):
     """
     Generates a 'Stochastic Event Set' (that is a collection of earthquake
     ruptures) representing a possible *realization* of the seismicity as
@@ -75,8 +74,7 @@ def stochastic_event_set(
     # else apply filtering
     for source, s_sites in source_site_filter(sources, sites):
         try:
-            for rupture, r_sites in rupture_site_filter(
-                    source.iter_ruptures(), s_sites):
+            for rupture in source.iter_ruptures():
                 for i in range(rupture.sample_number_of_occurrences()):
                     yield rupture
         except Exception as err:

--- a/openquake/hazardlib/tests/calc/disagg_test.py
+++ b/openquake/hazardlib/tests/calc/disagg_test.py
@@ -146,7 +146,8 @@ class CollectBinsDataTestCase(_BaseDisaggTestCase):
         (mags, dists, lons, lats, trts, trt_bins, probs_no_exceed) = \
             disagg._collect_bins_data_old(
                 self.sources, self.site, self.imt, self.iml, self.gsims,
-                self.truncation_level, n_epsilons=3)
+                self.truncation_level, n_epsilons=3,
+                source_site_filter=filters.source_site_noop_filter)
 
         aae = numpy.testing.assert_array_equal
 

--- a/openquake/hazardlib/tests/calc/disagg_test.py
+++ b/openquake/hazardlib/tests/calc/disagg_test.py
@@ -146,8 +146,7 @@ class CollectBinsDataTestCase(_BaseDisaggTestCase):
         (mags, dists, lons, lats, trts, trt_bins, probs_no_exceed) = \
             disagg._collect_bins_data_old(
                 self.sources, self.site, self.imt, self.iml, self.gsims,
-                self.truncation_level, n_epsilons=3,
-                source_site_filter=filters.source_site_noop_filter)
+                self.truncation_level, n_epsilons=3)
 
         aae = numpy.testing.assert_array_equal
 

--- a/openquake/hazardlib/tests/calc/disagg_test.py
+++ b/openquake/hazardlib/tests/calc/disagg_test.py
@@ -147,9 +147,7 @@ class CollectBinsDataTestCase(_BaseDisaggTestCase):
             disagg._collect_bins_data_old(
                 self.sources, self.site, self.imt, self.iml, self.gsims,
                 self.truncation_level, n_epsilons=3,
-                source_site_filter=filters.source_site_noop_filter,
-                rupture_site_filter=filters.rupture_site_noop_filter
-                )
+                source_site_filter=filters.source_site_noop_filter)
 
         aae = numpy.testing.assert_array_equal
 
@@ -181,47 +179,6 @@ class CollectBinsDataTestCase(_BaseDisaggTestCase):
         exp_p_ne = (1 - p_one_more) ** poe
         aae(probs_no_exceed, exp_p_ne)
         self.assertEqual(trt_bins, ['trt1', 'trt2'])
-
-    def test_filters(self):
-        def source_site_filter(sources, sites):
-            for source in sources:
-                if source is self.source2:
-                    continue
-                yield source, sites
-
-        def rupture_site_filter(ruptures, sites):
-            for rupture in ruptures:
-                if rupture.mag < 6:
-                    continue
-                yield rupture, sites
-
-        (mags, dists, lons, lats, trts, trt_bins, probs_no_exceed) = \
-            disagg._collect_bins_data_old(
-                self.sources, self.site, self.imt, self.iml, self.gsims,
-                self.truncation_level, n_epsilons=3,
-                source_site_filter=source_site_filter,
-                rupture_site_filter=rupture_site_filter
-                )
-
-        aae = numpy.testing.assert_array_equal
-
-        aae(mags, [9, 6, 6, 6])
-        aae(dists, [14, 12, 12, 11])
-        aae(lons, [21, 22, 21, 22])
-        aae(lats, [44, 44, 44, 45])
-        aae(trts, [0, 0, 0, 0])
-        poe = numpy.array([
-            [0, 0, 0],
-            [0.3, 0.4, 0.3],
-            [0, 0, 0.1],
-            [0, 0, 0],
-        ])
-        p_one_more = numpy.array(
-            [0.4, 0.1, 0.1, 0.1]
-        ).reshape(4, 1)
-        exp_p_ne = (1 - p_one_more) ** poe
-        aae(probs_no_exceed, exp_p_ne)
-        self.assertEqual(trt_bins, ['trt1'])
 
 
 class DigitizeLonsTestCase(unittest.TestCase):

--- a/openquake/hazardlib/tests/calc/stochastic_test.py
+++ b/openquake/hazardlib/tests/calc/stochastic_test.py
@@ -56,34 +56,6 @@ class StochasticEventSetTestCase(unittest.TestCase):
             ))
         self.assertEqual(ses, [self.r1_1, self.r1_2, self.r1_2, self.r2_1])
 
-    def test_filter(self):
-        def extract_first_source(sources, sites):
-            for source in sources:
-                yield source, None
-                break
-        fake_sites = [1, 2, 3]
-        ses = list(
-            stochastic_event_set(
-                [self.source1, self.source2],
-                fake_sites, extract_first_source
-            ))
-        self.assertEqual(ses, [self.r1_1, self.r1_2, self.r1_2])
-
-        def extract_first_rupture(ruptures, sites):
-            for rupture in ruptures:
-                yield rupture, None
-                break
-        ses = list(
-            stochastic_event_set(
-                [self.source1, self.source2],
-                fake_sites,
-                extract_first_source,
-                extract_first_rupture
-            ))
-        self.assertEqual(ses, [self.r1_1])
-        self.source1 = self.FakeSource(1, [self.r1_1, self.r1_0, self.r1_2])
-        self.source2 = self.FakeSource(2, [self.r2_1])
-
     def test(self):
         ses = list(stochastic_event_set(
             [self.source1, self.source2]))


### PR DESCRIPTION
From the point of view of the engine the `RuptureSitesFilter` class is redundant since it is never used: the rupture filtering is done during the calculation, when `make_contexts` is called. Also, the engine has a lot of filtering tests that are better than the one in hazardlib (which are mocking everything, wheres the tests in the engine are the real ones), so even the tests are redundant. Here I am doing some cleanup.
The function `filter_sites_by_distance_to_rupture` is not removed, it has been there for years and it will keep staying, so the change will not break existing code using it (if any).

If the future a new kind of filtering will be used - i.e. Marco Pagani's fantomatic distance-magnitude filtering - it will enter through `make_contexts` (the right place, just before the distances are computed) not directly in the API of the hazardlib calculators.

The engine tests are running here: https://ci.openquake.org/job/zdevel_oq-engine/2271