### PR TITLE
Cached the correlation matrix

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,6 @@
+  [Michele Simionato]
+  * Cached the correlation matrix for speed
+
   [Marco Pagani, Michele Simionato]
   * Extended the hazard curve calculator to manage mutually exclusive probabilities
 

--- a/openquake/hazardlib/correlation.py
+++ b/openquake/hazardlib/correlation.py
@@ -87,15 +87,10 @@ class BaseCorrelationModel(with_metaclass(abc.ABCMeta)):
             self.cache[imt] = corma
         if len(sites.complete) == len(sites):
             return numpy.dot(corma, residuals)
-        # else extract the indices (slow)
-        return numpy.dot(project(corma, sites.sids), residuals)
-
-
-def project(matrix, indices):
-    """
-    Project a matrix on the given indices
-    """
-    return matrix[indices].T[indices].T
+        # this is the fastest way I found
+        res = numpy.sum(corma[sites.sids, sid] * residuals[i]
+                        for i, sid in numpy.ndenumerate(sites.sids))
+        return res
 
 
 class JB2009CorrelationModel(BaseCorrelationModel):

--- a/openquake/hazardlib/correlation.py
+++ b/openquake/hazardlib/correlation.py
@@ -91,11 +91,8 @@ class BaseCorrelationModel(with_metaclass(abc.ABCMeta)):
         # accumulating below; if S is the length of the complete sitecollection
         # the correlation matrix has shape (S, S) and the residuals (N, s),
         # where s is the number of samples
-        acc = numpy.zeros_like(residuals)  # shape (N, s)
-        for i, sid in numpy.ndenumerate(sites.sids):
-            # multiplying shape (N, 1) * (s,) gives (N, s)
-            acc += corma[sites.sids, sid] * residuals[i]
-        return acc
+        return numpy.sum(corma[sites.sids, sid] * res
+                         for sid, res in zip(sites.sids, residuals))
 
 
 class JB2009CorrelationModel(BaseCorrelationModel):

--- a/openquake/hazardlib/correlation.py
+++ b/openquake/hazardlib/correlation.py
@@ -85,7 +85,7 @@ class BaseCorrelationModel(with_metaclass(abc.ABCMeta)):
             corma = self.get_lower_triangle_correlation_matrix(
                 sites.complete, imt)
             self.cache[imt] = corma
-        return numpy.dot(corma[sites.sids, sites.sids], residuals)
+        return numpy.dot(corma[sites.sids][sites.sids], residuals)
 
 
 class JB2009CorrelationModel(BaseCorrelationModel):

--- a/openquake/hazardlib/correlation.py
+++ b/openquake/hazardlib/correlation.py
@@ -85,7 +85,7 @@ class BaseCorrelationModel(with_metaclass(abc.ABCMeta)):
             corma = self.get_lower_triangle_correlation_matrix(
                 sites.complete, imt)
             self.cache[imt] = corma
-        return numpy.dot(corma[sites.sids][sites.sids], residuals)
+        return numpy.dot(corma[sites.sids].T[sites.sids], residuals)
 
 
 class JB2009CorrelationModel(BaseCorrelationModel):

--- a/openquake/hazardlib/correlation.py
+++ b/openquake/hazardlib/correlation.py
@@ -85,7 +85,7 @@ class BaseCorrelationModel(with_metaclass(abc.ABCMeta)):
             corma = self.get_lower_triangle_correlation_matrix(
                 sites.complete, imt)
             self.cache[imt] = corma
-        return numpy.dot(corma[sites.sids], residuals)
+        return numpy.dot(corma[sites.sids, sites.sids], residuals)
 
 
 class JB2009CorrelationModel(BaseCorrelationModel):

--- a/openquake/hazardlib/correlation.py
+++ b/openquake/hazardlib/correlation.py
@@ -85,7 +85,14 @@ class BaseCorrelationModel(with_metaclass(abc.ABCMeta)):
             corma = self.get_lower_triangle_correlation_matrix(
                 sites.complete, imt)
             self.cache[imt] = corma
-        return numpy.dot(corma[sites.sids].T[sites.sids], residuals)
+        return numpy.dot(project(corma, sites.sids), residuals)
+
+
+def project(matrix, indices):
+    """
+    Project a matrix on the given indices
+    """
+    return matrix[indices].T[indices].T
 
 
 class JB2009CorrelationModel(BaseCorrelationModel):

--- a/openquake/hazardlib/correlation.py
+++ b/openquake/hazardlib/correlation.py
@@ -85,6 +85,9 @@ class BaseCorrelationModel(with_metaclass(abc.ABCMeta)):
             corma = self.get_lower_triangle_correlation_matrix(
                 sites.complete, imt)
             self.cache[imt] = corma
+        if len(sites.complete) == len(sites):
+            return numpy.dot(corma, residuals)
+        # else extract the indices (slow)
         return numpy.dot(project(corma, sites.sids), residuals)
 
 


### PR DESCRIPTION
Recently a couple of risk users tried to use GMF-correlation, but discovered that the computation they wanted to do was impossibly slow. After inspection, the source of the problem has become clear to me: the correlation matrix is not cached, so it is recomputed million of times without need. This PR adds an IMT-specific cache for the correlation matrix.
