### PR TITLE
Mark the binary dist as pure, universal python

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[bdist_wheel]
+universal = 1


### PR DESCRIPTION
See: https://wheel.readthedocs.io/en/latest/#defining-the-python-version