### PR TITLE
Changed the API of `pmap_from_grp` and `calc_hazard_curves`

### DIFF
--- a/openquake/hazardlib/calc/disagg.py
+++ b/openquake/hazardlib/calc/disagg.py
@@ -64,7 +64,7 @@ def _disagg(iml, poes, curve_poes, imls, gsim, rupture, rlzi, imt, imt_str,
 
 def _collect_bins_data(trt_num, sources, site, curves, src_group_id,
                        rlzs_assoc, gsims, imtls, poes, truncation_level,
-                       n_epsilons, iml_disagg, ss_filter, mon):
+                       n_epsilons, iml_disagg, mon):
     # returns a BinData instance
     sitecol = SiteCollection([site])
     mags = []

--- a/openquake/hazardlib/calc/filters.py
+++ b/openquake/hazardlib/calc/filters.py
@@ -148,10 +148,9 @@ class RtreeFilter(object):
         by default True, i.e. try to use the rtree module if available
     """
     def __init__(self, sitecol, integration_distance, use_rtree=True):
-        assert integration_distance, 'Must be set'
         self.integration_distance = integration_distance
         self.sitecol = sitecol
-        self.use_rtree = use_rtree
+        self.use_rtree = use_rtree and integration_distance
         fixed_lons, self.idl = fix_lons_idl(sitecol.lons)
         if use_rtree:
             self.index = rtree.index.Index()

--- a/openquake/hazardlib/calc/filters.py
+++ b/openquake/hazardlib/calc/filters.py
@@ -123,8 +123,8 @@ def filter_sites_by_distance_to_rupture(rupture, integration_distance, sites):
 
 class SourceFilter(object):
     """
-    The SourceFilter uses the rtree library if available. The index is generated
-    at instantiation time and kept in memory, so the filter should be
+    The SourceFilter uses the rtree library if available. The index is
+    generated at instantiation time and kept in memory. The filter should be
     instantiated only once per calculation, after the site collection is
     known. It should be used as follows::
 
@@ -150,7 +150,7 @@ class SourceFilter(object):
     def __init__(self, sitecol, integration_distance, use_rtree=True):
         self.integration_distance = integration_distance
         self.sitecol = sitecol
-        self.use_rtree = use_rtree and integration_distance
+        self.use_rtree = use_rtree and integration_distance and rtree
         if self.use_rtree:
             fixed_lons, self.idl = fix_lons_idl(sitecol.lons)
             self.index = rtree.index.Index()

--- a/openquake/hazardlib/calc/filters.py
+++ b/openquake/hazardlib/calc/filters.py
@@ -52,7 +52,7 @@ the actual calculation on unfiltered collection only decreases performance).
 Module :mod:`openquake.hazardlib.calc.filters` exports one distance-based
 filter function (see :func:`filter_sites_by_distance_to_rupture`) as well as
 a "no operation" filter (:func:`source_site_noop_filter`). There is
-a class `RtreeFilter` to determine the sites
+a class `SourceFilter` to determine the sites
 affected by a given source: the second one uses an R-tree index and it is
 faster if there are a lot of sources, i.e. if the initial time to prepare
 the index can be compensed. Finally, there is a function
@@ -121,19 +121,19 @@ def filter_sites_by_distance_to_rupture(rupture, integration_distance, sites):
     return sites.filter(jb_dist <= integration_distance)
 
 
-class RtreeFilter(object):
+class SourceFilter(object):
     """
-    The RtreeFilter uses the rtree library if available. The index is generated
+    The SourceFilter uses the rtree library if available. The index is generated
     at instantiation time and kept in memory, so the filter should be
     instantiated only once per calculation, after the site collection is
     known. It should be used as follows::
 
-      ss_filter = RtreeFilter(sitecol, integration_distance)
+      ss_filter = SourceFilter(sitecol, integration_distance)
       for src, sites in ss_filter(sources):
          do_something(...)
 
     As a side effect, sets the `.nsites` attribute of the source, i.e. the
-    number of sites within the integration distance. Notice that RtreeFilter
+    number of sites within the integration distance. Notice that SourceFilter
     instances can be pickled, but when unpickled the `use_rtree` flag is set to
     false and the index is lost: the reason is that libspatialindex indices
     cannot be properly pickled (https://github.com/Toblerity/rtree/issues/65).

--- a/openquake/hazardlib/calc/hazard_curve.py
+++ b/openquake/hazardlib/calc/hazard_curve.py
@@ -32,7 +32,7 @@ from openquake.baselib.general import groupby, DictArray
 from openquake.hazardlib.probability_map import ProbabilityMap
 from openquake.hazardlib.gsim.base import ContextMaker, FarAwayRupture
 from openquake.hazardlib.gsim.base import GroundShakingIntensityModel
-
+from openquake.hazardlib.calc.filters import SourceFilter
 from openquake.hazardlib.imt import from_string
 
 
@@ -113,7 +113,11 @@ def calc_hazard_curves(
         size of each field is given by the number of levels in ``imtls``.
     """
     imtls = DictArray(imtls)
-    sites = source_site_filter.sitecol
+    if hasattr(source_site_filter, 'sitecol'):  # a filter, as it should be
+        sites = source_site_filter.sitecol
+    else:  # backward compatibility, a site collection was passed
+        sites = source_site_filter
+        source_site_filter = SourceFilter(sites, None)
     sources_by_trt = groupby(
         sources, operator.attrgetter('tectonic_region_type'))
     pmap = ProbabilityMap(len(imtls.array), 1)

--- a/openquake/hazardlib/calc/hazard_curve.py
+++ b/openquake/hazardlib/calc/hazard_curve.py
@@ -30,7 +30,6 @@ from openquake.baselib.python3compat import raise_, zip
 from openquake.baselib.performance import Monitor
 from openquake.baselib.general import groupby, DictArray
 from openquake.hazardlib.probability_map import ProbabilityMap
-from openquake.hazardlib.calc import filters
 from openquake.hazardlib.gsim.base import ContextMaker, FarAwayRupture
 from openquake.hazardlib.gsim.base import GroundShakingIntensityModel
 
@@ -65,8 +64,8 @@ def agg_curves(acc, curves):
 
 
 def calc_hazard_curves(
-        sources, sites, imtls, gsim_by_trt, truncation_level=None,
-        source_site_filter=filters.source_site_noop_filter):
+        sources, source_site_filter, imtls, gsim_by_trt,
+        truncation_level=None):
     """
     Compute hazard curves on a list of sites, given a set of seismic sources
     and a set of ground shaking intensity models (one per tectonic region type
@@ -94,9 +93,8 @@ def calc_hazard_curves(
     :param sources:
         A sequence of seismic sources objects (instances of subclasses
         of :class:`~openquake.hazardlib.source.base.BaseSeismicSource`).
-    :param sites:
-        Instance of :class:`~openquake.hazardlib.site.SiteCollection` object,
-        representing sites of interest.
+    :param source_site_filter:
+        A source filter over the sites of interest
     :param imtls:
         Dictionary mapping intensity measure type strings
         to lists of intensity measure levels.
@@ -108,9 +106,6 @@ def calc_hazard_curves(
     :param truncation_level:
         Float, number of standard deviations for truncation of the intensity
         distribution.
-    :param source_site_filter:
-        Optional source-site filter function. See
-        :mod:`openquake.hazardlib.calc.filters`.
 
     :returns:
         An array of size N, where N is the number of sites, which elements
@@ -118,13 +113,13 @@ def calc_hazard_curves(
         size of each field is given by the number of levels in ``imtls``.
     """
     imtls = DictArray(imtls)
+    sites = source_site_filter.sitecol
     sources_by_trt = groupby(
         sources, operator.attrgetter('tectonic_region_type'))
     pmap = ProbabilityMap(len(imtls.array), 1)
     for trt in sources_by_trt:
-        pmap |= pmap_from_grp(
-            sources_by_trt[trt], sites, imtls, [gsim_by_trt[trt]],
-            truncation_level, source_site_filter)
+        pmap |= pmap_from_grp(sources_by_trt[trt], source_site_filter, imtls,
+                              [gsim_by_trt[trt]], truncation_level)
     return pmap.convert(imtls, len(sites))
 
 
@@ -197,9 +192,8 @@ def poe_map(src, s_sites, imtls, cmaker, trunclevel, bbs,
 
 # this is used by the engine
 def pmap_from_grp(
-        sources, sites, imtls, gsims, truncation_level=None,
-        source_site_filter='RtreeFilter', maximum_distance=None, bbs=(),
-        monitor=Monitor()):
+        sources, source_site_filter, imtls, gsims, truncation_level=None,
+        bbs=(), monitor=Monitor()):
     """
     Compute the hazard curves for a set of sources belonging to the same
     tectonic region type for all the GSIMs associated to that TRT.
@@ -208,20 +202,21 @@ def pmap_from_grp(
 
     :returns: a ProbabilityMap instance
     """
-    if source_site_filter == 'RtreeFilter':  # default
-        source_site_filter = (
-            filters.RtreeFilter(sites, maximum_distance, use_rtree=False)
-            if maximum_distance else filters.source_site_noop_filter)
+    trt = sources[0].tectonic_region_type
+    try:
+        maxdist = source_site_filter.integration_distance[trt]
+    except:
+        maxdist = source_site_filter.integration_distance
     with GroundShakingIntensityModel.forbid_instantiation():
         imtls = DictArray(imtls)
-        cmaker = ContextMaker(gsims, maximum_distance)
+        cmaker = ContextMaker(gsims, maxdist)
         ctx_mon = monitor('making contexts', measuremem=False)
         pne_mon = monitor('computing poes', measuremem=False)
         disagg_mon = monitor('get closest points', measuremem=False)
         pmap = ProbabilityMap(len(imtls.array), len(gsims))
         pmap.calc_times = []  # pairs (src_id, delta_t)
         pmap.grp_id = sources[0].src_group_id
-        for src, s_sites in source_site_filter(sources, sites):
+        for src, s_sites in source_site_filter(sources):
             t0 = time.time()
             pmap |= poe_map(src, s_sites, imtls, cmaker, truncation_level, bbs,
                             ctx_mon, pne_mon, disagg_mon)

--- a/openquake/hazardlib/calc/hazard_curve.py
+++ b/openquake/hazardlib/calc/hazard_curve.py
@@ -94,7 +94,7 @@ def calc_hazard_curves(
         A sequence of seismic sources objects (instances of subclasses
         of :class:`~openquake.hazardlib.source.base.BaseSeismicSource`).
     :param source_site_filter:
-        A source filter over the sites of interest
+        A source filter over the site collection or the site collection itself
     :param imtls:
         Dictionary mapping intensity measure type strings
         to lists of intensity measure levels.

--- a/openquake/hazardlib/source/base.py
+++ b/openquake/hazardlib/source/base.py
@@ -149,6 +149,8 @@ class BaseSeismicSource(with_metaclass(abc.ABCMeta)):
         false negatives (it's better not to filter a site out if there is some
         uncertainty about its distance).
         """
+        if integration_distance is None:  # no filtering
+            return sites
         rup_enc_poly = self.get_rupture_enclosing_polygon(integration_distance)
         return sites.filter(rup_enc_poly.intersects(sites.mesh))
 

--- a/openquake/hazardlib/tests/acceptance/peer_test.py
+++ b/openquake/hazardlib/tests/acceptance/peer_test.py
@@ -34,7 +34,6 @@ from openquake.hazardlib.geo import NodalPlane, RectangularMesh, \
 from openquake.hazardlib.scalerel import PeerMSR, PointMSR
 from openquake.hazardlib.gsim.sadigh_1997 import SadighEtAl1997
 from openquake.hazardlib.calc.hazard_curve import calc_hazard_curves
-from openquake.hazardlib.calc.filters import SourceFilter
 from openquake.hazardlib.tom import PoissonTOM
 
 from openquake.hazardlib.tests.acceptance import _peer_test_data as test_data
@@ -73,7 +72,7 @@ class Set1TestCase(unittest.TestCase):
         imts = {str(test_data.IMT): test_data.SET1_CASE10_IMLS}
 
         curves = calc_hazard_curves(
-            sources, SourceFilter(sites, None), imts, gsims, truncation_level)
+            sources, sites, imts, gsims, truncation_level)
         s1hc, s2hc, s3hc, s4hc = curves[str(test_data.IMT)]
 
         assert_hazard_curve_is(self, s1hc, test_data.SET1_CASE10_SITE1_POES,
@@ -118,7 +117,7 @@ class Set1TestCase(unittest.TestCase):
         imts = {str(test_data.IMT): test_data.SET1_CASE11_IMLS}
 
         curves = calc_hazard_curves(
-            sources, SourceFilter(sites, None), imts, gsims, truncation_level)
+            sources, sites, imts, gsims, truncation_level)
         s1hc, s2hc, s3hc, s4hc = curves[str(test_data.IMT)]
 
         assert_hazard_curve_is(self, s1hc, test_data.SET1_CASE11_SITE1_POES,
@@ -156,7 +155,7 @@ class Set1TestCase(unittest.TestCase):
         imts = {str(test_data.IMT): test_data.SET1_CASE2_IMLS}
 
         curves = calc_hazard_curves(
-            sources, SourceFilter(sites, None), imts, gsims, truncation_level)
+            sources, sites, imts, gsims, truncation_level)
         s1hc, s2hc, s3hc, s4hc, s5hc, s6hc, s7hc = curves[str(test_data.IMT)]
 
         assert_hazard_curve_is(self, s1hc, test_data.SET1_CASE2_SITE1_POES,
@@ -200,7 +199,7 @@ class Set1TestCase(unittest.TestCase):
         imts = {str(test_data.IMT): test_data.SET1_CASE5_IMLS}
 
         curves = calc_hazard_curves(
-            sources, SourceFilter(sites, None), imts, gsims, truncation_level)
+            sources, sites, imts, gsims, truncation_level)
         s1hc, s2hc, s3hc, s4hc, s5hc, s6hc, s7hc = curves[str(test_data.IMT)]
 
         assert_hazard_curve_is(self, s1hc, test_data.SET1_CASE5_SITE1_POES,
@@ -252,7 +251,7 @@ class Set1TestCase(unittest.TestCase):
         imts = {str(test_data.IMT): test_data.SET1_CASE2_IMLS}
 
         curves = calc_hazard_curves(
-            [npss], SourceFilter(sites, None), imts, gsims, truncation_level)
+            [npss], sites, imts, gsims, truncation_level)
         s1hc, s2hc, s3hc, s4hc, s5hc, s6hc, s7hc = curves[str(test_data.IMT)]
 
         assert_hazard_curve_is(self, s1hc, test_data.SET1_CASE2_SITE1_POES,

--- a/openquake/hazardlib/tests/acceptance/peer_test.py
+++ b/openquake/hazardlib/tests/acceptance/peer_test.py
@@ -34,6 +34,7 @@ from openquake.hazardlib.geo import NodalPlane, RectangularMesh, \
 from openquake.hazardlib.scalerel import PeerMSR, PointMSR
 from openquake.hazardlib.gsim.sadigh_1997 import SadighEtAl1997
 from openquake.hazardlib.calc.hazard_curve import calc_hazard_curves
+from openquake.hazardlib.calc.filters import SourceFilter
 from openquake.hazardlib.tom import PoissonTOM
 
 from openquake.hazardlib.tests.acceptance import _peer_test_data as test_data
@@ -72,7 +73,7 @@ class Set1TestCase(unittest.TestCase):
         imts = {str(test_data.IMT): test_data.SET1_CASE10_IMLS}
 
         curves = calc_hazard_curves(
-            sources, sites, imts, gsims, truncation_level)
+            sources, SourceFilter(sites, None), imts, gsims, truncation_level)
         s1hc, s2hc, s3hc, s4hc = curves[str(test_data.IMT)]
 
         assert_hazard_curve_is(self, s1hc, test_data.SET1_CASE10_SITE1_POES,
@@ -117,7 +118,7 @@ class Set1TestCase(unittest.TestCase):
         imts = {str(test_data.IMT): test_data.SET1_CASE11_IMLS}
 
         curves = calc_hazard_curves(
-            sources, sites, imts, gsims, truncation_level)
+            sources, SourceFilter(sites, None), imts, gsims, truncation_level)
         s1hc, s2hc, s3hc, s4hc = curves[str(test_data.IMT)]
 
         assert_hazard_curve_is(self, s1hc, test_data.SET1_CASE11_SITE1_POES,
@@ -155,7 +156,7 @@ class Set1TestCase(unittest.TestCase):
         imts = {str(test_data.IMT): test_data.SET1_CASE2_IMLS}
 
         curves = calc_hazard_curves(
-            sources, sites, imts, gsims, truncation_level)
+            sources, SourceFilter(sites, None), imts, gsims, truncation_level)
         s1hc, s2hc, s3hc, s4hc, s5hc, s6hc, s7hc = curves[str(test_data.IMT)]
 
         assert_hazard_curve_is(self, s1hc, test_data.SET1_CASE2_SITE1_POES,
@@ -199,7 +200,7 @@ class Set1TestCase(unittest.TestCase):
         imts = {str(test_data.IMT): test_data.SET1_CASE5_IMLS}
 
         curves = calc_hazard_curves(
-            sources, sites, imts, gsims, truncation_level)
+            sources, SourceFilter(sites, None), imts, gsims, truncation_level)
         s1hc, s2hc, s3hc, s4hc, s5hc, s6hc, s7hc = curves[str(test_data.IMT)]
 
         assert_hazard_curve_is(self, s1hc, test_data.SET1_CASE5_SITE1_POES,
@@ -250,8 +251,8 @@ class Set1TestCase(unittest.TestCase):
         truncation_level = 0
         imts = {str(test_data.IMT): test_data.SET1_CASE2_IMLS}
 
-        curves = calc_hazard_curves([npss], sites, imts, gsims,
-                                    truncation_level)
+        curves = calc_hazard_curves(
+            [npss], SourceFilter(sites, None), imts, gsims, truncation_level)
         s1hc, s2hc, s3hc, s4hc, s5hc, s6hc, s7hc = curves[str(test_data.IMT)]
 
         assert_hazard_curve_is(self, s1hc, test_data.SET1_CASE2_SITE1_POES,

--- a/openquake/hazardlib/tests/acceptance/stochastic_test.py
+++ b/openquake/hazardlib/tests/acceptance/stochastic_test.py
@@ -131,7 +131,7 @@ class StochasticEventSetTestCase(unittest.TestCase):
         ses = stochastic_event_set(
             [self.area1, self.area2],
             sites=sites,
-            source_site_filter=filters.RtreeFilter(sites, 100.)
+            source_site_filter=filters.SourceFilter(sites, 100.)
         )
 
         rates = self._extract_rates(ses, time_span=self.time_span,

--- a/openquake/hazardlib/tests/calc/hazard_curve_test.py
+++ b/openquake/hazardlib/tests/calc/hazard_curve_test.py
@@ -21,7 +21,7 @@ from openquake.hazardlib import const
 from openquake.hazardlib.geo import Point
 from openquake.hazardlib.tom import PoissonTOM
 from openquake.hazardlib.calc.hazard_curve import calc_hazard_curves
-from openquake.hazardlib.calc.filters import RtreeFilter
+from openquake.hazardlib.calc.filters import SourceFilter
 
 
 class HazardCurvesFiltersTestCase(unittest.TestCase):
@@ -80,7 +80,7 @@ class HazardCurvesFiltersTestCase(unittest.TestCase):
         gsims = {const.TRT.ACTIVE_SHALLOW_CRUST: SadighEtAl1997()}
         truncation_level = 1
         imts = {'PGA': [0.1, 0.5, 1.3]}
-        s_filter = RtreeFilter(sitecol, {const.TRT.ACTIVE_SHALLOW_CRUST: 30})
+        s_filter = SourceFilter(sitecol, {const.TRT.ACTIVE_SHALLOW_CRUST: 30})
         result = calc_hazard_curves(
             sources, s_filter, imts, gsims, truncation_level)['PGA']
         # there are two sources and four sites. The first source contains only

--- a/openquake/hazardlib/tests/calc/hazard_curve_test.py
+++ b/openquake/hazardlib/tests/calc/hazard_curve_test.py
@@ -14,178 +14,17 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 import unittest
-
 import numpy
 
 import openquake.hazardlib
-from openquake.hazardlib import const, imt
-from openquake.hazardlib.site import Site, SiteCollection
+from openquake.hazardlib import const
 from openquake.hazardlib.geo import Point
 from openquake.hazardlib.tom import PoissonTOM
 from openquake.hazardlib.calc.hazard_curve import calc_hazard_curves
-from openquake.hazardlib.gsim.base import ContextMaker
-
-
-class FakeSiteContext(object):
-    def __init__(self, sites):
-        self.sites = sites
-        self.mesh = sites.mesh
-
-
-class HazardCurvesTestCase(unittest.TestCase):
-    class FakeRupture(object):
-        def __init__(self, probability, tectonic_region_type):
-            self.probability = probability
-            self.tectonic_region_type = tectonic_region_type
-
-        def get_probability_no_exceedance(self, poes):
-            return (1 - self.probability) ** numpy.array(poes)
-
-    class FakeSource(object):
-        def __init__(self, source_id, ruptures, time_span, trt):
-            self.source_id = source_id
-            self.time_span = time_span
-            self.ruptures = ruptures
-            self.tectonic_region_type = trt
-            self.src_group_id = 0
-
-        def iter_ruptures(self):
-            return iter(self.ruptures)
-
-    class FailSource(FakeSource):
-        def iter_ruptures(self):
-            raise ValueError('Something bad happened')
-
-    class FakeGSIM(object):
-        REQUIRES_DISTANCES = set()
-        REQUIRES_RUPTURE_PARAMETERS = set()
-        REQUIRES_SITES_PARAMETERS = set()
-
-        def __init__(self, truncation_level, imts, poes):
-            self.truncation_level = truncation_level
-            self.imts = imts
-            self.poes = poes
-
-        def get_poes(self, sctx, rctx, dctx, imt, imls, truncation_level):
-            assert truncation_level is self.truncation_level
-            return numpy.array([self.poes[(epicenter.latitude, rctx, imt)]
-                                for epicenter in sctx.mesh])
-
-        def __str__(self):
-            return self.__class__.__name__
-
-    def setUp(self):
-        self.orig_make_contexts = ContextMaker.make_contexts
-        ContextMaker.make_contexts = lambda self, sites, rupture: (
-            FakeSiteContext(sites), rupture, None)
-        self.truncation_level = 3.4
-        self.imts = {'PGA': [1, 2, 3], 'PGD': [2, 4]}
-        self.time_span = 49.2
-
-        rup11 = self.FakeRupture(0.23, const.TRT.ACTIVE_SHALLOW_CRUST)
-        rup12 = self.FakeRupture(0.15, const.TRT.ACTIVE_SHALLOW_CRUST)
-        rup21 = self.FakeRupture(0.04, const.TRT.VOLCANIC)
-        self.source1 = self.FakeSource(
-            1, [rup11, rup12], self.time_span, const.TRT.ACTIVE_SHALLOW_CRUST)
-        self.source2 = self.FakeSource(
-            2, [rup21], self.time_span, const.TRT.VOLCANIC)
-        self.sources = [self.source1, self.source2]
-        site1 = Site(Point(10, 20), 1, True, 2, 3)
-        site2 = Site(Point(20, 30), 2, False, 4, 5)
-        self.sites = SiteCollection([site1, site2])
-
-        gsim1 = self.FakeGSIM(self.truncation_level, self.imts, poes={
-            (site1.location.latitude, rup11, imt.PGA()): [0.1, 0.05, 0.03],
-            (site2.location.latitude, rup11, imt.PGA()): [0.11, 0.051, 0.034],
-            (site1.location.latitude, rup12, imt.PGA()): [0.12, 0.052, 0.035],
-            (site2.location.latitude, rup12, imt.PGA()): [0.13, 0.053, 0.036],
-
-            (site1.location.latitude, rup11, imt.PGD()): [0.4, 0.33],
-            (site2.location.latitude, rup11, imt.PGD()): [0.39, 0.331],
-            (site1.location.latitude, rup12, imt.PGD()): [0.38, 0.332],
-            (site2.location.latitude, rup12, imt.PGD()): [0.37, 0.333],
-        })
-        gsim2 = self.FakeGSIM(self.truncation_level, self.imts, poes={
-            (site1.location.latitude, rup21, imt.PGA()): [0.5, 0.3, 0.2],
-            (site2.location.latitude, rup21, imt.PGA()): [0.4, 0.2, 0.1],
-
-            (site1.location.latitude, rup21, imt.PGD()): [0.24, 0.08],
-            (site2.location.latitude, rup21, imt.PGD()): [0.14, 0.09],
-        })
-        self.gsims = {const.TRT.ACTIVE_SHALLOW_CRUST: gsim1,
-                      const.TRT.VOLCANIC: gsim2}
-
-    def tearDown(self):
-        ContextMaker.make_contexts = self.orig_make_contexts
-
-    def test1(self):
-        site1_pga_poe_expected = [0.0639157, 0.03320212, 0.02145989]
-        site2_pga_poe_expected = [0.06406232, 0.02965879, 0.01864331]
-        site1_pgd_poe_expected = [0.16146619, 0.1336553]
-        site2_pgd_poe_expected = [0.15445961, 0.13437589]
-
-        curves = calc_hazard_curves(
-            self.sources, self.sites, self.imts,
-            self.gsims, self.truncation_level)
-        self.assertEqual(set(curves.dtype.fields), set(['PGA', 'PGD']))
-
-        pga_curves = curves['PGA']
-        self.assertIsInstance(pga_curves, numpy.ndarray)
-        self.assertEqual(pga_curves.shape, (2, 3))  # two sites, three IMLs
-        site1_pga_poe, site2_pga_poe = pga_curves
-        numpy.testing.assert_allclose(
-            site1_pga_poe, site1_pga_poe_expected, 1E-6)
-        numpy.testing.assert_allclose(
-            site2_pga_poe, site2_pga_poe_expected, 1E-6)
-
-        pgd_curves = curves['PGD']
-        self.assertIsInstance(pgd_curves, numpy.ndarray)
-        self.assertEqual(pgd_curves.shape, (2, 2))  # two sites, two IMLs
-        site1_pgd_poe, site2_pgd_poe = pgd_curves
-        numpy.testing.assert_allclose(site1_pgd_poe, site1_pgd_poe_expected)
-        numpy.testing.assert_allclose(site2_pgd_poe, site2_pgd_poe_expected)
-
-    def test_source_errors(self):
-        # exercise `hazard_curves_poissonian` in the case of an exception,
-        # whereby we expect the source_id to be reported in the error message
-
-        fail_source = self.FailSource(self.source2.source_id,
-                                      self.source2.ruptures,
-                                      self.source2.time_span,
-                                      const.TRT.VOLCANIC)
-        sources = iter([self.source1, fail_source])
-
-        with self.assertRaises(ValueError) as ae:
-            calc_hazard_curves(sources, self.sites, self.imts, self.gsims,
-                               self.truncation_level)
-        expected_error = (
-            'An error occurred with source id=2. Error: Something bad happened'
-        )
-        self.assertEqual(expected_error, str(ae.exception))
+from openquake.hazardlib.calc.filters import RtreeFilter
 
 
 class HazardCurvesFiltersTestCase(unittest.TestCase):
-    class SitesCounterRtreeFilter(object):
-        def __init__(self, chained_generator):
-            self.counts = []
-            self.chained_generator = chained_generator
-
-        def __call__(self, sources, sites):
-            for source, sites in self.chained_generator(sources, sites):
-                self.counts.append(
-                    (source.source_id, list(map(int, sites.vs30))))
-                yield source, sites
-
-    class SitesCounterRuptureFilter(object):
-        def __init__(self, chained_generator):
-            self.counts = []
-            self.chained_generator = chained_generator
-
-        def __call__(self, ruptures, sites):
-            for rupture, sites in self.chained_generator(ruptures, sites):
-                self.counts.append((rupture.mag, list(map(int, sites.vs30))))
-                yield rupture, sites
-
     def test_point_sources(self):
         sources = [
             openquake.hazardlib.source.PointSource(
@@ -241,13 +80,9 @@ class HazardCurvesFiltersTestCase(unittest.TestCase):
         gsims = {const.TRT.ACTIVE_SHALLOW_CRUST: SadighEtAl1997()}
         truncation_level = 1
         imts = {'PGA': [0.1, 0.5, 1.3]}
-
-        from openquake.hazardlib.calc import filters
-        source_site_filter = self.SitesCounterRtreeFilter(
-            filters.RtreeFilter(sitecol, 30))
-        calc_hazard_curves(
-            sources, sitecol, imts, gsims, truncation_level,
-            source_site_filter=source_site_filter)
+        s_filter = RtreeFilter(sitecol, {const.TRT.ACTIVE_SHALLOW_CRUST: 30})
+        result = calc_hazard_curves(
+            sources, s_filter, imts, gsims, truncation_level)['PGA']
         # there are two sources and four sites. The first source contains only
         # one rupture, the second source contains three ruptures.
         #
@@ -278,5 +113,7 @@ class HazardCurvesFiltersTestCase(unittest.TestCase):
         # rupture 1 (magnitude 4) is not considered because too far, rupture 2
         # (magnitude 6) affect only the 4th site, rupture 3 (magnitude 8)
         # affect the 3rd and 4th sites.
-        self.assertEqual(source_site_filter.counts,
-                         [('point2', [1, 3, 4])])
+
+        self.assertEqual(result.shape, (4, 3))  # 4 sites, 3 levels
+        numpy.testing.assert_allclose(result[0], 0)  # no contrib to site 1
+        numpy.testing.assert_allclose(result[1], 0)  # no contrib to site 2

--- a/openquake/hazardlib/tests/source/base_test.py
+++ b/openquake/hazardlib/tests/source/base_test.py
@@ -133,7 +133,7 @@ class SeismicSourceFilterSitesTestCase(_BaseSeismicSourceTestCase):
             self.assertIs(filtered, None)  # all filtered
 
 
-class SeismicRtreeFilterSitesByRuptureTestCase(
+class SeismicSourceFilterSitesByRuptureTestCase(
         _BaseSeismicSourceTestCase):
     def test(self):
         surface_mesh = RectangularMesh(self.POLYGON.lons.reshape((2, 2)),


### PR DESCRIPTION
Now the second argument is a SourceFilter instance instead of a SiteCollection. This is possible since the SourceFilter is pickleable thanks to https://github.com/gem/oq-hazardlib/pull/536. This means that two redundant arguments have been removed from `pmap_from_grp` that now only requires 7 arguments instead of 9. Futher simplifications will follow in future pull requests.

Notice that `calc_hazard_curves` works both with the new API and the old API, so that there is no breakage of the notebooks and the code by the hazard scientists.

PS: the tests involving mock sources have been removed (they are a maintenance burden) while the tests involving real sources have been kept.