### PR TITLE
Force deb arch to all

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -9,7 +9,7 @@ Homepage: http://github.com/gem/oq-hazardlib
 #Vcs-Browser: http://git.debian.org/?p=collab-maint/python-dateutil.git;a=summary
 
 Package: python-oq-hazardlib
-Architecture: any
+Architecture: all
 Conflicts: python-nhlib
 Depends: ${shlibs:Depends}, ${misc:Depends}, ${dist:Depends}, python-numpy, python-scipy, python-shapely, python-psutil, python-decorator
 Description: hazardlib is a library for performing seismic hazard analysis


### PR DESCRIPTION
Now we are on pure python. With the default one (any) the packages are built as binary packages.
We do the same in the engine control: https://github.com/gem/oq-engine/blob/master/debian/control#L10

https://ci.openquake.org/job/zdevel_oq-hazardlib/657/