### PR TITLE
Azimuth

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,6 @@
+  [Marco Pagani]
+  * Add the azimuth 'distance' parameter
+
   [Michele Simionato]
   * Removed the speedups and optimized the distance calculations at the
     numpy level

--- a/openquake/hazardlib/geo/surface/base.py
+++ b/openquake/hazardlib/geo/surface/base.py
@@ -595,7 +595,7 @@ class BaseQuadrilateralSurface(with_metaclass(abc.ABCMeta, BaseSurface)):
         :parameter mesh:
             An instance of  :class:`openquake.hazardlib.geo.mesh`
         :return:
-            An instance of :class:`numpy.ndarray`
+            An instance of `numpy.ndarray`
         """
         # Get info about the rupture
         strike = self.get_strike()

--- a/openquake/hazardlib/geo/surface/base.py
+++ b/openquake/hazardlib/geo/surface/base.py
@@ -583,3 +583,28 @@ class BaseQuadrilateralSurface(with_metaclass(abc.ABCMeta, BaseSurface)):
                            mesh.lats[y_node][x_node],
                            mesh.depths[y_node][x_node])
         return hypocentre
+
+    def get_azimuth(self, mesh):
+        """
+        This method computes the azimuth of a set of points in a
+        :class:`openquake.hazardlib.geo.mesh` instance. The reference used for
+        the calculation of azimuth is the middle point and the strike of the
+        rupture. The value of azimuth computed corresponds to the angle
+        measured in a clockwise direction from the strike of the rupture.
+
+        :parameter mesh:
+            An instance of  :class:`openquake.hazardlib.geo.mesh`
+        :return:
+            An instance of :class:`numpy.ndarray`
+        """
+        # Get info about the rupture
+        strike = self.get_strike()
+        print strike
+        hypocenter = self.get_middle_point()
+        # This is the azimuth from the north of each point Vs. the middle of
+        # the rupture
+        azim = geodetic.azimuth(hypocenter.longitude, hypocenter.latitude,
+                                mesh.lons, mesh.lats)
+        # Compute the azimuth from the fault strike
+        rel_azi = (azim - strike) % 360
+        return rel_azi

--- a/openquake/hazardlib/geo/surface/base.py
+++ b/openquake/hazardlib/geo/surface/base.py
@@ -599,7 +599,6 @@ class BaseQuadrilateralSurface(with_metaclass(abc.ABCMeta, BaseSurface)):
         """
         # Get info about the rupture
         strike = self.get_strike()
-        print strike
         hypocenter = self.get_middle_point()
         # This is the azimuth from the north of each point Vs. the middle of
         # the rupture

--- a/openquake/hazardlib/gsim/base.py
+++ b/openquake/hazardlib/gsim/base.py
@@ -130,6 +130,8 @@ def get_distances(rupture, mesh, param='rjb'):
         dist = rupture.hypocenter.distance_to_mesh(mesh, with_depths=False)
     elif param == 'rcdpp':
         dist = rupture.get_cdppvalue(mesh)
+    elif param == 'azimuth':
+        dist = rupture.surface.get_azimuth(mesh)
     else:
         raise ValueError('Unknown distance measure %r' % param)
     return dist

--- a/openquake/hazardlib/tests/geo/surface/base_surface_test.py
+++ b/openquake/hazardlib/tests/geo/surface/base_surface_test.py
@@ -373,3 +373,29 @@ class GetMiddlePointTestCase(unittest.TestCase):
         self.assertTrue(
             Point(0.0, 0.044966, 5.0) == surface.get_middle_point()
         )
+
+
+class GetAzimuthTestCase(unittest.TestCase):
+    def test_01(self):
+        corners = [[(0.0, 0.0, 0.0), (0.0, 0.1, 0.0)],
+                   [(0.0, 0.0, 10.0), (0.0, 0.1, 10.0)]]
+        surface = DummySurface(corners)
+        mesh = Mesh.from_points_list([Point(0.0, 0.2),
+                                      Point(0.1, 0.05),
+                                      Point(0.0, -0.2)])
+        azimuths = surface.get_azimuth(mesh)
+        expected = numpy.array([0, 90, 180])
+        azimuths[azimuths>180] = azimuths[azimuths>180]-360
+        print expected, azimuths
+        numpy.testing.allclose()
+
+    def test_02(self):
+        corners = [[(-1.0, 0.0, 0.0), (1.0, 0.0, 0.0)],
+                   [(-1.0, 0.0, 10.0), (1.0, 0.0, 10.0)]]
+        surface = DummySurface(corners)
+        mesh = Mesh.from_points_list([Point(0.0, 0.2),
+                                      Point(0.0, -0.2),
+                                      Point(-0.1, 0.1)])
+        azimuths = surface.get_azimuth(mesh)
+        expected = numpy.array([270., 90., 225.])
+        numpy.testing.assert_almost_equal(expected, azimuths, 1e-2)

--- a/openquake/hazardlib/tests/geo/surface/base_surface_test.py
+++ b/openquake/hazardlib/tests/geo/surface/base_surface_test.py
@@ -387,7 +387,7 @@ class GetAzimuthTestCase(unittest.TestCase):
         expected = numpy.array([0, 90, 180])
         azimuths[azimuths>180] = azimuths[azimuths>180]-360
         print expected, azimuths
-        numpy.testing.allclose()
+        numpy.testing.assert_almost_equal(expected, azimuths, 1)
 
     def test_02(self):
         corners = [[(-1.0, 0.0, 0.0), (1.0, 0.0, 0.0)],
@@ -398,4 +398,4 @@ class GetAzimuthTestCase(unittest.TestCase):
                                       Point(-0.1, 0.1)])
         azimuths = surface.get_azimuth(mesh)
         expected = numpy.array([270., 90., 225.])
-        numpy.testing.assert_almost_equal(expected, azimuths, 1e-2)
+        numpy.testing.assert_almost_equal(expected, azimuths, 2)

--- a/openquake/hazardlib/tests/gsim/base_test.py
+++ b/openquake/hazardlib/tests/gsim/base_test.py
@@ -359,12 +359,17 @@ class MakeContextsTestCase(_FakeGSIMTestCase):
         rx_distance = numpy.array([4, 5])
         jb_distance = numpy.array([6, 7])
         ry0_distance = numpy.array([8, 9])
+        azimuth = numpy.array([12, 34])
         top_edge_depth = 30
         width = 15
         strike = 60.123
 
         class FakeSurface(object):
             call_counts = collections.Counter()
+
+            def get_azimuth(self):
+                self.call_counts['get_azimuth'] += 1
+                return azimuth
 
             def get_strike(self):
                 self.call_counts['get_strike'] += 1
@@ -451,7 +456,7 @@ class MakeContextsTestCase(_FakeGSIMTestCase):
 
     def test_all_values(self):
         self.gsim_class.REQUIRES_DISTANCES = set(
-            'rjb rx rrup repi rhypo ry0'.split()
+            'rjb rx rrup repi rhypo ry0 azimuth'.split()
         )
         self.gsim_class.REQUIRES_RUPTURE_PARAMETERS = set(
             'mag rake strike dip ztor hypo_lon hypo_lat hypo_depth width'.
@@ -484,6 +489,7 @@ class MakeContextsTestCase(_FakeGSIMTestCase):
         self.assertTrue((dctx.rx == [4, 5]).all())
         self.assertTrue((dctx.ry0 == [8, 9]).all())
         self.assertTrue((dctx.rrup == [10, 11]).all())
+        self.assertTrue((dctx.azimuth == [12, 34]).all())
         numpy.testing.assert_almost_equal(dctx.rhypo,
                                           [162.18749272, 802.72247682])
         numpy.testing.assert_almost_equal(dctx.repi,

--- a/openquake/hazardlib/tests/gsim/base_test.py
+++ b/openquake/hazardlib/tests/gsim/base_test.py
@@ -367,7 +367,7 @@ class MakeContextsTestCase(_FakeGSIMTestCase):
         class FakeSurface(object):
             call_counts = collections.Counter()
 
-            def get_azimuth(self):
+            def get_azimuth(self, mesh):
                 self.call_counts['get_azimuth'] += 1
                 return azimuth
 
@@ -498,7 +498,8 @@ class MakeContextsTestCase(_FakeGSIMTestCase):
                          {'get_top_edge_depth': 1, 'get_rx_distance': 1,
                           'get_joyner_boore_distance': 1, 'get_dip': 1,
                           'get_min_distance': 1, 'get_width': 1,
-                          'get_strike': 1, 'get_ry0_distance': 1})
+                          'get_strike': 1, 'get_ry0_distance': 1,
+                          'get_azimuth': 1})
 
     def test_some_values(self):
         self.gsim_class.REQUIRES_DISTANCES = set('rjb rx'.split())
@@ -522,6 +523,7 @@ class MakeContextsTestCase(_FakeGSIMTestCase):
         self.assertFalse(hasattr(sctx, 'vs30measured'))
         self.assertFalse(hasattr(sctx, 'z2pt0'))
         self.assertFalse(hasattr(dctx, 'rrup'))
+        self.assertFalse(hasattr(dctx, 'azimuth'))
         self.assertFalse(hasattr(dctx, 'ztor'))
         self.assertFalse(hasattr(dctx, 'width'))
         self.assertEqual(self.fake_surface.call_counts,


### PR DESCRIPTION
This PR adds a new 'distance' parameter i.e. the azimuth of the site referred to the point in the middle of the rupture. The origin used for computing the azimuth is the strike direction. This means that a point on a line passing through the middle of the rupture and with direction equal to the strike will have an azimuth equal to 0.