### PR TITLE
Automatic "for release" RPM generation and custom git version in __init.py__

### DIFF
--- a/rpm/makerpm.sh
+++ b/rpm/makerpm.sh
@@ -24,14 +24,24 @@ BASE=$(cd $(dirname $0)/.. && /bin/pwd)
 
 REPO=oq-hazardlib
 BRANCH='HEAD'
+STABLE=0
 EXTRA=''
 
 while (( "$#" )); do
     case "$1" in
         "-h")
             echo "Usage: $0 [-c] [-l] [BRANCH]"
-            echo -e "\nOptions:\n\t-l: build RPM locally\n\t-c: clean build dir before starting a new build"
+            echo -e "\nOptions:\n\t-l: build RPM locally\n\t-c: clean build dir before starting a new build\n\t-r N: make a stable release"
             exit 0
+            ;;
+        "-r")
+            STABLE=1
+            shift
+            if ! [[ $1 =~ ^[0-9]+$ ]] ; then
+               echo "Error: please provide a valid PKG number" >&2; exit 1
+            fi
+            PKG="$1"
+            shift
             ;;
         "-l")
             BUILD=1
@@ -58,17 +68,25 @@ mkdir -p build-rpm/{RPMS,SOURCES,SPECS,SRPMS}
 
 LIB=$(cut -d "-" -f 2 <<< $REPO)
 SHA=$(git rev-parse --short $BRANCH)
-VER=$(cat openquake/${LIB}/__init__.py | sed -n "s/^__version__[  ]*=[    ]*['\"]\([^'\"]\+\)['\"].*/\1/gp")
+VER=$(cat openquake/hazardlib/__init__.py | sed -n "s/^__version__[  ]*=[    ]*['\"]\([^'\"]\+\)['\"].*/\1/gp")
 TIME=$(date +"%s")
 echo "$LIB - $BRANCH - $SHA - $VER"
 
-sed "s/##_repo_##/${REPO}/g;s/##_version_##/${VER}/g;s/##_release_##/git${SHA}/g;s/##_timestamp_##/${TIME}/g" rpm/python-${REPO}.spec.inc > build-rpm/SPECS/python-${REPO}.spec
+sed "s/##_stable_##/${STABLE}/g;s/##_repo_##/${REPO}/g;s/##_version_##/${VER}/g;s/##_timestamp_##/${TIME}/g" rpm/python-${REPO}.spec.inc > build-rpm/SPECS/python-${REPO}.spec
 
-git archive --format=tar --prefix=${REPO}-${VER}-git${SHA}/ $BRANCH | gzip -9 > build-rpm/SOURCES/${REPO}-${VER}-git${SHA}.tar.gz
+if [ "$STABLE" == "1" ]; then
+    git archive --format=tar --prefix=${REPO}-${VER}/ $BRANCH | gzip -9 > build-rpm/SOURCES/${REPO}-${VER}.tar.gz
+    sed -i "s/##_release_##/${PKG}/g" build-rpm/SPECS/python-${REPO}.spec
+    OUT=python-${REPO}-${VER}-${PKG}.src.rpm
+else
+    git archive --format=tar --prefix=${REPO}-${VER}-git${SHA}/ $BRANCH | gzip -9 > build-rpm/SOURCES/${REPO}-${VER}-git${SHA}.tar.gz
+    sed -i "s/##_release_##/git${SHA}/g" build-rpm/SPECS/python-${REPO}.spec
+    OUT=python-${REPO}-${VER}-${TIME}_git${SHA}.src.rpm
+fi
 
 mock -r openquake --buildsrpm --spec build-rpm/SPECS/python-${REPO}.spec --source build-rpm/SOURCES --resultdir=build-rpm/SRPMS/
 if [ "$BUILD" == "1" ]; then
-    mock -r openquake build-rpm/SRPMS/python-${REPO}-${VER}-${TIME}_git${SHA}.src.rpm --resultdir=build-rpm/RPMS $EXTRA
+    mock -r openquake build-rpm/SRPMS/${OUT} --resultdir=build-rpm/RPMS $EXTRA
 fi
 
 cd $CUR

--- a/rpm/python-oq-hazardlib.spec.inc
+++ b/rpm/python-oq-hazardlib.spec.inc
@@ -1,3 +1,4 @@
+%define oqstable ##_stable_##
 %define oqrepo ##_repo_##
 %define oqversion ##_version_##
 %define oqrelease ##_release_##
@@ -7,11 +8,17 @@
 Summary: hazardlib is a library for performing seismic hazard analysis
 Name: %{oqname}
 Version: %{oqversion}
-Release: %{oqtimestamp}_%{oqrelease}
-Source0: %{oqrepo}-%{oqversion}-%{oqrelease}.tar.gz
 License: AGPLv3
 Group: Applications/Engineering
+%if %{oqstable} == 1
+Release: %{oqrelease}
+Source0: %{oqrepo}-%{oqversion}.tar.gz
+BuildRoot: %{_tmppath}/%{oqname}-%{oqversion}-buildroot
+%else
+Release: %{oqtimestamp}_%{oqrelease}
+Source0: %{oqrepo}-%{oqversion}-%{oqrelease}.tar.gz
 BuildRoot: %{_tmppath}/%{oqname}-%{oqversion}-%{oqrelease}-buildroot
+%endif
 Prefix: %{_prefix}
 BuildArch: noarch
 Vendor: The GEM OpenQuake team <devops@openquake.org>
@@ -50,7 +57,11 @@ Copyright (C) 2014-2016 GEM Foundation
 
 
 %prep
+%if %{oqstable} == 1
+%setup -n %{oqrepo}-%{oqversion} -n %{oqrepo}-%{oqversion}
+%else
 %setup -n %{oqrepo}-%{oqversion}-%{oqrelease} -n %{oqrepo}-%{oqversion}-%{oqrelease}
+%endif
 
 %build
 env CFLAGS="$RPM_OPT_FLAGS" python setup.py build
@@ -69,5 +80,10 @@ rm -rf %{buildroot}
 %doc CONTRIBUTORS.txt LICENSE README.md doc
 
 %changelog
+%if %{oqstable} == 1
+* %(date -d @%{oqtimestamp} '+%a %b %d %Y') GEM Automatic Packager <gem-autopack@openquake.org> %{oqversion}-%{oqrelease}
+– Stable release of %{oqname}
+%else
 * %(date -d @%{oqtimestamp} '+%a %b %d %Y') GEM Automatic Packager <gem-autopack@openquake.org> %{oqversion}-%{oqtimestamp}_%{oqrelease}
 – Unstable release of %{oqname}
+%endif

--- a/rpm/python-oq-hazardlib.spec.inc
+++ b/rpm/python-oq-hazardlib.spec.inc
@@ -70,6 +70,7 @@ env CFLAGS="$RPM_OPT_FLAGS" python setup.py build
 #nosetests -v -a '!slow' --with-doctest --with-coverage --cover-package=openquake.hazardlib
 
 %install
+sed -i "s/^__version__[  ]*=.*/__version__ = '%{oqversion}-%{oqrelease}'/g" openquake/hazardlib/__init__.py
 python setup.py install --single-version-externally-managed -O1 --root=%{buildroot} --record=INSTALLED_FILES
 
 %clean


### PR DESCRIPTION
This PR adds two features:
- Generation of a "for release" RPM package is fully automatic now (as it was for "master" packages) using the `-r N` flag where N is the number of the package release (1, 2...)
- A custom version, which includes the git short commit, is put in the `__init.py__`

Test: https://ci.openquake.org/job/redhat_oq-hazardlib/50/