### PR TITLE
Fixed a small Python 3 issue in git_suffix

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,5 @@
   [Michele Simionato]
+  * Fixed a Python 3 issue in git_suffix
   * Added support for AccumDict of accumulators
   * Made the RtreeFilter pickleable
   * Made the FilteredSiteCollections serializable to HDF5

--- a/openquake/baselib/general.py
+++ b/openquake/baselib/general.py
@@ -36,6 +36,7 @@ import collections
 
 import numpy
 from decorator import decorator
+from openquake.baselib.python3compat import decode
 
 F64 = numpy.float64
 
@@ -305,7 +306,7 @@ def git_suffix(fname):
         gh = subprocess.check_output(
             ['git', 'rev-parse', '--short', 'HEAD'],
             stderr=open(os.devnull, 'w'), cwd=os.path.dirname(fname)).strip()
-        gh = "-git" + gh if gh else ''
+        gh = "-git" + decode(gh) if gh else ''
         return gh
     except:
         # trapping everything on purpose; git may not be installed or it


### PR DESCRIPTION
Daniele discovered that `subprocess.check_output` returns bytes in Python 3, so it has to be decoded.