### PR TITLE
Made RtreeFilter instances pickleable

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,5 +1,5 @@
   [Michele Simionato]
-  * Used the Rtree filter also in the workers
+  * Made the RtreeFilter pickleable
   * Made the FilteredSiteCollections serializable to HDF5
 
   [Daniele Viganò]

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,5 @@
   [Michele Simionato]
+  * Used the Rtree filter also in the workers
   * Made the FilteredSiteCollections serializable to HDF5
 
   [Daniele Viganò]

--- a/openquake/hazardlib/calc/filters.py
+++ b/openquake/hazardlib/calc/filters.py
@@ -144,13 +144,13 @@ class RtreeFilter(object):
     :param rtree:
         the rtree module or None if not available
     """
-    def __init__(self, sitecol, integration_distance, rtree=rtree):
+    def __init__(self, sitecol, integration_distance, use_rtree=True):
         assert integration_distance, 'Must be set'
         self.integration_distance = integration_distance
         self.sitecol = sitecol
-        self.rtree = rtree
+        self.use_rtree = use_rtree
         fixed_lons, self.idl = fix_lons_idl(sitecol.lons)
-        if rtree:
+        if use_rtree:
             self.index = rtree.index.Index()
             for sid, lon, lat in zip(sitecol.sids, fixed_lons, sitecol.lats):
                 self.index.insert(sid, (lon, lat, lon, lat))
@@ -200,7 +200,7 @@ class RtreeFilter(object):
         if sites is None:
             sites = self.sitecol
         for source in sources:
-            if self.rtree:  # Rtree filtering
+            if self.use_rtree:  # Rtree filtering
                 box = self.get_affected_box(source)
                 sids = numpy.array(sorted(self.index.intersection(box)))
                 if len(sids):

--- a/openquake/hazardlib/calc/filters.py
+++ b/openquake/hazardlib/calc/filters.py
@@ -69,7 +69,7 @@ except ImportError:
     logging.warn('Cannot find the rtree module, using slow filtering')
 from openquake.baselib.python3compat import raise_
 from openquake.hazardlib.site import FilteredSiteCollection
-from openquake.hazardlib.geo.utils import fix_lons_idl
+from openquake.hazardlib.geo.utils import fix_lons_idl, cross_idl
 
 
 @contextmanager
@@ -150,11 +150,9 @@ class RtreeFilter(object):
         self.sitecol = sitecol
         self.rtree = rtree
         fixed_lons, self.idl = fix_lons_idl(sitecol.lons)
-        if self.idl:  # longitudes -> longitudes + 360 degrees
-            sitecol.complete.lons[sitecol.sids] = fixed_lons
         if rtree:
             self.index = rtree.index.Index()
-            for sid, lon, lat in zip(sitecol.sids, sitecol.lons, sitecol.lats):
+            for sid, lon, lat in zip(sitecol.sids, fixed_lons, sitecol.lats):
                 self.index.insert(sid, (lon, lat, lon, lat))
 
     def get_affected_box(self, src):

--- a/openquake/hazardlib/calc/hazard_curve.py
+++ b/openquake/hazardlib/calc/hazard_curve.py
@@ -210,7 +210,7 @@ def pmap_from_grp(
     """
     if source_site_filter == 'RtreeFilter':  # default
         source_site_filter = (
-            filters.RtreeFilter(sites, maximum_distance, rtree=None)
+            filters.RtreeFilter(sites, maximum_distance)
             if maximum_distance else filters.source_site_noop_filter)
     with GroundShakingIntensityModel.forbid_instantiation():
         imtls = DictArray(imtls)

--- a/openquake/hazardlib/calc/hazard_curve.py
+++ b/openquake/hazardlib/calc/hazard_curve.py
@@ -210,7 +210,7 @@ def pmap_from_grp(
     """
     if source_site_filter == 'RtreeFilter':  # default
         source_site_filter = (
-            filters.RtreeFilter(sites, maximum_distance)
+            filters.RtreeFilter(sites, maximum_distance, use_rtree=False)
             if maximum_distance else filters.source_site_noop_filter)
     with GroundShakingIntensityModel.forbid_instantiation():
         imtls = DictArray(imtls)


### PR DESCRIPTION
This allows further simplifications, since it will become possible to pass the filter from the controller node to the workers. The engine tests are green: https://travis-ci.org/gem/oq-engine/builds/177894918