### PR TITLE
Planar ry0 fix

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,7 @@
+  [Graeme Weatherill]
+  * Modifies the Ry0 calculator for the planer rupture surface to avoid
+    creating the Mesh
+
   [Michele Simionato]
   * Removed the speedups and optimized the distance calculations at the
     numpy level

--- a/openquake/hazardlib/geo/surface/planar.py
+++ b/openquake/hazardlib/geo/surface/planar.py
@@ -553,6 +553,37 @@ class PlanarSurface(BaseQuadrilateralSurface):
             mesh.lats
         )
 
+    def get_ry0_distance(self, mesh):
+        """
+        :param mesh:
+            :class:`~openquake.hazardlib.geo.mesh.Mesh` of points to calculate
+            Ry0-distance to.
+        :returns:
+            Numpy array of distances in km.
+
+        See also :meth:`superclass method <.base.BaseSurface.get_ry0_distance>`
+        for spec of input and result values.
+
+        This is version specific to the planar surface doesn't make use of the
+        mesh
+        """
+        dst1 = geodetic.distance_to_arc(self.top_left.longitude,
+                                        self.top_left.latitude,
+                                        (self.strike + 90.) % 360,
+                                        mesh.lons, mesh.lats)
+
+        dst2 = geodetic.distance_to_arc(self.top_right.longitude,
+                                        self.top_right.latitude,
+                                        (self.strike + 90.) % 360,
+                                        mesh.lons, mesh.lats)
+        # Find the points on the rupture
+
+        # Get the shortest distance from the two lines
+        idx = numpy.sign(dst1) == numpy.sign(dst2)
+        dst = numpy.zeros_like(dst1)
+        dst[idx] = numpy.fmin(np.abs(dst1[idx]), np.abs(dst2[idx]))
+        return dst
+
     def get_width(self):
         """
         Return surface's width value (in km) as computed in the constructor

--- a/openquake/hazardlib/geo/surface/planar.py
+++ b/openquake/hazardlib/geo/surface/planar.py
@@ -581,7 +581,7 @@ class PlanarSurface(BaseQuadrilateralSurface):
         # Get the shortest distance from the two lines
         idx = numpy.sign(dst1) == numpy.sign(dst2)
         dst = numpy.zeros_like(dst1)
-        dst[idx] = numpy.fmin(np.abs(dst1[idx]), np.abs(dst2[idx]))
+        dst[idx] = numpy.fmin(numpy.abs(dst1[idx]), numpy.abs(dst2[idx]))
         return dst
 
     def get_width(self):

--- a/openquake/hazardlib/tests/geo/surface/planar_test.py
+++ b/openquake/hazardlib/tests/geo/surface/planar_test.py
@@ -509,21 +509,21 @@ class PlanarSurfaceGetRy0DistanceTestCase(unittest.TestCase):
         sites = Mesh.from_points_list([Point(-0.05, 0.05),
                                        Point(-0.05, -0.05)])
         dists = surface.get_ry0_distance(sites)
-        self.assertTrue(numpy.allclose(dists, numpy.array([0.0, 0.0])))
+        numpy.testing.assert_allclose(dists, numpy.array([0.0, 0.0]))
 
     def test2_sites_parallel_to_fault_ends(self):
         surface = self._test1to7surface()
         sites = Mesh.from_points_list([Point(0.0, 0.05),
                                        Point(-0.10, -0.05)])
         dists = surface.get_ry0_distance(sites)
-        self.assertTrue(numpy.allclose(dists, numpy.array([0.0, 0.0])))
+        numpy.testing.assert_allclose(dists, numpy.array([0.0, 0.0]))
 
     def test3_sites_off_fault_ends(self):
         surface = self._test1to7surface()
         sites = Mesh.from_points_list([Point(0.05, 0.05),
                                        Point(-0.15, -0.05)])
         dists = surface.get_ry0_distance(sites)
-        self.assertTrue(numpy.allclose(dists, 5.55974422 * numpy.ones(2)))
+        numpy.testing.assert_allclose(dists, 5.55974422 * numpy.ones(2))
 
 
 class PlanarSurfaceGetTopEdgeDepthTestCase(unittest.TestCase):

--- a/openquake/hazardlib/tests/geo/surface/planar_test.py
+++ b/openquake/hazardlib/tests/geo/surface/planar_test.py
@@ -497,6 +497,35 @@ class PlanarSurfaceGetRXDistanceTestCase(unittest.TestCase):
                                3.9313415355436705, places=4)
 
 
+class PlanarSurfaceGetRy0DistanceTestCase(unittest.TestCase):
+    def _test1to7surface(self):
+        corners = [Point(0, 0, 8), Point(-0.1, 0, 8),
+                   Point(-0.1, 0, 9), Point(0, 0, 9)]
+        surface = PlanarSurface(1, 270, 90, *corners)
+        return surface
+
+    def test1_sites_within_fault_width(self):
+        surface = self._test1to7surface()
+        sites = Mesh.from_points_list([Point(-0.05, 0.05),
+                                       Point(-0.05, -0.05)])
+        dists = surface.get_ry0_distance(sites)
+        self.assertTrue(numpy.allclose(dists, numpy.array([0.0, 0.0])))
+
+    def test2_sites_parallel_to_fault_ends(self):
+        surface = self._test1to7surface()
+        sites = Mesh.from_points_list([Point(0.0, 0.05),
+                                       Point(-0.10, -0.05)])
+        dists = surface.get_ry0_distance(sites)
+        self.assertTrue(numpy.allclose(dists, numpy.array([0.0, 0.0])))
+
+    def test3_sites_off_fault_ends(self):
+        surface = self._test1to7surface()
+        sites = Mesh.from_points_list([Point(0.05, 0.05),
+                                       Point(-0.15, -0.05)])
+        dists = surface.get_ry0_distance(sites)
+        self.assertTrue(numpy.allclose(dists, 5.55974422 * numpy.ones(2)))
+
+
 class PlanarSurfaceGetTopEdgeDepthTestCase(unittest.TestCase):
     def test(self):
         corners = [Point(-0.05, -0.05, 8), Point(0.05, 0.05, 8),


### PR DESCRIPTION
The current version of the ry0 calculator for the planar fault uses the method in the base surface class, which relies on the creation of the mesh to determine the "average strike". At best this is unnecessary (the actual true strike is known from the corner points) and at worst this fails if the plane distorts such that a rectangular mesh cannot be created. This PR removes the call to the mesh and uses the strike directly.