### PR TITLE
Made `calc_hazard_curves` parallelizable

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,5 @@
   [Michele Simionato]
+  * Made calc_hazard_curves parallelizable
   * Fixed a Python 3 issue in git_suffix
   * Added support for AccumDict of accumulators
   * Made the RtreeFilter pickleable

--- a/openquake/baselib/general.py
+++ b/openquake/baselib/general.py
@@ -158,8 +158,14 @@ def ceil(a, b):
     return int(math.ceil(float(a) / b))
 
 
-def block_splitter(items, max_weight, weight=lambda item: 1,
-                   kind=lambda item: 'Unspecified'):
+def nokey(item):
+    """
+    Dummy function to apply to items without a key
+    """
+    return 'Unspecified'
+
+
+def block_splitter(items, max_weight, weight=lambda item: 1, kind=nokey):
     """
     :param items: an iterator over items
     :param max_weight: the max weight to split on
@@ -202,8 +208,7 @@ def block_splitter(items, max_weight, weight=lambda item: 1,
         yield ws
 
 
-def split_in_blocks(sequence, hint, weight=lambda item: 1,
-                    key=lambda item: 'Unspecified'):
+def split_in_blocks(sequence, hint, weight=lambda item: 1, key=nokey):
     """
     Split the `sequence` in a number of WeightedSequences close to `hint`.
 
@@ -222,7 +227,7 @@ def split_in_blocks(sequence, hint, weight=lambda item: 1,
     """
     if hint == 0:  # do not split
         return sequence
-    items = list(sequence)
+    items = list(sequence) if key is nokey else sorted(sequence, key=key)
     assert hint > 0, hint
     assert len(items) > 0, len(items)
     total_weight = float(sum(weight(item) for item in items))

--- a/openquake/baselib/hdf5.py
+++ b/openquake/baselib/hdf5.py
@@ -217,6 +217,11 @@ class File(h5py.File):
     """
     @classmethod
     def temporary(cls):
+        """
+        Returns a temporary hdf5 file, open for writing.
+        The temporary name is stored in the .path attribute.
+        It is the user responsability to remove the file when closed.
+        """
         fh, path = tempfile.mkstemp(suffix='.hdf5')
         os.close(fh)
         self = cls(path, 'w')

--- a/openquake/baselib/tests/general_test.py
+++ b/openquake/baselib/tests/general_test.py
@@ -123,8 +123,8 @@ class BlockSplitterTestCase(unittest.TestCase):
             split_in_blocks([s1, s2, s3, s4, s5], hint=6,
                             weight=attrgetter('weight'),
                             key=attrgetter('typology')))
-        self.assertEqual(list(map(len, blocks)), [2, 1, 1, 1])
-        self.assertEqual([b.weight for b in blocks], [2, 2, 4, 4])
+        self.assertEqual(list(map(len, blocks)), [1, 1, 1, 2])
+        self.assertEqual([b.weight for b in blocks], [2, 4, 4, 2])
 
 
 class SearchModuleTestCase(unittest.TestCase):

--- a/openquake/hazardlib/calc/hazard_curve.py
+++ b/openquake/hazardlib/calc/hazard_curve.py
@@ -108,7 +108,7 @@ def calc_hazard_curves(
         distribution.
     :param apply:
         Application function, for instance `parallel.apply`; by default use
-        the sequential `apply`.
+        the :func:`openquake.baselib.parallel.Sequential.apply`.
 
     :returns:
         An array of size N, where N is the number of sites, which elements

--- a/openquake/hazardlib/calc/hazard_curve.py
+++ b/openquake/hazardlib/calc/hazard_curve.py
@@ -140,7 +140,7 @@ def calc_hazard_curves(
         distribution.
     :param apply:
         Application function, for instance `parallel.apply`; by default use
-        the :func:`openquake.baselib.parallel.Sequential.apply`.
+        `openquake.baselib.parallel.Sequential.apply`.
 
     :returns:
         An array of size N, where N is the number of sites, which elements

--- a/openquake/hazardlib/calc/hazard_curve.py
+++ b/openquake/hazardlib/calc/hazard_curve.py
@@ -121,9 +121,6 @@ def calc_hazard_curves(
     else:  # backward compatibility, a site collection was passed
         sites = source_site_filter
         source_site_filter = SourceFilter(sites, None)
-    for src in sources:
-        if not src.num_ruptures:
-            src.num_ruptures = src.count_ruptures()
     pmap = apply(
         pmap_from_grp, (sources, source_site_filter, imtls,
                         gsim_by_trt, truncation_level),

--- a/openquake/hazardlib/calc/hazard_curve.py
+++ b/openquake/hazardlib/calc/hazard_curve.py
@@ -65,7 +65,7 @@ def agg_curves(acc, curves):
 
 def calc_hazard_curves(
         sources, source_site_filter, imtls, gsim_by_trt,
-        truncation_level=None):
+        truncation_level=None, apply=apply):
     """
     Compute hazard curves on a list of sites, given a set of seismic sources
     and a set of ground shaking intensity models (one per tectonic region type
@@ -106,6 +106,9 @@ def calc_hazard_curves(
     :param truncation_level:
         Float, number of standard deviations for truncation of the intensity
         distribution.
+    :param apply:
+        Application function, for instance parallel.apply; by default use
+        the Python builtin :func:`apply`.
 
     :returns:
         An array of size N, where N is the number of sites, which elements
@@ -122,8 +125,9 @@ def calc_hazard_curves(
         sources, operator.attrgetter('tectonic_region_type'))
     pmap = ProbabilityMap(len(imtls.array), 1)
     for trt in sources_by_trt:
-        pmap |= pmap_from_grp(sources_by_trt[trt], source_site_filter, imtls,
-                              [gsim_by_trt[trt]], truncation_level)
+        pmap |= apply(pmap_from_grp,
+                      (sources_by_trt[trt], source_site_filter, imtls,
+                       [gsim_by_trt[trt]], truncation_level))
     return pmap.convert(imtls, len(sites))
 
 

--- a/openquake/hazardlib/calc/hazard_curve.py
+++ b/openquake/hazardlib/calc/hazard_curve.py
@@ -121,6 +121,9 @@ def calc_hazard_curves(
     else:  # backward compatibility, a site collection was passed
         sites = source_site_filter
         source_site_filter = SourceFilter(sites, None)
+    for src in sources:
+        if not src.num_ruptures:
+            src.num_ruptures = src.count_ruptures()
     pmap = apply(
         pmap_from_grp, (sources, source_site_filter, imtls,
                         gsim_by_trt, truncation_level),

--- a/openquake/hazardlib/source/base.py
+++ b/openquake/hazardlib/source/base.py
@@ -50,6 +50,8 @@ class BaseSeismicSource(with_metaclass(abc.ABCMeta)):
         Determine the source weight from the number of ruptures, by
         multiplying with the scale factor RUPTURE_WEIGHT
         """
+        if not self.num_ruptures:
+            self.num_ruptures = self.count_ruptures()
         return self.num_ruptures * self.RUPTURE_WEIGHT
 
     def __init__(self, source_id, name, tectonic_region_type):


### PR DESCRIPTION
This is not needed by the engine, but it can be useful in the notebooks and in Python scripts. For instance, here is a classical calculator computing the hazard curves per each realization in less than 20 lines of code:

```python
import sys
import logging
from openquake.baselib import parallel
from openquake.hazardlib.calc.filters import SourceFilter
from openquake.hazardlib.calc.hazard_curve import calc_hazard_curves
from openquake.commonlib import readinput


def main(job_ini):
    logging.basicConfig(level=logging.INFO)
    oq = readinput.get_oqparam(job_ini)
    sitecol = readinput.get_site_collection(oq)
    src_filter = SourceFilter(sitecol, oq.maximum_distance)
    csm = readinput.get_composite_source_model(oq).filter(src_filter)
    rlzs_assoc = csm.info.get_rlzs_assoc()
    sources = csm.get_sources()
    for rlzno, gsim_by_trt in enumerate(rlzs_assoc.gsim_by_trt):
        hcurves = calc_hazard_curves(sources, src_filter, oq.imtls,
                                     gsim_by_trt, oq.truncation_level,
                                     parallel.apply)
        print('rlzno=%d, hcurves=%r' % (rlzno, hcurves))


if __name__ == '__main__':
    main(sys.argv[1])  # path to a job.ini file
```

NB: the implementation in the engine is smarter and more efficient. Here we start a parallel computation per each realization, the engine manages all the realizations at once.

The tests are running here: https://ci.openquake.org/job/zdevel_oq-hazardlib/676