### PR TITLE
vdist should be a float in npoints_towards function

### DIFF
--- a/openquake/hazardlib/geo/geodetic.py
+++ b/openquake/hazardlib/geo/geodetic.py
@@ -416,7 +416,7 @@ def npoints_towards(lon, lat, depth, azimuth, hdist, vdist, npoints):
     hdists = numpy.arange(npoints, dtype=float)
     hdists *= (hdist / EARTH_RADIUS) / (npoints - 1)
     vdists = numpy.arange(npoints, dtype=float)
-    vdists *= vdist / (npoints - 1)
+    vdists *= float(vdist) / (npoints - 1)
 
     sin_dists = numpy.sin(hdists)
     cos_dists = numpy.cos(hdists)

--- a/openquake/hazardlib/geo/geodetic.py
+++ b/openquake/hazardlib/geo/geodetic.py
@@ -20,6 +20,7 @@
 Module :mod:`openquake.hazardlib.geo.geodetic` contains functions for geodetic
 transformations, optimized for massive calculations.
 """
+from __future__ import division
 
 import operator
 
@@ -416,7 +417,7 @@ def npoints_towards(lon, lat, depth, azimuth, hdist, vdist, npoints):
     hdists = numpy.arange(npoints, dtype=float)
     hdists *= (hdist / EARTH_RADIUS) / (npoints - 1)
     vdists = numpy.arange(npoints, dtype=float)
-    vdists *= float(vdist) / (npoints - 1)
+    vdists *= vdist / (npoints - 1)
 
     sin_dists = numpy.sin(hdists)
     cos_dists = numpy.cos(hdists)

--- a/openquake/hazardlib/tests/geo/geodetic_test.py
+++ b/openquake/hazardlib/tests/geo/geodetic_test.py
@@ -397,10 +397,10 @@ class NPointsTowardsTest(unittest.TestCase):
         )
         expected_lons = [0, 0, 0, 0, 0, 0, 0]
         expected_lats = [0, 0, 0, 0, 0, 0, 0]
-        expected_depths = [0, 0.83333, 1.66667, 2.5, 3.33333, 4.16667, 5]
-        self.assertTrue(numpy.allclose(lons, expected_lons))
-        self.assertTrue(numpy.allclose(lats, expected_lats))
-        self.assertTrue(numpy.allclose(depths, expected_depths))
+        expected_depths = [0, 0.8333333, 1.6666667, 2.5, 3.3333333, 4.1666667, 5]
+        numpy.testing.assert_almost_equal(lons, expected_lons)
+        numpy.testing.assert_almost_equal(lats, expected_lats)
+        numpy.testing.assert_almost_equal(depths, expected_depths)
         self.assertEqual(lons[0], 0)
         self.assertEqual(lats[0], 0)
         self.assertEqual(depths[0], 0)

--- a/openquake/hazardlib/tests/geo/geodetic_test.py
+++ b/openquake/hazardlib/tests/geo/geodetic_test.py
@@ -390,6 +390,21 @@ class NPointsTowardsTest(unittest.TestCase):
         self.assertTrue(numpy.allclose(lats, expected_lats))
         self.assertTrue(numpy.allclose(depths, expected_depths))
 
+    def test_input_as_int(self):
+        lons, lats, depths = geodetic.npoints_towards(
+            lon=0, lat=0, depth=0, azimuth=0,
+            hdist=0, vdist=5, npoints=7
+        )
+        expected_lons = [0, 0, 0, 0, 0, 0, 0]
+        expected_lats = [0, 0, 0, 0, 0, 0, 0]
+        expected_depths = [0, 0.83333, 1.66667, 2.5, 3.33333, 4.16667, 5]
+        self.assertTrue(numpy.allclose(lons, expected_lons))
+        self.assertTrue(numpy.allclose(lats, expected_lats))
+        self.assertTrue(numpy.allclose(depths, expected_depths))
+        self.assertEqual(lons[0], 0)
+        self.assertEqual(lats[0], 0)
+        self.assertEqual(depths[0], 0)
+
 
 class IntervalsBetweenTest(unittest.TestCase):
     # values in this test have not been checked by hand


### PR DESCRIPTION
The npoints_towards() function does not ensure that the argument specifying the vertical distance (vdist) is turned into a float, and hence the output can be wrong. 

For example, npoints_towards(0,0,0,0,0,5,7) should give a list of 7 points equally spaced between 0 and 5km depth, but instead returns 7 points which are all (0.0, 0.0, 0.0)
