### PR TITLE
Add missing setuptool wheel

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,7 +2,8 @@
 # Ubuntu 16.04 stack
 # !! update pip first! so wheels will be used !!
 
-pkgconfig==1.1.0
+setuptools
+pkgconfig
 Cython==0.23.4
 mock==1.3.0
 h5py==2.6.0

--- a/requirements-py27-linux64.txt
+++ b/requirements-py27-linux64.txt
@@ -6,6 +6,7 @@
 # We also provide pre-compiled manylinux1 wheels for
 # h5py, Shapely and psutil
 
+http://ftp.openquake.org/python-new-wheels/setuptools-28.8.0-py2.py3-none-any.whl
 http://ftp.openquake.org/python-new-wheels/pkgconfig-1.1.0-cp27-none-any.whl
 http://ftp.openquake.org/python-new-wheels/Cython-0.23.4-cp27-cp27mu-manylinux1_x86_64.whl
 http://ftp.openquake.org/python-new-wheels/mock-1.3.0-py2.py3-none-any.whl

--- a/requirements-py35-linux64.txt
+++ b/requirements-py35-linux64.txt
@@ -6,6 +6,7 @@
 # We also provide pre-compiled manylinux1 wheels for
 # h5py, Shapely and psutil
 
+http://ftp.openquake.org/python-new-wheels/setuptools-28.8.0-py2.py3-none-any.whl
 http://ftp.openquake.org/python-new-wheels/pkgconfig-1.1.0-py3-none-any.whl
 http://ftp.openquake.org/python-new-wheels/Cython-0.23.4-cp35-cp35m-manylinux1_x86_64.whl
 http://ftp.openquake.org/python-new-wheels/mock-1.3.0-py2.py3-none-any.whl


### PR DESCRIPTION
This PR adds a local copy of the setuptool wheel which is needed when --no-index is used during wheels installation.