### PR TITLE
Move NRML libraries to hazardlib

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,7 @@
+  [Michele Simionato]
+  * Moved the NRML-related functionality from the engine into hazardlib
+    in order to have an engine-independent Hazard Modeler Toolkit
+
   [Daniele Viganò]
   * Add dependencies to setup.py
   * Update Copyright to 2017

--- a/openquake/hazardlib/__init__.py
+++ b/openquake/hazardlib/__init__.py
@@ -25,6 +25,10 @@ from openquake.hazardlib import (
     calc, geo, gsim, mfd, scalerel, source, const, correlation, imt, pmf, site,
     tom, near_fault)
 
+
+class InvalidFile(Exception):
+    pass
+
 # the version is managed by packager.sh with a sed
 __version__ = '0.22.0'
 __version__ += git_suffix(__file__)

--- a/openquake/hazardlib/nrml.py
+++ b/openquake/hazardlib/nrml.py
@@ -80,12 +80,13 @@ import re
 import sys
 import decimal
 import logging
+import operator
 import numpy
 
-from openquake.baselib.general import CallableDict
+from openquake.baselib.general import CallableDict, groupby
 from openquake.baselib.node import (
     node_to_xml, Node, striptag, ValidatingXmlParser, floatformat)
-from openquake.hazardlib import valid
+from openquake.hazardlib import valid, sourceconverter
 
 F64 = numpy.float64
 NAMESPACE = 'http://openquake.org/xmlns/nrml/0.4'
@@ -93,6 +94,10 @@ NRML05 = 'http://openquake.org/xmlns/nrml/0.5'
 GML_NAMESPACE = 'http://www.opengis.net/gml'
 SERIALIZE_NS_MAP = {None: NAMESPACE, 'gml': GML_NAMESPACE}
 PARSE_NS_MAP = {'nrml': NAMESPACE, 'gml': GML_NAMESPACE}
+
+
+class DuplicatedID(Exception):
+    """Raised when two sources with the same ID are found in a source model"""
 
 
 def get_tag_version(nrml_node):
@@ -115,6 +120,40 @@ def parse(fname, *args):
 
 node_to_obj = CallableDict(keyfunc=get_tag_version, keymissing=lambda n, f: n)
 # dictionary of functions with at least two arguments, node and fname
+
+
+@node_to_obj.add(('sourceModel', 'nrml/0.4'))
+def get_source_model_04(node, fname, converter):
+    sources = []
+    source_ids = set()
+    converter.fname = fname
+    for no, src_node in enumerate(node, 1):
+        src = converter.convert_node(src_node)
+        if src.source_id in source_ids:
+            raise DuplicatedID(
+                'The source ID %s is duplicated!' % src.source_id)
+        sources.append(src)
+        source_ids.add(src.source_id)
+        if no % 10000 == 0:  # log every 10,000 sources parsed
+            logging.info('Instantiated %d sources from %s', no, fname)
+    if no % 10000 != 0:
+        logging.info('Instantiated %d sources from %s', no, fname)
+    groups = groupby(
+        sources, operator.attrgetter('tectonic_region_type'))
+    return sorted(sourceconverter.SourceGroup(trt, srcs)
+                  for trt, srcs in groups.items())
+
+
+@node_to_obj.add(('sourceModel', 'nrml/0.5'))
+def get_source_model_05(node, fname, converter):
+    converter.fname = fname
+    groups = []  # expect a sequence of sourceGroup nodes
+    for src_group in node:
+        with context(fname, src_group):
+            if 'sourceGroup' not in src_group.tag:
+                raise ValueError('expected sourceGroup')
+        groups.append(converter.convert_node(src_group))
+    return sorted(groups)
 
 validators = {
     'strike': valid.strike_range,

--- a/openquake/hazardlib/nrml.py
+++ b/openquake/hazardlib/nrml.py
@@ -85,7 +85,7 @@ import numpy
 
 from openquake.baselib.general import CallableDict, groupby
 from openquake.baselib.node import (
-    node_to_xml, Node, striptag, ValidatingXmlParser, floatformat)
+    node_to_xml, context, Node, striptag, ValidatingXmlParser, floatformat)
 from openquake.hazardlib import valid, sourceconverter
 
 F64 = numpy.float64

--- a/openquake/hazardlib/nrml.py
+++ b/openquake/hazardlib/nrml.py
@@ -80,16 +80,12 @@ import re
 import sys
 import decimal
 import logging
-import operator
-import itertools
-
 import numpy
 
-from openquake.baselib.general import CallableDict, groupby
+from openquake.baselib.general import CallableDict
 from openquake.baselib.node import (
-    node_to_xml, Node, striptag, ValidatingXmlParser, context, floatformat)
-from openquake.risklib import scientific
-from openquake.hazardlib import InvalidFile, sourceconverter, valid
+    node_to_xml, Node, striptag, ValidatingXmlParser, floatformat)
+from openquake.hazardlib import valid
 
 F64 = numpy.float64
 NAMESPACE = 'http://openquake.org/xmlns/nrml/0.4'
@@ -97,10 +93,6 @@ NRML05 = 'http://openquake.org/xmlns/nrml/0.5'
 GML_NAMESPACE = 'http://www.opengis.net/gml'
 SERIALIZE_NS_MAP = {None: NAMESPACE, 'gml': GML_NAMESPACE}
 PARSE_NS_MAP = {'nrml': NAMESPACE, 'gml': GML_NAMESPACE}
-
-
-class DuplicatedID(Exception):
-    """Raised when two sources with the same ID are found in a source model"""
 
 
 def get_tag_version(nrml_node):
@@ -121,371 +113,8 @@ def parse(fname, *args):
     [node] = read(fname)
     return node_to_obj(node, fname, *args)
 
-
-# ######################## node_to_obj definitions ######################### #
-
 node_to_obj = CallableDict(keyfunc=get_tag_version, keymissing=lambda n, f: n)
 # dictionary of functions with at least two arguments, node and fname
-
-
-@node_to_obj.add(('sourceModel', 'nrml/0.4'))
-def get_source_model_04(node, fname, converter):
-    sources = []
-    source_ids = set()
-    converter.fname = fname
-    for no, src_node in enumerate(node, 1):
-        src = converter.convert_node(src_node)
-        if src.source_id in source_ids:
-            raise DuplicatedID(
-                'The source ID %s is duplicated!' % src.source_id)
-        sources.append(src)
-        source_ids.add(src.source_id)
-        if no % 10000 == 0:  # log every 10,000 sources parsed
-            logging.info('Instantiated %d sources from %s', no, fname)
-    if no % 10000 != 0:
-        logging.info('Instantiated %d sources from %s', no, fname)
-    groups = groupby(
-        sources, operator.attrgetter('tectonic_region_type'))
-    return sorted(sourceconverter.SourceGroup(trt, srcs)
-                  for trt, srcs in groups.items())
-
-
-@node_to_obj.add(('sourceModel', 'nrml/0.5'))
-def get_source_model_05(node, fname, converter):
-    converter.fname = fname
-    groups = []  # expect a sequence of sourceGroup nodes
-    for src_group in node:
-        with context(fname, src_group):
-            if 'sourceGroup' not in src_group.tag:
-                raise ValueError('expected sourceGroup')
-        groups.append(converter.convert_node(src_group))
-    return sorted(groups)
-
-
-@node_to_obj.add(('vulnerabilityModel', 'nrml/0.4'))
-def get_vulnerability_functions_04(node, fname):
-    """
-    :param node:
-        a vulnerabilityModel node
-    :param fname:
-        path to the vulnerability file
-    :returns:
-        a dictionary imt, taxonomy -> vulnerability function
-    """
-    logging.warn('Please upgrade %s to NRML 0.5', fname)
-    # NB: the IMTs can be duplicated and with different levels, each
-    # vulnerability function in a set will get its own levels
-    imts = set()
-    taxonomies = set()
-    # imt, taxonomy -> vulnerability function
-    vmodel = scientific.VulnerabilityModel(**node.attrib)
-    for vset in node:
-        imt_str = vset.IML['IMT']
-        imls = ~vset.IML
-        imts.add(imt_str)
-        for vfun in vset.getnodes('discreteVulnerability'):
-            taxonomy = vfun['vulnerabilityFunctionID']
-            if taxonomy in taxonomies:
-                raise InvalidFile(
-                    'Duplicated vulnerabilityFunctionID: %s: %s, line %d' %
-                    (taxonomy, fname, vfun.lineno))
-            taxonomies.add(taxonomy)
-            with context(fname, vfun):
-                loss_ratios = ~vfun.lossRatio
-                coefficients = ~vfun.coefficientsVariation
-            if len(loss_ratios) != len(imls):
-                raise InvalidFile(
-                    'There are %d loss ratios, but %d imls: %s, line %d' %
-                    (len(loss_ratios), len(imls), fname,
-                     vfun.lossRatio.lineno))
-            if len(coefficients) != len(imls):
-                raise InvalidFile(
-                    'There are %d coefficients, but %d imls: %s, line %d' %
-                    (len(coefficients), len(imls), fname,
-                     vfun.coefficientsVariation.lineno))
-            with context(fname, vfun):
-                vmodel[imt_str, taxonomy] = scientific.VulnerabilityFunction(
-                    taxonomy, imt_str, imls, loss_ratios, coefficients,
-                    vfun['probabilisticDistribution'])
-    return vmodel
-
-
-@node_to_obj.add(('vulnerabilityModel', 'nrml/0.5'))
-def get_vulnerability_functions_05(node, fname):
-    """
-    :param node:
-        a vulnerabilityModel node
-    :param fname:
-        path of the vulnerability filter
-    :returns:
-        a dictionary imt, taxonomy -> vulnerability function
-    """
-    # NB: the IMTs can be duplicated and with different levels, each
-    # vulnerability function in a set will get its own levels
-    taxonomies = set()
-    vmodel = scientific.VulnerabilityModel(**node.attrib)
-    # imt, taxonomy -> vulnerability function
-    for vfun in node.getnodes('vulnerabilityFunction'):
-        with context(fname, vfun):
-            imt = vfun.imls['imt']
-            imls = numpy.array(~vfun.imls)
-            taxonomy = vfun['id']
-        if taxonomy in taxonomies:
-            raise InvalidFile(
-                'Duplicated vulnerabilityFunctionID: %s: %s, line %d' %
-                (taxonomy, fname, vfun.lineno))
-        if vfun['dist'] == 'PM':
-            loss_ratios, probs = [], []
-            for probabilities in vfun[1:]:
-                loss_ratios.append(probabilities['lr'])
-                probs.append(valid.probabilities(~probabilities))
-            probs = numpy.array(probs)
-            assert probs.shape == (len(loss_ratios), len(imls))
-            vmodel[imt, taxonomy] = (
-                scientific.VulnerabilityFunctionWithPMF(
-                    taxonomy, imt, imls, numpy.array(loss_ratios),
-                    probs))  # the seed will be set by readinput.get_risk_model
-        else:
-            with context(fname, vfun):
-                loss_ratios = ~vfun.meanLRs
-                coefficients = ~vfun.covLRs
-            if len(loss_ratios) != len(imls):
-                raise InvalidFile(
-                    'There are %d loss ratios, but %d imls: %s, line %d' %
-                    (len(loss_ratios), len(imls), fname,
-                     vfun.meanLRs.lineno))
-            if len(coefficients) != len(imls):
-                raise InvalidFile(
-                    'There are %d coefficients, but %d imls: %s, '
-                    'line %d' % (len(coefficients), len(imls), fname,
-                                 vfun.covLRs.lineno))
-            with context(fname, vfun):
-                vmodel[imt, taxonomy] = scientific.VulnerabilityFunction(
-                    taxonomy, imt, imls, loss_ratios, coefficients,
-                    vfun['dist'])
-    return vmodel
-
-
-# ########################### fragility ############################### #
-
-
-def ffconvert(fname, limit_states, ff, min_iml=1E-10):
-    """
-    Convert a fragility function into a numpy array plus a bunch
-    of attributes.
-
-    :param fname: path to the fragility model file
-    :param limit_states: expected limit states
-    :param ff: fragility function node
-    :returns: a pair (array, dictionary)
-    """
-    with context(fname, ff):
-        ffs = ff[1:]
-        imls = ff.imls
-    nodamage = imls.attrib.get('noDamageLimit')
-    if nodamage == 0:
-        # use a cutoff to avoid log(0) in GMPE.to_distribution_values
-        logging.warn('Found a noDamageLimit=0 in %s, line %s, '
-                     'using %g instead', fname, ff.lineno, min_iml)
-        nodamage = min_iml
-    with context(fname, imls):
-        attrs = dict(format=ff['format'],
-                     imt=imls['imt'],
-                     nodamage=nodamage)
-
-    LS = len(limit_states)
-    if LS != len(ffs):
-        with context(fname, ff):
-            raise InvalidFile('expected %d limit states, found %d' %
-                              (LS, len(ffs)))
-    if ff['format'] == 'continuous':
-        minIML = float(imls['minIML'])
-        if minIML == 0:
-            # use a cutoff to avoid log(0) in GMPE.to_distribution_values
-            logging.warn('Found minIML=0 in %s, line %s, using %g instead',
-                         fname, imls.lineno, min_iml)
-            minIML = min_iml
-        attrs['minIML'] = minIML
-        attrs['maxIML'] = float(imls['maxIML'])
-        array = numpy.zeros(LS, [('mean', F64), ('stddev', F64)])
-        for i, ls, node in zip(range(LS), limit_states, ff[1:]):
-            if ls != node['ls']:
-                with context(fname, node):
-                    raise InvalidFile('expected %s, found' %
-                                      (ls, node['ls']))
-            array['mean'][i] = node['mean']
-            array['stddev'][i] = node['stddev']
-    elif ff['format'] == 'discrete':
-        attrs['imls'] = ~imls
-        valid.check_levels(attrs['imls'], attrs['imt'])
-        num_poes = len(attrs['imls'])
-        array = numpy.zeros((LS, num_poes))
-        for i, ls, node in zip(range(LS), limit_states, ff[1:]):
-            with context(fname, node):
-                if ls != node['ls']:
-                    raise InvalidFile('expected %s, found' %
-                                      (ls, node['ls']))
-                poes = (~node if isinstance(~node, list)
-                        else valid.probabilities(~node))
-                if len(poes) != num_poes:
-                    raise InvalidFile('expected %s, found' %
-                                      (num_poes, len(poes)))
-                array[i, :] = poes
-    # NB: the format is constrained in nrml.FragilityNode to be either
-    # discrete or continuous, there is no third option
-    return array, attrs
-
-
-@node_to_obj.add(('fragilityModel', 'nrml/0.5'))
-def get_fragility_model(node, fname):
-    """
-    :param node:
-        a vulnerabilityModel node
-    :param fname:
-        path to the vulnerability file
-    :returns:
-        a dictionary imt, taxonomy -> fragility function list
-    """
-    with context(fname, node):
-        fid = node['id']
-        asset_category = node['assetCategory']
-        loss_type = node['lossCategory']
-        description = ~node.description
-        limit_states = ~node.limitStates
-        ffs = node[2:]
-    fmodel = scientific.FragilityModel(
-        fid, asset_category, loss_type, description, limit_states)
-    for ff in ffs:
-        imt_taxo = ff.imls['imt'], ff['id']
-        array, attrs = ffconvert(fname, limit_states, ff)
-        ffl = scientific.FragilityFunctionList(array)
-        vars(ffl).update(attrs)
-        fmodel[imt_taxo] = ffl
-    return fmodel
-
-
-# ################################## consequences ########################## #
-
-@node_to_obj.add(('consequenceModel', 'nrml/0.5'))
-def get_consequence_model(node, fname):
-    with context(fname, node):
-        description = ~node.description  # make sure it is there
-        limitStates = ~node.limitStates  # make sure it is there
-        # ASK: is the 'id' mandatory?
-        node['assetCategory']  # make sure it is there
-        node['lossCategory']  # make sure it is there
-        cfs = node[2:]
-    functions = {}
-    for cf in cfs:
-        with context(fname, cf):
-            params = []
-            if len(limitStates) != len(cf):
-                raise ValueError(
-                    'Expected %d limit states, got %d' %
-                    (len(limitStates), len(cf)))
-            for ls, param in zip(limitStates, cf):
-                with context(fname, param):
-                    if param['ls'] != ls:
-                        raise ValueError("Expected '%s', got '%s'" %
-                                         (ls, param['ls']))
-                    params.append((param['mean'], param['stddev']))
-            functions[cf['id']] = scientific.ConsequenceFunction(
-                cf['id'], cf['dist'], params)
-    attrs = node.attrib.copy()
-    attrs.update(description=description, limitStates=limitStates)
-    cmodel = scientific.ConsequenceModel(**attrs)
-    cmodel.update(functions)
-    return cmodel
-
-
-# utility to convert the old, deprecated format
-def convert_fragility_model_04(node, fname, fmcounter=itertools.count(1)):
-    """
-    :param node:
-        an :class:`openquake.commonib.node.Node` in NRML 0.4
-    :param fname:
-        path of the fragility file
-    :returns:
-        an :class:`openquake.commonib.node.Node` in NRML 0.5
-    """
-    convert_type = {"lognormal": "logncdf"}
-    new = Node('fragilityModel',
-               dict(assetCategory='building',
-                    lossCategory='structural',
-                    id='fm_%d_converted_from_NRML_04' %
-                    next(fmcounter)))
-    with context(fname, node):
-        fmt = node['format']
-        descr = ~node.description
-        limit_states = ~node.limitStates
-    new.append(Node('description', {}, descr))
-    new.append((Node('limitStates', {}, ' '.join(limit_states))))
-    for ffs in node[2:]:
-        IML = ffs.IML
-        # NB: noDamageLimit = None is different than zero
-        nodamage = ffs.attrib.get('noDamageLimit')
-        ff = Node('fragilityFunction', {'format': fmt})
-        ff['id'] = ~ffs.taxonomy
-        ff['shape'] = convert_type[ffs.attrib.get('type', 'lognormal')]
-        if fmt == 'continuous':
-            with context(fname, IML):
-                attr = dict(imt=IML['IMT'],
-                            minIML=IML['minIML'],
-                            maxIML=IML['maxIML'])
-                if nodamage is not None:
-                    attr['noDamageLimit'] = nodamage
-                ff.append(Node('imls', attr))
-            for ffc in ffs[2:]:
-                with context(fname, ffc):
-                    ls = ffc['ls']
-                    param = ffc.params
-                with context(fname, param):
-                    m, s = param['mean'], param['stddev']
-                ff.append(Node('params', dict(ls=ls, mean=m, stddev=s)))
-        else:  # discrete
-            with context(fname, IML):
-                imls = ' '.join(map(str, (~IML)[1]))
-                attr = dict(imt=IML['IMT'])
-            if nodamage is not None:
-                attr['noDamageLimit'] = nodamage
-            ff.append(Node('imls', attr, imls))
-            for ffd in ffs[2:]:
-                ls = ffd['ls']
-                with context(fname, ffd):
-                    poes = ' '.join(map(str, ~ffd.poEs))
-                ff.append(Node('poes', dict(ls=ls), poes))
-        new.append(ff)
-    return new
-
-
-@node_to_obj.add(('fragilityModel', 'nrml/0.4'))
-def get_fragility_model_04(fmodel, fname):
-    """
-    :param fmodel:
-        a fragilityModel node
-    :param fname:
-        path of the fragility file
-    :returns:
-        an :class:`openquake.risklib.scientific.FragilityModel` instance
-    """
-    logging.warn('Please upgrade %s to NRML 0.5', fname)
-    node05 = convert_fragility_model_04(fmodel, fname)
-    node05.limitStates.text = node05.limitStates.text.split()
-    return get_fragility_model(node05, fname)
-
-# ######################## validators ######################## #
-
-
-valid_loss_types = valid.Choice('structural', 'nonstructural', 'contents',
-                                'business_interruption', 'occupants')
-
-
-def asset_mean_stddev(value, assetRef, mean, stdDev):
-    return assetRef, valid.positivefloat(mean), valid.positivefloat(stdDev)
-
-
-def damage_triple(value, ds, mean, stddev):
-    return ds, valid.positivefloat(mean), valid.positivefloat(stddev)
 
 validators = {
     'strike': valid.strike_range,
@@ -518,55 +147,19 @@ validators = {
     'characteristicRate': valid.positivefloat,
     'characteristicMag': valid.positivefloat,
     'magnitudes': valid.positivefloats,
-    'fragilityFunction.id': valid.utf8,  # taxonomy
-    'vulnerabilityFunction.id': valid.utf8,  # taxonomy
-    'consequenceFunction.id': valid.utf8,  # taxonomy
     'id': valid.simple_id,
     'rupture.id': valid.utf8,  # event tag
     'discretization': valid.compose(valid.positivefloat, valid.nonzero),
-    'asset.id': valid.asset_id,
-    'costType.name': valid.cost_type,
-    'costType.type': valid.cost_type_type,
-    'cost.type': valid.cost_type,
-    'area.type': valid.name,
-    'isAbsolute': valid.boolean,
-    'insuranceLimit': valid.positivefloat,
-    'deductible': valid.positivefloat,
-    'occupants': valid.positivefloat,
-    'value': valid.positivefloat,
-    'retrofitted': valid.positivefloat,
-    'number': valid.compose(valid.positivefloat, valid.nonzero),
-    'vulnerabilitySetID': str,  # any ASCII string is fine
-    'vulnerabilityFunctionID': str,  # any ASCII string is fine
-    'lossCategory': valid.utf8,  # a description field
     'IML': valid.positivefloats,  # used in NRML 0.4
     'imt': valid.intensity_measure_type,
     'imls': valid.positivefloats,
-    'lr': valid.probability,
-    'lossRatio': valid.positivefloats,
-    'coefficientsVariation': valid.positivefloats,
-    'probabilisticDistribution': valid.Choice('LN', 'BT'),
-    'dist': valid.Choice('LN', 'BT', 'PM'),
-    'meanLRs': valid.positivefloats,
-    'covLRs': valid.positivefloats,
-    'format': valid.ChoiceCI('discrete', 'continuous'),
-    'mean': valid.positivefloat,
-    'stddev': valid.positivefloat,
     'poes': valid.positivefloats,
-    'minIML': valid.positivefloat,
-    'maxIML': valid.positivefloat,
-    'limitStates': valid.namelist,
     'description': valid.utf8_not_empty,
-    'poEs': valid.probabilities,
     'noDamageLimit': valid.NoneOr(valid.positivefloat),
     'investigationTime': valid.positivefloat,
-    'loss_type': valid_loss_types,
     'poEs': valid.probabilities,
     'gsimTreePath': lambda v: v.split('_'),
     'sourceModelTreePath': lambda v: v.split('_'),
-    'losses': valid.positivefloats,
-    'averageLoss': valid.positivefloat,
-    'stdDevLoss': valid.positivefloat,
     'poE': valid.probability,
     'IMLs': valid.positivefloats,
     'pos': valid.lon_lat,
@@ -579,9 +172,6 @@ validators = {
     'periods': valid.positivefloats,
     'pos': valid.lon_lat,
     'IMLs': valid.positivefloats,
-    'saPeriod': valid.positivefloat,
-    'saDamping': valid.positivefloat,
-    'investigationTime': valid.positivefloat,
     'lon': valid.longitude,
     'lat': valid.latitude,
     'magBinEdges': valid.integers,
@@ -589,7 +179,6 @@ validators = {
     'epsBinEdges': valid.integers,
     'lonBinEdges': valid.longitudes,
     'latBinEdges': valid.latitudes,
-    'ffs.type': valid.ChoiceCI('lognormal'),
     'type': valid.namelist,
     'dims': valid.positiveints,
     'poE': valid.probability,
@@ -598,22 +187,9 @@ validators = {
     'value': valid.positivefloat,
     'assetLifeExpectancy': valid.positivefloat,
     'interestRate': valid.positivefloat,
-    'lossCategory': valid.utf8,
-    'lossType': valid_loss_types,
-    'quantileValue': valid.positivefloat,
     'statistics': valid.Choice('mean', 'quantile'),
     'pos': valid.lon_lat,
-    'aalOrig': valid.positivefloat,
-    'aalRetr': valid.positivefloat,
-    'ratio': valid.positivefloat,
-    'pos': valid.lon_lat,
-    'cf': asset_mean_stddev,
-    'damage': damage_triple,
-    'pos': valid.lon_lat,
-    'damageStates': valid.namelist,
     'gmv': valid.positivefloat,
-    'lon': valid.longitude,
-    'lat': valid.latitude,
     'spacing': valid.positivefloat,
     'srcs_weights': valid.weights,
 }

--- a/openquake/hazardlib/nrml.py
+++ b/openquake/hazardlib/nrml.py
@@ -1,0 +1,672 @@
+# -*- coding: utf-8 -*-
+# vim: tabstop=4 shiftwidth=4 softtabstop=4
+#
+# Copyright (C) 2014-2017 GEM Foundation
+#
+# OpenQuake is free software: you can redistribute it and/or modify it
+# under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# OpenQuake is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with OpenQuake. If not, see <http://www.gnu.org/licenses/>.
+
+"""
+From Node objects to NRML files and viceversa
+------------------------------------------------------
+
+It is possible to save a Node object into a NRML file by using the
+function ``write(nodes, output)`` where output is a file
+object. If you want to make sure that the generated file is valid
+according to the NRML schema just open it in 'w+' mode: immediately
+after writing it will be read and validated. It is also possible to
+convert a NRML file into a Node object with the routine
+``read(node, input)`` where input is the path name of the
+NRML file or a file object opened for reading. The file will be
+validated as soon as opened.
+
+For instance an exposure file like the following::
+
+  <?xml version='1.0' encoding='utf-8'?>
+  <nrml xmlns="http://openquake.org/xmlns/nrml/0.4"
+        xmlns:gml="http://www.opengis.net/gml">
+    <exposureModel
+        id="my_exposure_model_for_population"
+        category="population"
+        taxonomySource="fake population datasource">
+
+      <description>
+        Sample population
+      </description>
+
+      <assets>
+        <asset id="asset_01" number="7" taxonomy="IT-PV">
+            <location lon="9.15000" lat="45.16667" />
+        </asset>
+
+        <asset id="asset_02" number="7" taxonomy="IT-CE">
+            <location lon="9.15333" lat="45.12200" />
+        </asset>
+      </assets>
+    </exposureModel>
+  </nrml>
+
+can be converted as follows:
+
+>> nrml = read(<path_to_the_exposure_file.xml>)
+
+Then subnodes and attributes can be conveniently accessed:
+
+>> nrml.exposureModel.assets[0]['taxonomy']
+'IT-PV'
+>> nrml.exposureModel.assets[0]['id']
+'asset_01'
+>> nrml.exposureModel.assets[0].location['lon']
+'9.15000'
+>> nrml.exposureModel.assets[0].location['lat']
+'45.16667'
+
+The Node class provides no facility to cast strings into Python types;
+this is a job for the Node class which can be subclassed and
+supplemented by a dictionary of validators.
+"""
+from __future__ import print_function
+import re
+import sys
+import decimal
+import logging
+import operator
+import itertools
+
+import numpy
+
+from openquake.baselib.general import CallableDict, groupby
+from openquake.baselib.node import (
+    node_to_xml, Node, striptag, ValidatingXmlParser, context, floatformat)
+from openquake.risklib import scientific
+from openquake.hazardlib import InvalidFile, sourceconverter, valid
+
+F64 = numpy.float64
+NAMESPACE = 'http://openquake.org/xmlns/nrml/0.4'
+NRML05 = 'http://openquake.org/xmlns/nrml/0.5'
+GML_NAMESPACE = 'http://www.opengis.net/gml'
+SERIALIZE_NS_MAP = {None: NAMESPACE, 'gml': GML_NAMESPACE}
+PARSE_NS_MAP = {'nrml': NAMESPACE, 'gml': GML_NAMESPACE}
+
+
+class DuplicatedID(Exception):
+    """Raised when two sources with the same ID are found in a source model"""
+
+
+def get_tag_version(nrml_node):
+    """
+    Extract from a node of kind NRML the tag and the version. For instance
+    from '{http://openquake.org/xmlns/nrml/0.4}fragilityModel' one gets
+    the pair ('fragilityModel', 'nrml/0.4').
+    """
+    version, tag = re.search(r'(nrml/[\d\.]+)\}(\w+)', nrml_node.tag).groups()
+    return tag, version
+
+
+def parse(fname, *args):
+    """
+    Parse a NRML file and return an associated Python object. It works by
+    calling nrml.read() and node_to_obj() in sequence.
+    """
+    [node] = read(fname)
+    return node_to_obj(node, fname, *args)
+
+
+# ######################## node_to_obj definitions ######################### #
+
+node_to_obj = CallableDict(keyfunc=get_tag_version, keymissing=lambda n, f: n)
+# dictionary of functions with at least two arguments, node and fname
+
+
+@node_to_obj.add(('sourceModel', 'nrml/0.4'))
+def get_source_model_04(node, fname, converter):
+    sources = []
+    source_ids = set()
+    converter.fname = fname
+    for no, src_node in enumerate(node, 1):
+        src = converter.convert_node(src_node)
+        if src.source_id in source_ids:
+            raise DuplicatedID(
+                'The source ID %s is duplicated!' % src.source_id)
+        sources.append(src)
+        source_ids.add(src.source_id)
+        if no % 10000 == 0:  # log every 10,000 sources parsed
+            logging.info('Instantiated %d sources from %s', no, fname)
+    if no % 10000 != 0:
+        logging.info('Instantiated %d sources from %s', no, fname)
+    groups = groupby(
+        sources, operator.attrgetter('tectonic_region_type'))
+    return sorted(sourceconverter.SourceGroup(trt, srcs)
+                  for trt, srcs in groups.items())
+
+
+@node_to_obj.add(('sourceModel', 'nrml/0.5'))
+def get_source_model_05(node, fname, converter):
+    converter.fname = fname
+    groups = []  # expect a sequence of sourceGroup nodes
+    for src_group in node:
+        with context(fname, src_group):
+            if 'sourceGroup' not in src_group.tag:
+                raise ValueError('expected sourceGroup')
+        groups.append(converter.convert_node(src_group))
+    return sorted(groups)
+
+
+@node_to_obj.add(('vulnerabilityModel', 'nrml/0.4'))
+def get_vulnerability_functions_04(node, fname):
+    """
+    :param node:
+        a vulnerabilityModel node
+    :param fname:
+        path to the vulnerability file
+    :returns:
+        a dictionary imt, taxonomy -> vulnerability function
+    """
+    logging.warn('Please upgrade %s to NRML 0.5', fname)
+    # NB: the IMTs can be duplicated and with different levels, each
+    # vulnerability function in a set will get its own levels
+    imts = set()
+    taxonomies = set()
+    # imt, taxonomy -> vulnerability function
+    vmodel = scientific.VulnerabilityModel(**node.attrib)
+    for vset in node:
+        imt_str = vset.IML['IMT']
+        imls = ~vset.IML
+        imts.add(imt_str)
+        for vfun in vset.getnodes('discreteVulnerability'):
+            taxonomy = vfun['vulnerabilityFunctionID']
+            if taxonomy in taxonomies:
+                raise InvalidFile(
+                    'Duplicated vulnerabilityFunctionID: %s: %s, line %d' %
+                    (taxonomy, fname, vfun.lineno))
+            taxonomies.add(taxonomy)
+            with context(fname, vfun):
+                loss_ratios = ~vfun.lossRatio
+                coefficients = ~vfun.coefficientsVariation
+            if len(loss_ratios) != len(imls):
+                raise InvalidFile(
+                    'There are %d loss ratios, but %d imls: %s, line %d' %
+                    (len(loss_ratios), len(imls), fname,
+                     vfun.lossRatio.lineno))
+            if len(coefficients) != len(imls):
+                raise InvalidFile(
+                    'There are %d coefficients, but %d imls: %s, line %d' %
+                    (len(coefficients), len(imls), fname,
+                     vfun.coefficientsVariation.lineno))
+            with context(fname, vfun):
+                vmodel[imt_str, taxonomy] = scientific.VulnerabilityFunction(
+                    taxonomy, imt_str, imls, loss_ratios, coefficients,
+                    vfun['probabilisticDistribution'])
+    return vmodel
+
+
+@node_to_obj.add(('vulnerabilityModel', 'nrml/0.5'))
+def get_vulnerability_functions_05(node, fname):
+    """
+    :param node:
+        a vulnerabilityModel node
+    :param fname:
+        path of the vulnerability filter
+    :returns:
+        a dictionary imt, taxonomy -> vulnerability function
+    """
+    # NB: the IMTs can be duplicated and with different levels, each
+    # vulnerability function in a set will get its own levels
+    taxonomies = set()
+    vmodel = scientific.VulnerabilityModel(**node.attrib)
+    # imt, taxonomy -> vulnerability function
+    for vfun in node.getnodes('vulnerabilityFunction'):
+        with context(fname, vfun):
+            imt = vfun.imls['imt']
+            imls = numpy.array(~vfun.imls)
+            taxonomy = vfun['id']
+        if taxonomy in taxonomies:
+            raise InvalidFile(
+                'Duplicated vulnerabilityFunctionID: %s: %s, line %d' %
+                (taxonomy, fname, vfun.lineno))
+        if vfun['dist'] == 'PM':
+            loss_ratios, probs = [], []
+            for probabilities in vfun[1:]:
+                loss_ratios.append(probabilities['lr'])
+                probs.append(valid.probabilities(~probabilities))
+            probs = numpy.array(probs)
+            assert probs.shape == (len(loss_ratios), len(imls))
+            vmodel[imt, taxonomy] = (
+                scientific.VulnerabilityFunctionWithPMF(
+                    taxonomy, imt, imls, numpy.array(loss_ratios),
+                    probs))  # the seed will be set by readinput.get_risk_model
+        else:
+            with context(fname, vfun):
+                loss_ratios = ~vfun.meanLRs
+                coefficients = ~vfun.covLRs
+            if len(loss_ratios) != len(imls):
+                raise InvalidFile(
+                    'There are %d loss ratios, but %d imls: %s, line %d' %
+                    (len(loss_ratios), len(imls), fname,
+                     vfun.meanLRs.lineno))
+            if len(coefficients) != len(imls):
+                raise InvalidFile(
+                    'There are %d coefficients, but %d imls: %s, '
+                    'line %d' % (len(coefficients), len(imls), fname,
+                                 vfun.covLRs.lineno))
+            with context(fname, vfun):
+                vmodel[imt, taxonomy] = scientific.VulnerabilityFunction(
+                    taxonomy, imt, imls, loss_ratios, coefficients,
+                    vfun['dist'])
+    return vmodel
+
+
+# ########################### fragility ############################### #
+
+
+def ffconvert(fname, limit_states, ff, min_iml=1E-10):
+    """
+    Convert a fragility function into a numpy array plus a bunch
+    of attributes.
+
+    :param fname: path to the fragility model file
+    :param limit_states: expected limit states
+    :param ff: fragility function node
+    :returns: a pair (array, dictionary)
+    """
+    with context(fname, ff):
+        ffs = ff[1:]
+        imls = ff.imls
+    nodamage = imls.attrib.get('noDamageLimit')
+    if nodamage == 0:
+        # use a cutoff to avoid log(0) in GMPE.to_distribution_values
+        logging.warn('Found a noDamageLimit=0 in %s, line %s, '
+                     'using %g instead', fname, ff.lineno, min_iml)
+        nodamage = min_iml
+    with context(fname, imls):
+        attrs = dict(format=ff['format'],
+                     imt=imls['imt'],
+                     nodamage=nodamage)
+
+    LS = len(limit_states)
+    if LS != len(ffs):
+        with context(fname, ff):
+            raise InvalidFile('expected %d limit states, found %d' %
+                              (LS, len(ffs)))
+    if ff['format'] == 'continuous':
+        minIML = float(imls['minIML'])
+        if minIML == 0:
+            # use a cutoff to avoid log(0) in GMPE.to_distribution_values
+            logging.warn('Found minIML=0 in %s, line %s, using %g instead',
+                         fname, imls.lineno, min_iml)
+            minIML = min_iml
+        attrs['minIML'] = minIML
+        attrs['maxIML'] = float(imls['maxIML'])
+        array = numpy.zeros(LS, [('mean', F64), ('stddev', F64)])
+        for i, ls, node in zip(range(LS), limit_states, ff[1:]):
+            if ls != node['ls']:
+                with context(fname, node):
+                    raise InvalidFile('expected %s, found' %
+                                      (ls, node['ls']))
+            array['mean'][i] = node['mean']
+            array['stddev'][i] = node['stddev']
+    elif ff['format'] == 'discrete':
+        attrs['imls'] = ~imls
+        valid.check_levels(attrs['imls'], attrs['imt'])
+        num_poes = len(attrs['imls'])
+        array = numpy.zeros((LS, num_poes))
+        for i, ls, node in zip(range(LS), limit_states, ff[1:]):
+            with context(fname, node):
+                if ls != node['ls']:
+                    raise InvalidFile('expected %s, found' %
+                                      (ls, node['ls']))
+                poes = (~node if isinstance(~node, list)
+                        else valid.probabilities(~node))
+                if len(poes) != num_poes:
+                    raise InvalidFile('expected %s, found' %
+                                      (num_poes, len(poes)))
+                array[i, :] = poes
+    # NB: the format is constrained in nrml.FragilityNode to be either
+    # discrete or continuous, there is no third option
+    return array, attrs
+
+
+@node_to_obj.add(('fragilityModel', 'nrml/0.5'))
+def get_fragility_model(node, fname):
+    """
+    :param node:
+        a vulnerabilityModel node
+    :param fname:
+        path to the vulnerability file
+    :returns:
+        a dictionary imt, taxonomy -> fragility function list
+    """
+    with context(fname, node):
+        fid = node['id']
+        asset_category = node['assetCategory']
+        loss_type = node['lossCategory']
+        description = ~node.description
+        limit_states = ~node.limitStates
+        ffs = node[2:]
+    fmodel = scientific.FragilityModel(
+        fid, asset_category, loss_type, description, limit_states)
+    for ff in ffs:
+        imt_taxo = ff.imls['imt'], ff['id']
+        array, attrs = ffconvert(fname, limit_states, ff)
+        ffl = scientific.FragilityFunctionList(array)
+        vars(ffl).update(attrs)
+        fmodel[imt_taxo] = ffl
+    return fmodel
+
+
+# ################################## consequences ########################## #
+
+@node_to_obj.add(('consequenceModel', 'nrml/0.5'))
+def get_consequence_model(node, fname):
+    with context(fname, node):
+        description = ~node.description  # make sure it is there
+        limitStates = ~node.limitStates  # make sure it is there
+        # ASK: is the 'id' mandatory?
+        node['assetCategory']  # make sure it is there
+        node['lossCategory']  # make sure it is there
+        cfs = node[2:]
+    functions = {}
+    for cf in cfs:
+        with context(fname, cf):
+            params = []
+            if len(limitStates) != len(cf):
+                raise ValueError(
+                    'Expected %d limit states, got %d' %
+                    (len(limitStates), len(cf)))
+            for ls, param in zip(limitStates, cf):
+                with context(fname, param):
+                    if param['ls'] != ls:
+                        raise ValueError("Expected '%s', got '%s'" %
+                                         (ls, param['ls']))
+                    params.append((param['mean'], param['stddev']))
+            functions[cf['id']] = scientific.ConsequenceFunction(
+                cf['id'], cf['dist'], params)
+    attrs = node.attrib.copy()
+    attrs.update(description=description, limitStates=limitStates)
+    cmodel = scientific.ConsequenceModel(**attrs)
+    cmodel.update(functions)
+    return cmodel
+
+
+# utility to convert the old, deprecated format
+def convert_fragility_model_04(node, fname, fmcounter=itertools.count(1)):
+    """
+    :param node:
+        an :class:`openquake.commonib.node.Node` in NRML 0.4
+    :param fname:
+        path of the fragility file
+    :returns:
+        an :class:`openquake.commonib.node.Node` in NRML 0.5
+    """
+    convert_type = {"lognormal": "logncdf"}
+    new = Node('fragilityModel',
+               dict(assetCategory='building',
+                    lossCategory='structural',
+                    id='fm_%d_converted_from_NRML_04' %
+                    next(fmcounter)))
+    with context(fname, node):
+        fmt = node['format']
+        descr = ~node.description
+        limit_states = ~node.limitStates
+    new.append(Node('description', {}, descr))
+    new.append((Node('limitStates', {}, ' '.join(limit_states))))
+    for ffs in node[2:]:
+        IML = ffs.IML
+        # NB: noDamageLimit = None is different than zero
+        nodamage = ffs.attrib.get('noDamageLimit')
+        ff = Node('fragilityFunction', {'format': fmt})
+        ff['id'] = ~ffs.taxonomy
+        ff['shape'] = convert_type[ffs.attrib.get('type', 'lognormal')]
+        if fmt == 'continuous':
+            with context(fname, IML):
+                attr = dict(imt=IML['IMT'],
+                            minIML=IML['minIML'],
+                            maxIML=IML['maxIML'])
+                if nodamage is not None:
+                    attr['noDamageLimit'] = nodamage
+                ff.append(Node('imls', attr))
+            for ffc in ffs[2:]:
+                with context(fname, ffc):
+                    ls = ffc['ls']
+                    param = ffc.params
+                with context(fname, param):
+                    m, s = param['mean'], param['stddev']
+                ff.append(Node('params', dict(ls=ls, mean=m, stddev=s)))
+        else:  # discrete
+            with context(fname, IML):
+                imls = ' '.join(map(str, (~IML)[1]))
+                attr = dict(imt=IML['IMT'])
+            if nodamage is not None:
+                attr['noDamageLimit'] = nodamage
+            ff.append(Node('imls', attr, imls))
+            for ffd in ffs[2:]:
+                ls = ffd['ls']
+                with context(fname, ffd):
+                    poes = ' '.join(map(str, ~ffd.poEs))
+                ff.append(Node('poes', dict(ls=ls), poes))
+        new.append(ff)
+    return new
+
+
+@node_to_obj.add(('fragilityModel', 'nrml/0.4'))
+def get_fragility_model_04(fmodel, fname):
+    """
+    :param fmodel:
+        a fragilityModel node
+    :param fname:
+        path of the fragility file
+    :returns:
+        an :class:`openquake.risklib.scientific.FragilityModel` instance
+    """
+    logging.warn('Please upgrade %s to NRML 0.5', fname)
+    node05 = convert_fragility_model_04(fmodel, fname)
+    node05.limitStates.text = node05.limitStates.text.split()
+    return get_fragility_model(node05, fname)
+
+# ######################## validators ######################## #
+
+
+valid_loss_types = valid.Choice('structural', 'nonstructural', 'contents',
+                                'business_interruption', 'occupants')
+
+
+def asset_mean_stddev(value, assetRef, mean, stdDev):
+    return assetRef, valid.positivefloat(mean), valid.positivefloat(stdDev)
+
+
+def damage_triple(value, ds, mean, stddev):
+    return ds, valid.positivefloat(mean), valid.positivefloat(stddev)
+
+validators = {
+    'strike': valid.strike_range,
+    'dip': valid.dip_range,
+    'rake': valid.rake_range,
+    'magnitude': valid.positivefloat,
+    'lon': valid.longitude,
+    'lat': valid.latitude,
+    'depth': valid.positivefloat,
+    'upperSeismoDepth': valid.positivefloat,
+    'lowerSeismoDepth': valid.positivefloat,
+    'posList': valid.posList,
+    'pos': valid.lon_lat,
+    'aValue': float,
+    'bValue': valid.positivefloat,
+    'magScaleRel': valid.mag_scale_rel,
+    'tectonicRegion': str,
+    'ruptAspectRatio': valid.positivefloat,
+    'maxMag': valid.positivefloat,
+    'minMag': valid.positivefloat,
+    'binWidth': valid.positivefloat,
+    'probability': valid.probability,
+    'occurRates': valid.positivefloats,
+    'probs_occur': valid.pmf,
+    'weight': valid.probability,
+    'uncertaintyWeight': decimal.Decimal,
+    'alongStrike': valid.probability,
+    'downDip': valid.probability,
+    'totalMomentRate': valid.positivefloat,
+    'characteristicRate': valid.positivefloat,
+    'characteristicMag': valid.positivefloat,
+    'magnitudes': valid.positivefloats,
+    'fragilityFunction.id': valid.utf8,  # taxonomy
+    'vulnerabilityFunction.id': valid.utf8,  # taxonomy
+    'consequenceFunction.id': valid.utf8,  # taxonomy
+    'id': valid.simple_id,
+    'rupture.id': valid.utf8,  # event tag
+    'discretization': valid.compose(valid.positivefloat, valid.nonzero),
+    'asset.id': valid.asset_id,
+    'costType.name': valid.cost_type,
+    'costType.type': valid.cost_type_type,
+    'cost.type': valid.cost_type,
+    'area.type': valid.name,
+    'isAbsolute': valid.boolean,
+    'insuranceLimit': valid.positivefloat,
+    'deductible': valid.positivefloat,
+    'occupants': valid.positivefloat,
+    'value': valid.positivefloat,
+    'retrofitted': valid.positivefloat,
+    'number': valid.compose(valid.positivefloat, valid.nonzero),
+    'vulnerabilitySetID': str,  # any ASCII string is fine
+    'vulnerabilityFunctionID': str,  # any ASCII string is fine
+    'lossCategory': valid.utf8,  # a description field
+    'IML': valid.positivefloats,  # used in NRML 0.4
+    'imt': valid.intensity_measure_type,
+    'imls': valid.positivefloats,
+    'lr': valid.probability,
+    'lossRatio': valid.positivefloats,
+    'coefficientsVariation': valid.positivefloats,
+    'probabilisticDistribution': valid.Choice('LN', 'BT'),
+    'dist': valid.Choice('LN', 'BT', 'PM'),
+    'meanLRs': valid.positivefloats,
+    'covLRs': valid.positivefloats,
+    'format': valid.ChoiceCI('discrete', 'continuous'),
+    'mean': valid.positivefloat,
+    'stddev': valid.positivefloat,
+    'poes': valid.positivefloats,
+    'minIML': valid.positivefloat,
+    'maxIML': valid.positivefloat,
+    'limitStates': valid.namelist,
+    'description': valid.utf8_not_empty,
+    'poEs': valid.probabilities,
+    'noDamageLimit': valid.NoneOr(valid.positivefloat),
+    'investigationTime': valid.positivefloat,
+    'loss_type': valid_loss_types,
+    'poEs': valid.probabilities,
+    'gsimTreePath': lambda v: v.split('_'),
+    'sourceModelTreePath': lambda v: v.split('_'),
+    'losses': valid.positivefloats,
+    'averageLoss': valid.positivefloat,
+    'stdDevLoss': valid.positivefloat,
+    'poE': valid.probability,
+    'IMLs': valid.positivefloats,
+    'pos': valid.lon_lat,
+    'IMT': str,
+    'saPeriod': valid.positivefloat,
+    'saDamping': valid.positivefloat,
+    'quantileValue': valid.positivefloat,
+    'investigationTime': valid.positivefloat,
+    'poE': valid.probability,
+    'periods': valid.positivefloats,
+    'pos': valid.lon_lat,
+    'IMLs': valid.positivefloats,
+    'saPeriod': valid.positivefloat,
+    'saDamping': valid.positivefloat,
+    'investigationTime': valid.positivefloat,
+    'lon': valid.longitude,
+    'lat': valid.latitude,
+    'magBinEdges': valid.integers,
+    'distBinEdges': valid.integers,
+    'epsBinEdges': valid.integers,
+    'lonBinEdges': valid.longitudes,
+    'latBinEdges': valid.latitudes,
+    'ffs.type': valid.ChoiceCI('lognormal'),
+    'type': valid.namelist,
+    'dims': valid.positiveints,
+    'poE': valid.probability,
+    'iml': valid.positivefloat,
+    'index': valid.positiveints,
+    'value': valid.positivefloat,
+    'assetLifeExpectancy': valid.positivefloat,
+    'interestRate': valid.positivefloat,
+    'lossCategory': valid.utf8,
+    'lossType': valid_loss_types,
+    'quantileValue': valid.positivefloat,
+    'statistics': valid.Choice('mean', 'quantile'),
+    'pos': valid.lon_lat,
+    'aalOrig': valid.positivefloat,
+    'aalRetr': valid.positivefloat,
+    'ratio': valid.positivefloat,
+    'pos': valid.lon_lat,
+    'cf': asset_mean_stddev,
+    'damage': damage_triple,
+    'pos': valid.lon_lat,
+    'damageStates': valid.namelist,
+    'gmv': valid.positivefloat,
+    'lon': valid.longitude,
+    'lat': valid.latitude,
+    'spacing': valid.positivefloat,
+    'srcs_weights': valid.weights,
+}
+
+
+def read(source, chatty=True, stop=None):
+    """
+    Convert a NRML file into a validated Node object. Keeps
+    the entire tree in memory.
+
+    :param source:
+        a file name or file object open for reading
+    """
+    vparser = ValidatingXmlParser(validators, stop)
+    nrml = vparser.parse_file(source)
+    assert striptag(nrml.tag) == 'nrml', nrml.tag
+    # extract the XML namespace URL ('http://openquake.org/xmlns/nrml/0.5')
+    xmlns = nrml.tag.split('}')[0][1:]
+    if xmlns != NRML05 and chatty:
+        # for the moment NRML04 is still supported, so we hide the warning
+        logging.debug('%s is at an outdated version: %s', source, xmlns)
+    nrml['xmlns'] = xmlns
+    nrml['xmlns:gml'] = GML_NAMESPACE
+    return nrml
+
+
+def write(nodes, output=sys.stdout, fmt='%.7E', gml=True, xmlns=None):
+    """
+    Convert nodes into a NRML file. output must be a file
+    object open in write mode. If you want to perform a
+    consistency check, open it in read-write mode, then it will
+    be read after creation and validated.
+
+    :params nodes: an iterable over Node objects
+    :params output: a file-like object in write or read-write mode
+    :param fmt: format used for writing the floats (default '%.7E')
+    :param gml: add the http://www.opengis.net/gml namespace
+    :param xmlns: NRML namespace like http://openquake.org/xmlns/nrml/0.4
+    """
+    root = Node('nrml', nodes=nodes)
+    namespaces = {xmlns or NRML05: ''}
+    if gml:
+        namespaces[GML_NAMESPACE] = 'gml:'
+    with floatformat(fmt):
+        node_to_xml(root, output, namespaces)
+    if hasattr(output, 'mode') and '+' in output.mode:  # read-write mode
+        output.seek(0)
+        read(output)  # validate the written file
+
+
+if __name__ == '__main__':
+    import sys
+    for fname in sys.argv[1:]:
+        print('****** %s ******' % fname)
+        print(read(fname).to_str())
+        print()

--- a/openquake/hazardlib/sourceconverter.py
+++ b/openquake/hazardlib/sourceconverter.py
@@ -1,0 +1,820 @@
+# -*- coding: utf-8 -*-
+# vim: tabstop=4 shiftwidth=4 softtabstop=4
+#
+# Copyright (C) 2015-2017 GEM Foundation
+#
+# OpenQuake is free software: you can redistribute it and/or modify it
+# under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# OpenQuake is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with OpenQuake. If not, see <http://www.gnu.org/licenses/>.
+from __future__ import division
+import math
+import copy
+import operator
+import collections
+
+from openquake.baselib.node import context, striptag
+from openquake.hazardlib import geo, mfd, pmf, source
+from openquake.hazardlib.tom import PoissonTOM
+from openquake.hazardlib import valid
+
+MAXWEIGHT = 200  # tuned by M. Simionato
+
+
+class SourceModel(object):
+    """
+    A container of SourceGroup instances with some additional attributes
+    describing the source model in the logic tree.
+    """
+    def __init__(self, name, weight, path, src_groups, num_gsim_paths, ordinal,
+                 samples):
+        self.name = name
+        self.weight = weight
+        self.path = path
+        self.src_groups = src_groups
+        self.num_gsim_paths = num_gsim_paths
+        self.ordinal = ordinal
+        self.samples = samples
+
+    @property
+    def num_sources(self):
+        return sum(len(sg) for sg in self.src_groups)
+
+    def get_skeleton(self):
+        """
+        Return an empty copy of the source model, i.e. without sources,
+        but with the proper attributes for each SourceGroup contained within.
+        """
+        src_groups = [SourceGroup(sg.trt, [], sg.min_mag, sg.max_mag, sg.id)
+                      for sg in self.src_groups]
+        return self.__class__(self.name, self.weight, self.path, src_groups,
+                              self.num_gsim_paths, self.ordinal, self.samples)
+
+
+class SourceGroup(collections.Sequence):
+    """
+    A container for the following parameters:
+
+    :param str trt:
+        the tectonic region type all the sources belong to
+    :param list sources:
+        a list of hazardlib source objects
+    :param min_mag:
+        the minimum magnitude among the given sources
+    :param max_mag:
+        the maximum magnitude among the given sources
+    :param id:
+        an optional numeric ID (default None) useful to associate
+        the model to a database object
+    :param eff_ruptures:
+        the number of ruptures contained in the group; if -1,
+        the number is unknown and has to be computed by using
+        get_set_num_ruptures
+    """
+    @classmethod
+    def collect(cls, sources):
+        """
+        :param sources: dictionaries with a key 'tectonicRegion'
+        :returns: an ordered list of SourceGroup instances
+        """
+        source_stats_dict = {}
+        for src in sources:
+            trt = src['tectonicRegion']
+            if trt not in source_stats_dict:
+                source_stats_dict[trt] = SourceGroup(trt)
+            sg = source_stats_dict[trt]
+            if not sg.sources:
+                # we append just one source per SourceGroup, so that
+                # the memory occupation is insignificant
+                sg.sources.append(src)
+
+        # return SourceGroups, ordered by TRT string
+        return sorted(source_stats_dict.values())
+
+    def __init__(self, trt, sources=None,
+                 min_mag=None, max_mag=None, id=0, eff_ruptures=-1):
+        self.trt = trt
+        self.sources = self.src_list = []
+        self.min_mag = min_mag
+        self.max_mag = max_mag
+        self.id = id
+        if sources:
+            for src in sorted(sources, key=operator.attrgetter('source_id')):
+                self.update(src)
+        self.source_model = None  # to be set later, in CompositionInfo
+        self.eff_ruptures = eff_ruptures  # set later nby get_rlzs_assoc
+
+    def tot_ruptures(self):
+        return sum(src.num_ruptures for src in self.sources)
+
+    def update(self, src):
+        """
+        Update the attributes sources, min_mag, max_mag
+        according to the given source.
+
+        :param src:
+            an instance of :class:
+            `openquake.hazardlib.source.base.BaseSeismicSource`
+        """
+        assert src.tectonic_region_type == self.trt, (
+            src.tectonic_region_type, self.trt)
+        self.sources.append(src)
+        min_mag, max_mag = src.get_min_max_mag()
+        prev_min_mag = self.min_mag
+        if prev_min_mag is None or min_mag < prev_min_mag:
+            self.min_mag = min_mag
+        prev_max_mag = self.max_mag
+        if prev_max_mag is None or max_mag > prev_max_mag:
+            self.max_mag = max_mag
+
+    def __repr__(self):
+        return '<%s #%d %s, %d source(s), %d effective rupture(s)>' % (
+            self.__class__.__name__, self.id, self.trt,
+            len(self.sources), self.eff_ruptures)
+
+    def __lt__(self, other):
+        """
+        Make sure there is a precise ordering of SourceGroup objects.
+        Objects with less sources are put first; in case the number
+        of sources is the same, use lexicographic ordering on the trts
+        """
+        num_sources = len(self.sources)
+        other_sources = len(other.sources)
+        if num_sources == other_sources:
+            return self.trt < other.trt
+        return num_sources < other_sources
+
+    def __getitem__(self, i):
+        return self.sources[i]
+
+    def __iter__(self):
+        return iter(self.sources)
+
+    def __len__(self):
+        return len(self.sources)
+
+
+def get_set_num_ruptures(src):
+    """
+    Extract the number of ruptures and set it
+    """
+    if not src.num_ruptures:
+        src.num_ruptures = src.count_ruptures()
+    return src.num_ruptures
+
+
+def area_to_point_sources(area_src):
+    """
+    Split an area source into a generator of point sources.
+
+    MFDs will be rescaled appropriately for the number of points in the area
+    mesh.
+
+    :param area_src:
+        :class:`openquake.hazardlib.source.AreaSource`
+    """
+    mesh = area_src.polygon.discretize(area_src.area_discretization)
+    num_points = len(mesh)
+    area_mfd = area_src.mfd
+
+    if isinstance(area_mfd, mfd.TruncatedGRMFD):
+        new_a_val = math.log10(10 ** area_mfd.a_val / float(num_points))
+        new_mfd = mfd.TruncatedGRMFD(
+            a_val=new_a_val,
+            b_val=area_mfd.b_val,
+            bin_width=area_mfd.bin_width,
+            min_mag=area_mfd.min_mag,
+            max_mag=area_mfd.max_mag)
+    elif isinstance(area_mfd, mfd.EvenlyDiscretizedMFD):
+        new_occur_rates = [float(x) / num_points
+                           for x in area_mfd.occurrence_rates]
+        new_mfd = mfd.EvenlyDiscretizedMFD(
+            min_mag=area_mfd.min_mag,
+            bin_width=area_mfd.bin_width,
+            occurrence_rates=new_occur_rates)
+    elif isinstance(area_mfd, mfd.ArbitraryMFD):
+        new_occur_rates = [float(x) / num_points
+                           for x in area_mfd.occurrence_rates]
+        new_mfd = mfd.ArbitraryMFD(
+            magnitudes=area_mfd.magnitudes,
+            occurrence_rates=new_occur_rates)
+
+    for i, (lon, lat) in enumerate(zip(mesh.lons, mesh.lats)):
+        pt = source.PointSource(
+            # Generate a new ID and name
+            source_id='%s:%s' % (area_src.source_id, i),
+            name='%s:%s' % (area_src.name, i),
+            tectonic_region_type=area_src.tectonic_region_type,
+            mfd=new_mfd,
+            rupture_mesh_spacing=area_src.rupture_mesh_spacing,
+            magnitude_scaling_relationship=
+            area_src.magnitude_scaling_relationship,
+            rupture_aspect_ratio=area_src.rupture_aspect_ratio,
+            upper_seismogenic_depth=area_src.upper_seismogenic_depth,
+            lower_seismogenic_depth=area_src.lower_seismogenic_depth,
+            location=geo.Point(lon, lat),
+            nodal_plane_distribution=area_src.nodal_plane_distribution,
+            hypocenter_distribution=area_src.hypocenter_distribution,
+            temporal_occurrence_model=area_src.temporal_occurrence_model)
+        pt.src_group_id = area_src.src_group_id
+        pt.num_ruptures = pt.count_ruptures()
+        yield pt
+
+
+def _split_start_stop(n, chunksize):
+    start = 0
+    while start < n:
+        stop = start + chunksize
+        yield start, min(stop, n)
+        start = stop
+
+
+# this is only called on heavy sources
+def split_fault_source(src):
+    """
+    Generator splitting a fault source into several fault sources.
+
+    :param src:
+        an instance of :class:`openquake.hazardlib.source.base.SeismicSource`
+    """
+    # NB: the splitting is tricky; if you don't split, you will not
+    # take advantage of the multiple cores; if you split too much,
+    # the data transfer will kill you, i.e. multiprocessing/celery
+    # will fail to transmit to the workers the generated sources.
+    i = 0
+    splitlist = []
+    mag_rates = [(mag, rate) for (mag, rate) in
+                 src.mfd.get_annual_occurrence_rates() if rate]
+    if len(mag_rates) > 1:  # split by magnitude bin
+        for mag, rate in mag_rates:
+            new_src = copy.copy(src)
+            new_src.source_id = '%s:%s' % (src.source_id, i)
+            new_src.mfd = mfd.ArbitraryMFD([mag], [rate])
+            new_src.num_ruptures = new_src.count_ruptures()
+            i += 1
+            splitlist.append(new_src)
+    elif hasattr(src, 'start'):  # split by slice of ruptures
+        for start, stop in _split_start_stop(src.num_ruptures, MAXWEIGHT):
+            new_src = copy.copy(src)
+            new_src.start = start
+            new_src.stop = stop
+            new_src.num_ruptures = stop - start
+            new_src.source_id = '%s:%s' % (src.source_id, i)
+            i += 1
+            splitlist.append(new_src)
+    else:
+        splitlist.append(src)
+    return splitlist
+
+
+def split_source(src):
+    """
+    Split an area source into point sources and a fault sources into
+    smaller fault sources.
+
+    :param src:
+        an instance of :class:`openquake.hazardlib.source.base.SeismicSource`
+    """
+    if isinstance(src, source.AreaSource):
+        for s in area_to_point_sources(src):
+            yield s
+    elif isinstance(
+            src, (source.SimpleFaultSource, source.ComplexFaultSource)):
+        for s in split_fault_source(src):
+            yield s
+    else:
+        # characteristic and nonparametric sources are not split
+        # since they are small anyway
+        yield src
+
+
+def split_coords_2d(seq):
+    """
+    :param seq: a flat list with lons and lats
+    :returns: a validated list of pairs (lon, lat)
+
+    >>> split_coords_2d([1.1, 2.1, 2.2, 2.3])
+    [(1.1, 2.1), (2.2, 2.3)]
+    """
+    lons, lats = [], []
+    for i, el in enumerate(seq):
+        if i % 2 == 0:
+            lons.append(valid.longitude(el))
+        elif i % 2 == 1:
+            lats.append(valid.latitude(el))
+    return list(zip(lons, lats))
+
+
+def split_coords_3d(seq):
+    """
+    :param seq: a flat list with lons, lats and depths
+    :returns: a validated list of (lon, lat, depths) triplets
+
+    >>> split_coords_3d([1.1, 2.1, 0.1, 2.3, 2.4, 0.1])
+    [(1.1, 2.1, 0.1), (2.3, 2.4, 0.1)]
+    """
+    lons, lats, depths = [], [], []
+    for i, el in enumerate(seq):
+        if i % 3 == 0:
+            lons.append(valid.longitude(el))
+        elif i % 3 == 1:
+            lats.append(valid.latitude(el))
+        elif i % 3 == 2:
+            depths.append(valid.depth(el))
+    return list(zip(lons, lats, depths))
+
+
+class RuptureConverter(object):
+    """
+    Convert ruptures from nodes into Hazardlib ruptures.
+    """
+    fname = None  # should be set externally
+
+    def __init__(self, rupture_mesh_spacing, complex_fault_mesh_spacing=None):
+        self.rupture_mesh_spacing = rupture_mesh_spacing
+        self.complex_fault_mesh_spacing = (
+            complex_fault_mesh_spacing or rupture_mesh_spacing)
+
+    def convert_node(self, node):
+        """
+        Convert the given rupture node into a hazardlib rupture, depending
+        on the node tag.
+
+        :param node: a node representing a rupture
+        """
+        with context(self.fname, node):
+            convert_rupture = getattr(self, 'convert_' + striptag(node.tag))
+            mag = ~node.magnitude
+            rake = ~node.rake
+            h = node.hypocenter
+            hypocenter = geo.Point(h['lon'], h['lat'], h['depth'])
+        return convert_rupture(node, mag, rake, hypocenter)
+
+    def geo_line(self, edge):
+        """
+        Utility function to convert a node of kind edge
+        into a :class:`openquake.hazardlib.geo.Line` instance.
+
+        :param edge: a node describing an edge
+        """
+        with context(self.fname, edge.LineString.posList) as plist:
+            coords = split_coords_2d(~plist)
+        return geo.Line([geo.Point(*p) for p in coords])
+
+    def geo_lines(self, edges):
+        """
+        Utility function to convert a list of edges into a list of
+        :class:`openquake.hazardlib.geo.Line` instances.
+
+        :param edge: a node describing an edge
+        """
+        lines = []
+        for edge in edges:
+            with context(self.fname, edge):
+                coords = split_coords_3d(~edge.LineString.posList)
+            lines.append(geo.Line([geo.Point(*p) for p in coords]))
+        return lines
+
+    def geo_planar(self, surface):
+        """
+        Utility to convert a PlanarSurface node with subnodes
+        topLeft, topRight, bottomLeft, bottomRight into a
+        :class:`openquake.hazardlib.geo.PlanarSurface` instance.
+
+        :param surface: PlanarSurface node
+        """
+        with context(self.fname, surface):
+            tl = surface.topLeft
+            top_left = geo.Point(tl['lon'], tl['lat'], tl['depth'])
+            tr = surface.topRight
+            top_right = geo.Point(tr['lon'], tr['lat'], tr['depth'])
+            bl = surface.bottomLeft
+            bottom_left = geo.Point(bl['lon'], bl['lat'], bl['depth'])
+            br = surface.bottomRight
+            bottom_right = geo.Point(br['lon'], br['lat'], br['depth'])
+        return geo.PlanarSurface.from_corner_points(
+            self.rupture_mesh_spacing,
+            top_left, top_right, bottom_right, bottom_left)
+
+    def convert_surfaces(self, surface_nodes):
+        """
+        Utility to convert a list of surface nodes into a single hazardlib
+        surface. There are three possibilities:
+
+        1. there is a single simpleFaultGeometry node; returns a
+           :class:`openquake.hazardlib.geo.simpleFaultSurface` instance
+        2. there is a single complexFaultGeometry node; returns a
+           :class:`openquake.hazardlib.geo.complexFaultSurface` instance
+        3. there is a list of PlanarSurface nodes; returns a
+           :class:`openquake.hazardlib.geo.MultiSurface` instance
+
+        :param surface_nodes: surface nodes as just described
+        """
+        surface_node = surface_nodes[0]
+        if surface_node.tag.endswith('simpleFaultGeometry'):
+            surface = geo.SimpleFaultSurface.from_fault_data(
+                self.geo_line(surface_node),
+                ~surface_node.upperSeismoDepth,
+                ~surface_node.lowerSeismoDepth,
+                ~surface_node.dip,
+                self.rupture_mesh_spacing)
+        elif surface_node.tag.endswith('complexFaultGeometry'):
+            surface = geo.ComplexFaultSurface.from_fault_data(
+                self.geo_lines(surface_node),
+                self.complex_fault_mesh_spacing)
+        else:  # a collection of planar surfaces
+            planar_surfaces = list(map(self.geo_planar, surface_nodes))
+            surface = geo.MultiSurface(planar_surfaces)
+        return surface
+
+    def convert_simpleFaultRupture(self, node, mag, rake, hypocenter):
+        """
+        Convert a simpleFaultRupture node.
+
+        :param node: the rupture node
+        :param mag: the rupture magnitude
+        :param rake: the rupture rake angle
+        :param hypocenter: the rupture hypocenter
+        """
+        with context(self.fname, node):
+            surfaces = [node.simpleFaultGeometry]
+        rupt = source.rupture.Rupture(
+            mag=mag, rake=rake, tectonic_region_type=None,
+            hypocenter=hypocenter,
+            surface=self.convert_surfaces(surfaces),
+            source_typology=source.SimpleFaultSource)
+        return rupt
+
+    def convert_complexFaultRupture(self, node, mag, rake, hypocenter):
+        """
+        Convert a complexFaultRupture node.
+
+        :param node: the rupture node
+        :param mag: the rupture magnitude
+        :param rake: the rupture rake angle
+        :param hypocenter: the rupture hypocenter
+        """
+        with context(self.fname, node):
+            surfaces = [node.complexFaultGeometry]
+        rupt = source.rupture.Rupture(
+            mag=mag, rake=rake, tectonic_region_type=None,
+            hypocenter=hypocenter,
+            surface=self.convert_surfaces(surfaces),
+            source_typology=source.ComplexFaultSource)
+        return rupt
+
+    def convert_singlePlaneRupture(self, node, mag, rake, hypocenter):
+        """
+        Convert a singlePlaneRupture node.
+
+        :param node: the rupture node
+        :param mag: the rupture magnitude
+        :param rake: the rupture rake angle
+        :param hypocenter: the rupture hypocenter
+        """
+        with context(self.fname, node):
+            surfaces = [node.planarSurface]
+        rupt = source.rupture.Rupture(
+            mag=mag, rake=rake,
+            tectonic_region_type=None,
+            hypocenter=hypocenter,
+            surface=self.convert_surfaces(surfaces),
+            source_typology=source.NonParametricSeismicSource)
+        return rupt
+
+    def convert_multiPlanesRupture(self, node, mag, rake, hypocenter):
+        """
+        Convert a multiPlanesRupture node.
+
+        :param node: the rupture node
+        :param mag: the rupture magnitude
+        :param rake: the rupture rake angle
+        :param hypocenter: the rupture hypocenter
+        """
+        with context(self.fname, node):
+            surfaces = list(node.getnodes('planarSurface'))
+        rupt = source.rupture.Rupture(
+            mag=mag, rake=rake,
+            tectonic_region_type=None,
+            hypocenter=hypocenter,
+            surface=self.convert_surfaces(surfaces),
+            source_typology=source.NonParametricSeismicSource)
+        return rupt
+
+
+class SourceConverter(RuptureConverter):
+    """
+    Convert sources from valid nodes into Hazardlib objects.
+    """
+    def __init__(self, investigation_time, rupture_mesh_spacing,
+                 complex_fault_mesh_spacing=None, width_of_mfd_bin=1.0,
+                 area_source_discretization=None):
+        self.area_source_discretization = area_source_discretization
+        self.rupture_mesh_spacing = rupture_mesh_spacing
+        self.complex_fault_mesh_spacing = (
+            complex_fault_mesh_spacing or rupture_mesh_spacing)
+        self.width_of_mfd_bin = width_of_mfd_bin
+        self.tom = PoissonTOM(investigation_time)
+
+    def convert_node(self, node):
+        """
+        Convert the given node into a hazardlib source, depending
+        on the node tag.
+
+        :param node: a node representing a source
+        """
+        with context(self.fname, node):
+            convert_source = getattr(self, 'convert_' + striptag(node.tag))
+        return convert_source(node)
+
+    def convert_mfdist(self, node):
+        """
+        Convert the given node into a Magnitude-Frequency Distribution
+        object.
+
+        :param node: a node of kind incrementalMFD or truncGutenbergRichterMFD
+        :returns: a :class:`openquake.hazardlib.mdf.EvenlyDiscretizedMFD.` or
+                  :class:`openquake.hazardlib.mdf.TruncatedGRMFD` instance
+        """
+        with context(self.fname, node):
+            [mfd_node] = [subnode for subnode in node
+                          if subnode.tag.endswith(
+                              ('incrementalMFD', 'truncGutenbergRichterMFD',
+                               'arbitraryMFD', 'YoungsCoppersmithMFD'))]
+            if mfd_node.tag.endswith('incrementalMFD'):
+                return mfd.EvenlyDiscretizedMFD(
+                    min_mag=mfd_node['minMag'], bin_width=mfd_node['binWidth'],
+                    occurrence_rates=~mfd_node.occurRates)
+            elif mfd_node.tag.endswith('truncGutenbergRichterMFD'):
+                return mfd.TruncatedGRMFD(
+                    a_val=mfd_node['aValue'], b_val=mfd_node['bValue'],
+                    min_mag=mfd_node['minMag'], max_mag=mfd_node['maxMag'],
+                    bin_width=self.width_of_mfd_bin)
+            elif mfd_node.tag.endswith('arbitraryMFD'):
+                return mfd.ArbitraryMFD(
+                    magnitudes=~mfd_node.magnitudes,
+                    occurrence_rates=~mfd_node.occurRates)
+            elif mfd_node.tag.endswith('YoungsCoppersmithMFD'):
+                if "totalMomentRate" in mfd_node.attrib.keys():
+                    # Return Youngs & Coppersmith from the total moment rate
+                    return mfd.YoungsCoppersmith1985MFD.from_total_moment_rate(
+                        min_mag=mfd_node["minMag"], b_val=mfd_node["bValue"],
+                        char_mag=mfd_node["characteristicMag"],
+                        total_moment_rate=mfd_node["totalMomentRate"],
+                        bin_width=mfd_node["binWidth"])
+                elif "characteristicRate" in mfd_node.attrib.keys():
+                    # Return Youngs & Coppersmith from the total moment rate
+                    return mfd.YoungsCoppersmith1985MFD.\
+                        from_characteristic_rate(
+                            min_mag=mfd_node["minMag"],
+                            b_val=mfd_node["bValue"],
+                            char_mag=mfd_node["characteristicMag"],
+                            char_rate=mfd_node["characteristicRate"],
+                            bin_width=mfd_node["binWidth"])
+
+    def convert_npdist(self, node):
+        """
+        Convert the given node into a Nodal Plane Distribution.
+
+        :param node: a nodalPlaneDist node
+        :returns: a :class:`openquake.hazardlib.geo.NodalPlane` instance
+        """
+        with context(self.fname, node):
+            npdist = []
+            for np in node.nodalPlaneDist:
+                prob, strike, dip, rake = (
+                    np['probability'], np['strike'], np['dip'], np['rake'])
+                npdist.append((prob, geo.NodalPlane(strike, dip, rake)))
+            return pmf.PMF(npdist)
+
+    def convert_hpdist(self, node):
+        """
+        Convert the given node into a probability mass function for the
+        hypo depth distribution.
+
+        :param node: a hypoDepthDist node
+        :returns: a :class:`openquake.hazardlib.pmf.PMF` instance
+        """
+        with context(self.fname, node):
+            return pmf.PMF([(hd['probability'], hd['depth'])
+                            for hd in node.hypoDepthDist])
+
+    def convert_areaSource(self, node):
+        """
+        Convert the given node into an area source object.
+
+        :param node: a node with tag areaGeometry
+        :returns: a :class:`openquake.hazardlib.source.AreaSource` instance
+        """
+        geom = node.areaGeometry
+        coords = split_coords_2d(~geom.Polygon.exterior.LinearRing.posList)
+        polygon = geo.Polygon([geo.Point(*xy) for xy in coords])
+        msr = valid.SCALEREL[~node.magScaleRel]()
+        area_discretization = geom.attrib.get(
+            'discretization', self.area_source_discretization)
+        if area_discretization is None:
+            raise ValueError(
+                'The source %r has no `discretization` parameter and the job.'
+                'ini file has no `area_source_discretization` parameter either'
+                % node['id'])
+        return source.AreaSource(
+            source_id=node['id'],
+            name=node['name'],
+            tectonic_region_type=node.attrib.get('tectonicRegion'),
+            mfd=self.convert_mfdist(node),
+            rupture_mesh_spacing=self.rupture_mesh_spacing,
+            magnitude_scaling_relationship=msr,
+            rupture_aspect_ratio=~node.ruptAspectRatio,
+            upper_seismogenic_depth=~geom.upperSeismoDepth,
+            lower_seismogenic_depth=~geom.lowerSeismoDepth,
+            nodal_plane_distribution=self.convert_npdist(node),
+            hypocenter_distribution=self.convert_hpdist(node),
+            polygon=polygon,
+            area_discretization=area_discretization,
+            temporal_occurrence_model=self.tom)
+
+    def convert_pointSource(self, node):
+        """
+        Convert the given node into a point source object.
+
+        :param node: a node with tag pointGeometry
+        :returns: a :class:`openquake.hazardlib.source.PointSource` instance
+        """
+        geom = node.pointGeometry
+        lon_lat = ~geom.Point.pos
+        msr = valid.SCALEREL[~node.magScaleRel]()
+        return source.PointSource(
+            source_id=node['id'],
+            name=node['name'],
+            tectonic_region_type=node.attrib.get('tectonicRegion'),
+            mfd=self.convert_mfdist(node),
+            rupture_mesh_spacing=self.rupture_mesh_spacing,
+            magnitude_scaling_relationship=msr,
+            rupture_aspect_ratio=~node.ruptAspectRatio,
+            upper_seismogenic_depth=~geom.upperSeismoDepth,
+            lower_seismogenic_depth=~geom.lowerSeismoDepth,
+            location=geo.Point(*lon_lat),
+            nodal_plane_distribution=self.convert_npdist(node),
+            hypocenter_distribution=self.convert_hpdist(node),
+            temporal_occurrence_model=self.tom)
+
+    def convert_simpleFaultSource(self, node):
+        """
+        Convert the given node into a simple fault object.
+
+        :param node: a node with tag areaGeometry
+        :returns: a :class:`openquake.hazardlib.source.SimpleFaultSource`
+                  instance
+        """
+        geom = node.simpleFaultGeometry
+        msr = valid.SCALEREL[~node.magScaleRel]()
+        fault_trace = self.geo_line(geom)
+        mfd = self.convert_mfdist(node)
+        with context(self.fname, node):
+            try:
+                hypo_list = valid.hypo_list(node.hypoList)
+            except AttributeError:
+                hypo_list = ()
+            try:
+                slip_list = valid.slip_list(node.slipList)
+            except AttributeError:
+                slip_list = ()
+            simple = source.SimpleFaultSource(
+                source_id=node['id'],
+                name=node['name'],
+                tectonic_region_type=node.attrib.get('tectonicRegion'),
+                mfd=mfd,
+                rupture_mesh_spacing=self.rupture_mesh_spacing,
+                magnitude_scaling_relationship=msr,
+                rupture_aspect_ratio=~node.ruptAspectRatio,
+                upper_seismogenic_depth=~geom.upperSeismoDepth,
+                lower_seismogenic_depth=~geom.lowerSeismoDepth,
+                fault_trace=fault_trace,
+                dip=~geom.dip,
+                rake=~node.rake,
+                temporal_occurrence_model=self.tom,
+                hypo_list=hypo_list,
+                slip_list=slip_list)
+        return simple
+
+    def convert_complexFaultSource(self, node):
+        """
+        Convert the given node into a complex fault object.
+
+        :param node: a node with tag areaGeometry
+        :returns: a :class:`openquake.hazardlib.source.ComplexFaultSource`
+                  instance
+        """
+        geom = node.complexFaultGeometry
+        edges = self.geo_lines(geom)
+        mfd = self.convert_mfdist(node)
+        msr = valid.SCALEREL[~node.magScaleRel]()
+        with context(self.fname, node):
+            cmplx = source.ComplexFaultSource(
+                source_id=node['id'],
+                name=node['name'],
+                tectonic_region_type=node.attrib.get('tectonicRegion'),
+                mfd=mfd,
+                rupture_mesh_spacing=self.complex_fault_mesh_spacing,
+                magnitude_scaling_relationship=msr,
+                rupture_aspect_ratio=~node.ruptAspectRatio,
+                edges=edges,
+                rake=~node.rake,
+                temporal_occurrence_model=self.tom)
+        return cmplx
+
+    def convert_characteristicFaultSource(self, node):
+        """
+        Convert the given node into a characteristic fault object.
+
+        :param node:
+            a node with tag areaGeometry
+        :returns:
+            a :class:`openquake.hazardlib.source.CharacteristicFaultSource`
+            instance
+        """
+        char = source.CharacteristicFaultSource(
+            source_id=node['id'],
+            name=node['name'],
+            tectonic_region_type=node.attrib.get('tectonicRegion'),
+            mfd=self.convert_mfdist(node),
+            surface=self.convert_surfaces(node.surface),
+            rake=~node.rake,
+            temporal_occurrence_model=self.tom)
+        return char
+
+    def convert_nonParametricSeismicSource(self, node):
+        """
+        Convert the given node into a non parametric source object.
+
+        :param node:
+            a node with tag areaGeometry
+        :returns:
+            a :class:`openquake.hazardlib.source.NonParametricSeismicSource`
+            instance
+        """
+        trt = node.attrib.get('tectonicRegion')
+        rup_pmf_data = []
+        for rupnode in node:
+            probs = pmf.PMF(rupnode['probs_occur'])
+            rup = RuptureConverter.convert_node(self, rupnode)
+            rup.tectonic_region_type = trt
+            rup_pmf_data.append((rup, probs))
+        nps = source.NonParametricSeismicSource(
+            node['id'], node['name'], trt, rup_pmf_data)
+        return nps
+
+    def convert_sourceModel(self, node):
+        return [self.convert_node(subnode) for subnode in node]
+
+    def convert_sourceGroup(self, node):
+        """
+        Convert the given node into a SourceGroup object.
+
+        :param node:
+            a node with tag sourceGroup
+        :returns:
+            a :class:`openquake.commonlib.source.SourceGroup` instance
+            mimicking a :class:`openquake.hazardlib.source.base.SourceGroup`
+        """
+        trt = node['tectonicRegion']
+        srcs_weights = node.attrib.get('srcs_weights')
+        grp_attrs = {k: v for k, v in node.attrib.items()
+                     if k not in ('name', 'src_interdep', 'rup_interdep',
+                                  'srcs_weights')}
+        srcs = []
+        for src_node in node:
+            src = self.convert_node(src_node)
+            # transmit the group attributes to the underlying source
+            for attr, value in grp_attrs.items():
+                if attr == 'tectonicRegion':
+                    src.tectonic_region_type = value
+                else:  # transmit as it is
+                    setattr(src, attr, node[attr])
+            srcs.append(src)
+        sg = SourceGroup(trt, srcs)
+        if srcs_weights is not None:
+            if len(srcs_weights) != len(node):
+                raise ValueError('There are %d srcs_weights but %d source(s)'
+                                 % (len(srcs_weights), len(node)))
+        sg.name = node.attrib.get('name')
+        sg.src_interdep = node.attrib.get('src_interdep')
+        sg.rup_interdep = node.attrib.get('rup_interdep')
+        sg.srcs_weights = srcs_weights
+        return sg
+
+
+def parse_ses_ruptures(fname):
+    """
+    Convert a stochasticEventSetCollection file into a set of SES,
+    each one containing ruptures with an etag and a seed.
+    """
+    raise NotImplementedError('parse_ses_ruptures')

--- a/openquake/hazardlib/sourcewriter.py
+++ b/openquake/hazardlib/sourcewriter.py
@@ -1,0 +1,500 @@
+# -*- coding: utf-8 -*-
+# vim: tabstop=4 shiftwidth=4 softtabstop=4
+#
+# Copyright (C) 2015-2017 GEM Foundation
+#
+# OpenQuake is free software: you can redistribute it and/or modify it
+# under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# OpenQuake is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with OpenQuake. If not, see <http://www.gnu.org/licenses/>.
+
+"""
+Source model XML Writer
+"""
+
+import os
+from openquake.baselib.general import CallableDict
+from openquake.baselib.node import Node
+from openquake.hazardlib import nrml
+
+obj_to_node = CallableDict(lambda obj: obj.__class__.__name__)
+
+
+def build_area_source_geometry(area_source):
+    """
+    Returns the area source geometry as a Node
+    :param area_source:
+        Area source model as an instance of the :class:
+        openquake.hazardlib.source.area.AreaSource
+    :returns:
+        Instance of :class: openquake.baselib.node.Node
+    """
+    geom_str = ["%s %s" % lonlat for lonlat in
+                zip(area_source.polygon.lons, area_source.polygon.lats)]
+    poslist_node = Node("gml:posList", text=geom_str)
+    linear_ring_node = Node("gml:LinearRing", nodes=[poslist_node])
+    exterior_node = Node("gml:exterior", nodes=[linear_ring_node])
+    polygon_node = Node("gml:Polygon", nodes=[exterior_node])
+    upper_depth_node = Node(
+        "upperSeismoDepth", text=area_source.upper_seismogenic_depth)
+    lower_depth_node = Node(
+        "lowerSeismoDepth", text=area_source.lower_seismogenic_depth)
+    return Node(
+        "areaGeometry", {'discretization': area_source.area_discretization},
+        nodes=[polygon_node, upper_depth_node, lower_depth_node])
+
+
+def build_point_source_geometry(point_source):
+    """
+    Returns the poing source geometry as a Node
+    :param point_source:
+        Point source model as an instance of the :class:
+        openquake.hazardlib.source.point.PointSource
+    :returns:
+        Instance of :class: openquake.baselib.node.Node
+    """
+    xy = point_source.location.x, point_source.location.y
+    pos_node = Node("gml:pos", text=xy)
+    point_node = Node("gml:Point", nodes=[pos_node])
+    upper_depth_node = Node(
+        "upperSeismoDepth", text=point_source.upper_seismogenic_depth)
+    lower_depth_node = Node(
+        "lowerSeismoDepth", text=point_source.lower_seismogenic_depth)
+    return Node(
+        "pointGeometry",
+        nodes=[point_node, upper_depth_node, lower_depth_node])
+
+
+def build_linestring_node(line, with_depth=False):
+    """
+    Parses a line to a Node class
+    :param line:
+        Line as instance of :class: openquake.hazardlib.geo.line.Line
+    :param bool with_depth:
+        Include the depth values (True) or not (False):
+    :returns:
+        Instance of :class: openquake.baselib.node.Node
+    """
+    if with_depth:
+        geom_str = ["%s %s %s" % (p.x, p.y, p.z) for p in line.points]
+    else:
+        geom_str = ["%s %s" % (p.x, p.y) for p in line.points]
+    poslist_node = Node("gml:posList", text=geom_str)
+    return Node("gml:LineString", nodes=[poslist_node])
+
+
+def build_simple_fault_geometry(fault_source):
+    """
+    Returns the simple fault source geometry as a Node
+    :param fault_source:
+        Simple fault source model as an instance of the :class:
+        openquake.hazardlib.source.simple_fault.SimpleFaultSource
+    :returns:
+        Instance of :class: openquake.baselib.node.Node
+    """
+    linestring_node = build_linestring_node(fault_source.fault_trace,
+                                            with_depth=False)
+    dip_node = Node("dip", text=fault_source.dip)
+    upper_depth_node = Node(
+        "upperSeismoDepth", text=fault_source.upper_seismogenic_depth)
+    lower_depth_node = Node(
+        "lowerSeismoDepth", text=fault_source.lower_seismogenic_depth)
+    return Node("simpleFaultGeometry",
+                nodes=[linestring_node, dip_node, upper_depth_node,
+                       lower_depth_node])
+
+
+def build_complex_fault_geometry(fault_source):
+    """
+    Returns the complex fault source geometry as a Node
+    :param fault_source:
+        Complex fault source model as an instance of the :class:
+        openquake.hazardlib.source.complex_fault.ComplexFaultSource
+    :returns:
+        Instance of :class: openquake.baselib.node.Node
+    """
+    num_edges = len(fault_source.edges)
+    edge_nodes = []
+    for iloc, edge in enumerate(fault_source.edges):
+        if iloc == 0:
+            # Top Edge
+            node_name = "faultTopEdge"
+
+        elif iloc == (num_edges - 1):
+            # Bottom edge
+            node_name = "faultBottomEdge"
+        else:
+            # Intermediate edge
+            node_name = "intermediateEdge"
+        edge_nodes.append(
+            Node(node_name,
+                 nodes=[build_linestring_node(edge, with_depth=True)]))
+    return Node("complexFaultGeometry", nodes=edge_nodes)
+
+
+@obj_to_node.add('EvenlyDiscretizedMFD')
+def build_evenly_discretised_mfd(mfd):
+    """
+    Returns the evenly discretized MFD as a Node
+    :param mfd:
+        MFD as instance of :class:
+        openquake.hazardlib.mfd.evenly_discretized.EvenlyDiscretizedMFD
+    :returns:
+        Instance of :class: openquake.baselib.node.Node
+    """
+    occur_rates = Node("occurRates", text=mfd.occurrence_rates)
+    return Node("incrementalMFD",
+                {"binWidth": mfd.bin_width, "minMag": mfd.min_mag},
+                nodes=[occur_rates])
+
+
+@obj_to_node.add('TruncatedGRMFD')
+def build_truncated_gr_mfd(mfd):
+    """
+    Parses the truncated Gutenberg Richter MFD as a Node
+    :param mfd:
+        MFD as instance of :class:
+        openquake.hazardlib.mfd.truncated_gr.TruncatedGRMFD
+    :returns:
+        Instance of :class: openquake.baselib.node.Node
+    """
+    return Node("truncGutenbergRichterMFD",
+                {"aValue": mfd.a_val, "bValue": mfd.b_val,
+                 "minMag": mfd.min_mag, "maxMag": mfd.max_mag})
+
+
+@obj_to_node.add('ArbitraryMFD')
+def build_arbitrary_mfd(mfd):
+    """
+    Parses the arbitrary MFD as a Node
+    param mfd:
+        MFD as instance of :class:
+        openquake.hazardlib.mfd.arbitrary.ArbitraryMFD
+    :returns:
+        Instance of :class: openquake.baselib.node.Node
+    """
+    magnitudes = Node("magnitudes", text=mfd.magnitudes)
+    occur_rates = Node("occurRates", text=mfd.occurrence_rates)
+    return Node("arbitraryMFD", nodes=[magnitudes, occur_rates])
+
+
+@obj_to_node.add("YoungsCoppersmith1985MFD")
+def build_youngs_coppersmith_mfd(mfd):
+    """
+    Parses the Youngs & Coppersmith MFD as a node. Note that the MFD does
+    not hold the total moment rate, but only the characteristic rate. Therefore
+    the node is written to the characteristic rate version regardless of
+    whether or not it was originally created from total moment rate
+    :param mfd:
+        MFD as instance of :class:
+        openquake.hazardlib.mfd.youngs_coppersmith_1985.
+        YoungsCoppersmith1985MFD
+    :returns:
+        Instance of :class: openquake.baselib.node.Node
+    """
+    return Node("YoungsCoppersmithMFD",
+                {"minMag": mfd.min_mag, "bValue": mfd.b_val,
+                 "characteristicMag": mfd.char_mag,
+                 "characteristicRate": mfd.char_rate,
+                 "binWidth": mfd.bin_width})
+
+
+def build_nodal_plane_dist(npd):
+    """
+    Returns the nodal plane distribution as a Node instance
+    :param npd:
+        Nodal plane distribution as instance of :class:
+        openquake.hazardlib.pmf.PMF
+    :returns:
+        Instance of :class: openquake.baselib.node.Node
+    """
+    npds = []
+    for prob, npd in npd.data:
+        nodal_plane = Node(
+            "nodalPlane", {"dip": npd.dip, "probability": prob,
+                           "strike": npd.strike, "rake": npd.rake})
+        npds.append(nodal_plane)
+    return Node("nodalPlaneDist", nodes=npds)
+
+
+def build_hypo_depth_dist(hdd):
+    """
+    Returns the hypocentral depth distribution as a Node instance
+    :param hdd:
+        Hypocentral depth distribution as an instance of :class:
+        openuake.hzardlib.pmf.PMF
+    :returns:
+        Instance of :class: openquake.baselib.node.Node
+    """
+    hdds = []
+    for (prob, depth) in hdd.data:
+        hdds.append(
+            Node("hypoDepth", {"depth": depth, "probability": prob}))
+    return Node("hypoDepthDist", nodes=hdds)
+
+
+def get_distributed_seismicity_source_nodes(source):
+    """
+    Returns list of nodes of attributes common to all distributed seismicity
+    source classes
+    :param source:
+        Seismic source as instance of :class:
+        openquake.hazardlib.source.area.AreaSource or :class:
+        openquake.hazardlib.source.point.PointSource
+    :returns:
+        List of instances of :class: openquake.baselib.node.Node
+    """
+    source_nodes = []
+    #  parse msr
+    source_nodes.append(
+        Node("magScaleRel",
+             text=source.magnitude_scaling_relationship.__class__.__name__))
+    # Parse aspect ratio
+    source_nodes.append(
+        Node("ruptAspectRatio", text=source.rupture_aspect_ratio))
+    # Parse MFD
+    source_nodes.append(obj_to_node(source.mfd))
+    # Parse nodal plane distribution
+    source_nodes.append(
+        build_nodal_plane_dist(source.nodal_plane_distribution))
+    # Parse hypocentral depth distribution
+    source_nodes.append(
+        build_hypo_depth_dist(source.hypocenter_distribution))
+    return source_nodes
+
+
+def build_hypo_list_node(hypo_list):
+    """
+    :param hypo_list:
+       an array of shape (N, 3) with columns (alongStrike, downDip, weight)
+    :returns:
+        a hypoList node containing N hypo nodes
+    """
+    hypolist = Node('hypoList', {})
+    for row in hypo_list:
+        n = Node(
+            'hypo', dict(alongStrike=row[0], downDip=row[1], weight=row[2]))
+        hypolist.append(n)
+    return hypolist
+
+
+def build_slip_list_node(slip_list):
+    """
+    :param slip_list:
+       an array of shape (N, 2) with columns (slip, weight)
+    :returns:
+        a hypoList node containing N slip nodes
+    """
+    sliplist = Node('slipList', {})
+    for row in slip_list:
+        sliplist.append(
+            Node('slip', dict(weight=row[1]), row[0]))
+    return sliplist
+
+
+def get_fault_source_nodes(source):
+    """
+    Returns list of nodes of attributes common to all fault source classes
+    :param source:
+        Fault source as instance of :class:
+        openquake.hazardlib.source.simple_fault.SimpleFaultSource or :class:
+        openquake.hazardlib.source.complex_fault.ComplexFaultSource
+    :returns:
+        List of instances of :class: openquake.baselib.node.Node
+    """
+    source_nodes = []
+    #  parse msr
+    source_nodes.append(
+        Node(
+            "magScaleRel",
+            text=source.magnitude_scaling_relationship.__class__.__name__))
+    # Parse aspect ratio
+    source_nodes.append(
+        Node("ruptAspectRatio", text=source.rupture_aspect_ratio))
+    # Parse MFD
+    source_nodes.append(obj_to_node(source.mfd))
+    # Parse Rake
+    source_nodes.append(Node("rake", text=source.rake))
+    if len(getattr(source, 'hypo_list', [])):
+        source_nodes.append(build_hypo_list_node(source.hypo_list))
+    if len(getattr(source, 'slip_list', [])):
+        source_nodes.append(build_slip_list_node(source.slip_list))
+    return source_nodes
+
+
+def get_source_attributes(source):
+    """
+    Retreives a dictionary of source attributes from the source class
+    :param source:
+        Seismic source as instance of :class:
+        openquake.hazardlib.source.base.BaseSeismicSource
+    :returns:
+        Dictionary of source attributes
+    """
+    return {"id": source.source_id,
+            "name": source.name,
+            "tectonicRegion": source.tectonic_region_type}
+
+
+@obj_to_node.add('AreaSource')
+def build_area_source_node(area_source):
+    """
+    Parses an area source to a Node class
+    :param area_source:
+        Area source as instance of :class:
+        openquake.hazardlib.source.area.AreaSource
+    :returns:
+        Instance of :class: openquake.baselib.node.Node
+    """
+    # parse geometry
+    source_nodes = [build_area_source_geometry(area_source)]
+    # parse common distributed attributes
+    source_nodes.extend(get_distributed_seismicity_source_nodes(area_source))
+    return Node(
+        "areaSource", get_source_attributes(area_source), nodes=source_nodes)
+
+
+@obj_to_node.add('CharacteristicFaultSource')
+def build_characteristic_fault_source_node(source):
+    source_nodes = [obj_to_node(source.mfd)]
+    source_nodes.append(Node("rake", text=source.rake))
+    surface_node = Node('surface', nodes=source.surface.surface_nodes)
+    source_nodes.append(surface_node)
+    return Node('characteristicFaultSource',
+                get_source_attributes(source),
+                nodes=source_nodes)
+
+
+@obj_to_node.add('NonParametricSeismicSource')
+def build_nonparametric_source_node(source):
+    rup_nodes = []
+    for rup, pmf in source.data:
+        probs = [prob for (prob, no) in pmf.data]
+        rup_nodes.append(build_rupture_node(rup, probs))
+    return Node('nonParametricSeismicSource',
+                get_source_attributes(source), nodes=rup_nodes)
+
+
+def build_rupture_node(rupt, probs_occur):
+    """
+    :param rupt: a hazardlib rupture object
+    :param probs_occur: a list of floats with sum 1
+    """
+    h = rupt.hypocenter
+    hp_dict = dict(lon=h.longitude, lat=h.latitude, depth=h.depth)
+    rupt_nodes = [Node('magnitude', {}, rupt.mag),
+                  Node('rake', {}, rupt.rake),
+                  Node('hypocenter', hp_dict)]
+    rupt_nodes.extend(rupt.surface.surface_nodes)
+    geom = rupt.surface.surface_nodes[0].tag
+    if len(rupt.surface.surface_nodes) > 1:
+        name = 'multiPlanesRupture'
+    elif geom == 'planarSurface':
+        name = 'singlePlaneRupture'
+    elif geom == 'simpleFaultGeometry':
+        name = 'simpleFaultRupture'
+    elif geom == 'complexFaultGeometry':
+        name = 'complexFaultRupture'
+    return Node(name, {'probs_occur': probs_occur}, nodes=rupt_nodes)
+
+
+@obj_to_node.add('PointSource')
+def build_point_source_node(point_source):
+    """
+    Parses a point source to a Node class
+    :param point_source:
+        Point source as instance of :class:
+        openquake.hazardlib.source.point.PointSource
+    :returns:
+        Instance of :class: openquake.baselib.node.Node
+
+    """
+    # parse geometry
+    source_nodes = [build_point_source_geometry(point_source)]
+    # parse common distributed attributes
+    source_nodes.extend(get_distributed_seismicity_source_nodes(point_source))
+    return Node("pointSource",
+                get_source_attributes(point_source),
+                nodes=source_nodes)
+
+
+@obj_to_node.add('SimpleFaultSource')
+def build_simple_fault_source_node(fault_source):
+    """
+    Parses a simple fault source to a Node class
+    :param fault_source:
+        Simple fault source as instance of :class:
+        openquake.hazardlib.source.simple_fault.SimpleFaultSource
+    :returns:
+        Instance of :class: openquake.baselib.node.Node
+    """
+    # Parse geometry
+    source_nodes = [build_simple_fault_geometry(fault_source)]
+    # Parse common fault source attributes
+    source_nodes.extend(get_fault_source_nodes(fault_source))
+    return Node("simpleFaultSource",
+                get_source_attributes(fault_source),
+                nodes=source_nodes)
+
+
+@obj_to_node.add('ComplexFaultSource')
+def build_complex_fault_source_node(fault_source):
+    """
+    Parses a complex fault source to a Node class
+    :param fault_source:
+        Simple fault source as instance of :class:
+        openquake.hazardlib.source.complex_fault.ComplexFaultSource
+    :returns:
+        Instance of :class: openquake.baselib.node.Node
+    """
+    # Parse geometry
+    source_nodes = [build_complex_fault_geometry(fault_source)]
+    # Parse common fault source attributes
+    source_nodes.extend(get_fault_source_nodes(fault_source))
+    return Node("complexFaultSource",
+                get_source_attributes(fault_source),
+                nodes=source_nodes)
+
+
+@obj_to_node.add('SourceGroup')
+def build_source_group(source_group):
+    source_nodes = [obj_to_node(src) for src in source_group.src_list]
+    attrs = dict(tectonicRegion=source_group.trt)
+    if source_group.name:
+        attrs['name'] = source_group.name
+    if source_group.src_interdep:
+        attrs['src_interdep'] = source_group.src_interdep
+    if source_group.rup_interdep:
+        attrs['rup_interdep'] = source_group.rup_interdep
+    if source_group.srcs_weights:
+        attrs['srcs_weights'] = ' '.join(map(str, source_group.srcs_weights))
+    return Node('sourceGroup', attrs, nodes=source_nodes)
+
+
+# ##################### generic source model writer ####################### #
+
+def write_source_model(dest, groups, name=None):
+    """
+    Writes a source model to XML.
+
+    :param str dest:
+        Destination path
+    :param list groups:
+        Source model as list of SourceGroups
+    :param str name:
+        Name of the source model (if missing, extracted from the filename)
+    """
+    name = name or os.path.splitext(os.path.basename(dest))[0]
+    nodes = list(map(obj_to_node, sorted(groups)))
+    source_model = Node("sourceModel", {"name": name}, nodes=nodes)
+    with open(dest, 'wb') as f:
+        nrml.write([source_model], f, '%s')
+    return dest

--- a/openquake/hazardlib/tests/valid_test.py
+++ b/openquake/hazardlib/tests/valid_test.py
@@ -1,0 +1,139 @@
+# -*- coding: utf-8 -*-
+# vim: tabstop=4 shiftwidth=4 softtabstop=4
+#
+# Copyright (C) 2014-2017 GEM Foundation
+#
+# OpenQuake is free software: you can redistribute it and/or modify it
+# under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# OpenQuake is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with OpenQuake. If not, see <http://www.gnu.org/licenses/>.
+
+import unittest
+from openquake.hazardlib import imt, valid
+
+
+class ValidationTestCase(unittest.TestCase):
+    # more is done in the doctests inside baselib.valid
+
+    def test_simple_id(self):
+        self.assertEqual(valid.simple_id('0'), '0')
+        self.assertEqual(valid.simple_id('1-0'), '1-0')
+        self.assertEqual(valid.simple_id('a_x'), 'a_x')
+        with self.assertRaises(ValueError) as ctx:
+            valid.simple_id('a x')
+        self.assertEqual(
+            str(ctx.exception),
+            "Invalid ID 'a x': the only accepted chars are a-zA-Z0-9_-")
+        with self.assertRaises(ValueError):
+            valid.simple_id('0|1')
+        with self.assertRaises(ValueError):
+            valid.simple_id('à')
+        with self.assertRaises(ValueError):
+            valid.simple_id('\t')
+        with self.assertRaises(ValueError):
+            valid.simple_id('a' * 101)
+
+    def test_source_id(self):
+        valid.source_id('ab_2.3_-27.0')
+
+    def test_name(self):
+        self.assertEqual(valid.name('x'), 'x')
+        with self.assertRaises(ValueError):
+            valid.name('1')
+        with self.assertRaises(ValueError):
+            valid.name('x y')
+
+    def test_namelist(self):
+        self.assertEqual(valid.namelist('x y'), ['x', 'y'])
+        self.assertEqual(valid.namelist(' '), [])
+        with self.assertRaises(ValueError):
+            valid.namelist('x 1')
+
+    def test_longitude(self):
+        self.assertEqual(valid.longitude('1'), 1.0)
+        self.assertEqual(valid.longitude('180'), 180.0)
+        with self.assertRaises(ValueError):
+            valid.longitude('181')
+        with self.assertRaises(ValueError):
+            valid.longitude('-181')
+
+    def test_latitude(self):
+        self.assertEqual(valid.latitude('1'), 1.0)
+        self.assertEqual(valid.latitude('90'), 90.0)
+        with self.assertRaises(ValueError):
+            valid.latitude('91')
+        with self.assertRaises(ValueError):
+            valid.latitude('-91')
+
+    def test_positiveint(self):
+        self.assertEqual(valid.positiveint('1'), 1)
+        with self.assertRaises(ValueError):
+            valid.positiveint('-1')
+        with self.assertRaises(ValueError):
+            valid.positiveint('1.1')
+        with self.assertRaises(ValueError):
+            valid.positiveint('1.0')
+
+    def test_positivefloat(self):
+        self.assertEqual(valid.positiveint('1'), 1)
+        with self.assertRaises(ValueError):
+            valid.positivefloat('-1')
+        self.assertEqual(valid.positivefloat('1.1'), 1.1)
+
+    def test_probability(self):
+        self.assertEqual(valid.probability('1'), 1.0)
+        self.assertEqual(valid.probability('.5'), 0.5)
+        self.assertEqual(valid.probability('0'), 0.0)
+        with self.assertRaises(ValueError):
+            valid.probability('1.1')
+        with self.assertRaises(ValueError):
+            valid.probability('-0.1')
+
+    def test_IMTstr(self):
+        self.assertEqual(imt.from_string('SA(1)'), ('SA', 1, 5))
+        self.assertEqual(imt.from_string('SA(1.)'), ('SA', 1, 5))
+        self.assertEqual(imt.from_string('SA(0.5)'), ('SA', 0.5, 5))
+        self.assertEqual(imt.from_string('PGV'), ('PGV', None, None))
+        with self.assertRaises(ValueError):
+            imt.from_string('S(1)')
+
+    def test_choice(self):
+        validator = valid.Choice('aggregated', 'per_asset')
+        self.assertEqual(validator.__name__,
+                         "Choice('aggregated', 'per_asset')")
+        self.assertEqual(validator('aggregated'), 'aggregated')
+        self.assertEqual(validator('per_asset'), 'per_asset')
+        with self.assertRaises(ValueError):
+            validator('xxx')
+
+    def test_empty(self):
+        self.assertEqual(valid.not_empty("text"), "text")
+        with self.assertRaises(ValueError):
+            valid.not_empty("")
+
+    def test_none_or(self):
+        validator = valid.NoneOr(valid.positiveint)
+        self.assertEqual(validator(''), None)
+        self.assertEqual(validator('1'), 1)
+
+    def test_gsim(self):
+        class FakeGsim(object):
+            def __init__(self, arg):
+                self.arg = arg
+
+            def __repr__(self):
+                return '<FakeGsim(%s)>' % self.arg
+        valid.GSIM['FakeGsim'] = FakeGsim
+        try:
+            gsim = valid.gsim('FakeGsim', arg='0.1')
+            self.assertEqual(repr(gsim), '<FakeGsim(0.1)>')
+        finally:
+            del valid.GSIM['FakeGsim']

--- a/openquake/hazardlib/valid.py
+++ b/openquake/hazardlib/valid.py
@@ -1,0 +1,1044 @@
+# -*- coding: utf-8 -*-
+# vim: tabstop=4 shiftwidth=4 softtabstop=4
+#
+# Copyright (C) 2013-2017 GEM Foundation
+#
+# OpenQuake is free software: you can redistribute it and/or modify it
+# under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# OpenQuake is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with OpenQuake. If not, see <http://www.gnu.org/licenses/>.
+
+"""
+Validation library for the engine, the desktop tools, and anything else
+"""
+
+import re
+import ast
+import logging
+import textwrap
+import collections
+from decimal import Decimal
+
+import numpy
+
+from openquake.baselib.python3compat import with_metaclass
+from openquake.baselib import hdf5
+from openquake.hazardlib import imt, scalerel, gsim
+from openquake.baselib.general import distinct
+
+SCALEREL = scalerel.get_available_magnitude_scalerel()
+
+GSIM = gsim.get_available_gsims()
+
+
+# more tests are in tests/valid_test.py
+def gsim(value, **kwargs):
+    """
+    Make sure the given value is the name of an available GSIM class.
+
+    >>> gsim('BooreAtkinson2011')
+    'BooreAtkinson2011()'
+    """
+    if value == 'FromFile':
+        return 'FromFile'
+    elif value.endswith('()'):
+        value = value[:-2]  # strip parenthesis
+    try:
+        gsim_class = GSIM[value]
+    except KeyError:
+        raise ValueError('Unknown GSIM: %s' % value)
+    try:
+        return gsim_class(**kwargs)
+    except TypeError:
+        raise ValueError('Could not instantiate %s%s' % (value, kwargs))
+
+
+def compose(*validators):
+    """
+    Implement composition of validators. For instance
+
+    >>> utf8_not_empty = compose(utf8, not_empty)
+    """
+    def composed_validator(value):
+        out = value
+        for validator in reversed(validators):
+            out = validator(out)
+        return out
+    composed_validator.__name__ = 'compose(%s)' % ','.join(
+        val.__name__ for val in validators)
+    return composed_validator
+
+
+class NoneOr(object):
+    """
+    Accept the empty string (casted to None) or something else validated
+    by the underlying `cast` validator.
+    """
+    def __init__(self, cast):
+        self.cast = cast
+        self.__name__ = cast.__name__
+
+    def __call__(self, value):
+        if value:
+            return self.cast(value)
+
+
+class Choice(object):
+    """
+    Check if the choice is valid (case sensitive).
+    """
+    @property
+    def __name__(self):
+        return 'Choice%s' % str(self.choices)
+
+    def __init__(self, *choices):
+        self.choices = choices
+
+    def __call__(self, value):
+        if value not in self.choices:
+            raise ValueError("Got '%s', expected %s" % (
+                             value, '|'.join(self.choices)))
+        return value
+
+
+class ChoiceCI(object):
+    """
+    Check if the choice is valid (case insensitive version).
+    """
+    def __init__(self, *choices):
+        self.choices = choices
+        self.__name__ = 'ChoiceCI%s' % str(choices)
+
+    def __call__(self, value):
+        value = value.lower()
+        if value not in self.choices:
+            raise ValueError("'%s' is not a valid choice in %s" % (
+                             value, self.choices))
+        return value
+
+category = ChoiceCI('population', 'buildings')
+
+
+class Choices(Choice):
+    """
+    Convert the choices, passed as a comma separated string, into a tuple
+    of validated strings. For instance
+
+    >>> Choices('xml', 'csv')('xml,csv')
+    ('xml', 'csv')
+    """
+    def __call__(self, value):
+        values = value.lower().split(',')
+        for val in values:
+            if val not in self.choices:
+                raise ValueError("'%s' is not a valid choice in %s" % (
+                    val, self.choices))
+        return tuple(values)
+
+export_formats = Choices('', 'xml', 'geojson', 'txt', 'csv', 'npz')
+
+
+def hazard_id(value):
+    """
+    >>> hazard_id('')
+    ()
+    >>> hazard_id('-1')
+    (-1,)
+    >>> hazard_id('42')
+    (42,)
+    >>> hazard_id('42,3')
+    (42, 3)
+    >>> hazard_id('42,3,4')
+    (42, 3, 4)
+    >>> hazard_id('42:3')
+    Traceback (most recent call last):
+       ...
+    ValueError: Invalid hazard_id '42:3'
+    """
+    if not value:
+        return ()
+    try:
+        return tuple(map(int, value.split(',')))
+    except:
+        raise ValueError('Invalid hazard_id %r' % value)
+
+
+class Regex(object):
+    """
+    Compare the value with the given regex
+    """
+    def __init__(self, regex):
+        self.rx = re.compile(regex)
+        self.__name__ = 'Regex[%s]' % regex
+
+    def __call__(self, value):
+        if self.rx.match(value) is None:
+            raise ValueError("'%s' does not match the regex '%s'" %
+                             (value, self.rx.pattern))
+        return value
+
+name = Regex(r'^[a-zA-Z_]\w*$')
+
+name_with_dashes = Regex(r'^[a-zA-Z_][\w\-]*$')
+
+
+class SimpleId(object):
+    """
+    Check if the given value is a valid ID.
+
+    :param length: maximum length of the ID
+    :param regex: accepted characters
+    """
+    def __init__(self, length, regex=r'^[\w_\-]+$'):
+        self.length = length
+        self.regex = regex
+        self.__name__ = 'SimpleId(%d, %s)' % (length, regex)
+
+    def __call__(self, value):
+        if max(map(ord, value)) > 127:
+            raise ValueError(
+                'Invalid ID %r: the only accepted chars are a-zA-Z0-9_-'
+                % value)
+        elif len(value) > self.length:
+            raise ValueError("The ID '%s' is longer than %d character" %
+                             (value, self.length))
+        elif re.match(self.regex, value):
+            return value
+        raise ValueError(
+            "Invalid ID '%s': the only accepted chars are a-zA-Z0-9_-" % value)
+
+MAX_ID_LENGTH = 60
+ASSET_ID_LENGTH = 100
+
+simple_id = SimpleId(MAX_ID_LENGTH)
+asset_id = SimpleId(ASSET_ID_LENGTH)
+source_id = SimpleId(MAX_ID_LENGTH, r'^[\w\.\-_]+$')
+
+
+class FloatRange(object):
+    def __init__(self, minrange, maxrange):
+        self.minrange = minrange
+        self.maxrange = maxrange
+        self.__name__ = 'FloatRange[%s:%s]' % (minrange, maxrange)
+
+    def __call__(self, value):
+        f = float_(value)
+        if f > self.maxrange:
+            raise ValueError("'%s' is bigger than the max, '%s'" %
+                             (f, self.maxrange))
+        if f < self.minrange:
+            raise ValueError("'%s' is smaller than the min, '%s'" %
+                             (f, self.minrange))
+        return f
+
+
+def not_empty(value):
+    """Check that the string is not all blanks"""
+    if value is None or value.strip() == '':
+        raise ValueError('Got an empty string')
+    return value
+
+
+def utf8(value):
+    r"""
+    Check that the string is UTF-8. Returns an encode bytestring.
+
+    >>> utf8(b'\xe0')  # doctest: +ELLIPSIS
+    Traceback (most recent call last):
+    ...
+    ValueError: Not UTF-8: ...
+    """
+    try:
+        if isinstance(value, bytes):
+            return value.decode('utf-8')
+        else:
+            return value
+    except:
+        raise ValueError('Not UTF-8: %r' % value)
+
+
+def utf8_not_empty(value):
+    """Check that the string is UTF-8 and not empty"""
+    return utf8(not_empty(value))
+
+
+def namelist(value):
+    """
+    :param value: input string
+    :returns: list of identifiers separated by whitespace or commas
+
+    >>> namelist('a,b')
+    ['a', 'b']
+    >>> namelist('a1  b_2\t_c')
+    ['a1', 'b_2', '_c']
+
+    >>> namelist('a1 b_2 1c')
+    Traceback (most recent call last):
+        ...
+    ValueError: List of names containing an invalid name: 1c
+    """
+    names = value.replace(',', ' ').split()
+    for n in names:
+        try:
+            name(n)
+        except ValueError:
+            raise ValueError('List of names containing an invalid name:'
+                             ' %s' % n)
+    return names
+
+
+def float_(value):
+    """
+    :param value: input string
+    :returns: a floating point number
+    """
+    try:
+        return float(value)
+    except:
+        raise ValueError("'%s' is not a float" % value)
+
+
+def nonzero(value):
+    """
+    :param value: input string
+    :returns: the value unchanged
+
+    >>> nonzero('1')
+    '1'
+    >>> nonzero('0')
+    Traceback (most recent call last):
+      ...
+    ValueError: '0' is zero
+    """
+    if float_(value) == 0:
+        raise ValueError("'%s' is zero" % value)
+    return value
+
+
+def longitude(value):
+    """
+    :param value: input string
+    :returns: longitude float, rounded to 5 digits, i.e. 1 meter maximum
+
+    >>> longitude('0.123456')
+    0.12346
+    """
+    lon = round(float_(value), 5)
+    if lon > 180.:
+        raise ValueError('longitude %s > 180' % lon)
+    elif lon < -180.:
+        raise ValueError('longitude %s < -180' % lon)
+    return lon
+
+
+def latitude(value):
+    """
+    :param value: input string
+    :returns: latitude float, rounded to 5 digits, i.e. 1 meter maximum
+
+    >>> latitude('-0.123456')
+    -0.12346
+    """
+    lat = round(float_(value), 5)
+    if lat > 90.:
+        raise ValueError('latitude %s > 90' % lat)
+    elif lat < -90.:
+        raise ValueError('latitude %s < -90' % lat)
+    return lat
+
+
+def longitudes(value):
+    """
+    :param value: a comma separated string of longitudes
+    :returns: a list of longitudes
+    """
+    return [longitude(v) for v in value.split(',')]
+
+
+def latitudes(value):
+    """
+    :param value: a comma separated string of latitudes
+    :returns: a list of latitudes
+    """
+    return [latitude(v) for v in value.split(',')]
+
+
+def depth(value):
+    """
+    :param value: input string
+    :returns: float >= 0
+    """
+    dep = float_(value)
+    if dep < 0:
+        raise ValueError('depth %s < 0' % dep)
+    return dep
+
+
+def lon_lat(value):
+    """
+    :param value: a pair of coordinates
+    :returns: a tuple (longitude, latitude)
+
+    >>> lon_lat('12 14')
+    (12.0, 14.0)
+    """
+    lon, lat = value.split()
+    return longitude(lon), latitude(lat)
+
+
+def coordinates(value):
+    """
+    Convert a non-empty string into a list of lon-lat coordinates
+    >>> coordinates('')
+    Traceback (most recent call last):
+    ...
+    ValueError: Empty list of coordinates: ''
+    >>> coordinates('1.1 1.2')
+    [(1.1, 1.2)]
+    >>> coordinates('1.1 1.2, 2.2 2.3')
+    [(1.1, 1.2), (2.2, 2.3)]
+    """
+    if not value.strip():
+        raise ValueError('Empty list of coordinates: %r' % value)
+    return list(map(lon_lat, value.split(',')))
+
+
+def wkt_polygon(value):
+    """
+    Convert a string with a comma separated list of coordinates into
+    a WKT polygon, by closing the ring.
+    """
+    points = ['%s %s' % lon_lat for lon_lat in coordinates(value)]
+    # close the linear polygon ring by appending the first coord to the end
+    points.append(points[0])
+    return 'POLYGON((%s))' % ', '.join(points)
+
+
+def positiveint(value):
+    """
+    :param value: input string
+    :returns: positive integer
+    """
+    i = int(not_empty(value))
+    if i < 0:
+        raise ValueError('integer %d < 0' % i)
+    return i
+
+
+def positivefloat(value):
+    """
+    :param value: input string
+    :returns: positive float
+    """
+    f = float(not_empty(value))
+    if f < 0:
+        raise ValueError('float %s < 0' % f)
+    return f
+
+
+def positivefloats(value):
+    """
+    :param value: string of whitespace separated floats
+    :returns: a list of positive floats
+    """
+    return list(map(positivefloat, value.split()))
+
+
+_BOOL_DICT = {
+    '': False,
+    '0': False,
+    '1': True,
+    'false': False,
+    'true': True,
+}
+
+
+def boolean(value):
+    """
+    :param value: input string such as '0', '1', 'true', 'false'
+    :returns: boolean
+
+    >>> boolean('')
+    False
+    >>> boolean('True')
+    True
+    >>> boolean('false')
+    False
+    >>> boolean('t')
+    Traceback (most recent call last):
+        ...
+    ValueError: Not a boolean: t
+    """
+    value = value.strip().lower()
+    try:
+        return _BOOL_DICT[value]
+    except KeyError:
+        raise ValueError('Not a boolean: %s' % value)
+
+
+range01 = FloatRange(0, 1)
+probability = FloatRange(0, 1)
+probability.__name__ = 'probability'
+
+
+def probabilities(value):
+    """
+    :param value: input string, comma separated or space separated
+    :returns: a list of probabilities
+
+    >>> probabilities('')
+    []
+    >>> probabilities('1')
+    [1.0]
+    >>> probabilities('0.1 0.2')
+    [0.1, 0.2]
+    >>> probabilities('0.1, 0.2')  # commas are ignored
+    [0.1, 0.2]
+    """
+    return list(map(probability, value.replace(',', ' ').split()))
+
+
+def decreasing_probabilities(value):
+    """
+    :param value: input string, comma separated or space separated
+    :returns: a list of decreasing probabilities
+
+    >>> decreasing_probabilities('1')
+    Traceback (most recent call last):
+    ...
+    ValueError: Not enough probabilities, found '1'
+    >>> decreasing_probabilities('0.2 0.1')
+    [0.2, 0.1]
+    >>> decreasing_probabilities('0.1 0.2')
+    Traceback (most recent call last):
+    ...
+    ValueError: The probabilities 0.1 0.2 are not in decreasing order
+    """
+    probs = probabilities(value)
+    if len(probs) < 2:
+        raise ValueError('Not enough probabilities, found %r' % value)
+    elif sorted(probs, reverse=True) != probs:
+        raise ValueError('The probabilities %s are not in decreasing order'
+                         % value)
+    return probs
+
+
+def intensity_measure_type(value):
+    """
+    Make sure `value` is a valid intensity measure type and return it
+    in a normalized form
+
+    >>> intensity_measure_type('SA(0.10)')  # NB: strips the trailing 0
+    'SA(0.1)'
+    >>> intensity_measure_type('SA')  # this is invalid
+    Traceback (most recent call last):
+      ...
+    ValueError: Invalid IMT: 'SA'
+    """
+    try:
+        return str(imt.from_string(value))
+    except:
+        raise ValueError("Invalid IMT: '%s'" % value)
+
+
+def intensity_measure_types(value):
+    """
+    :param value: input string
+    :returns: non-empty list of Intensity Measure Type objects
+
+    >>> intensity_measure_types('PGA')
+    ['PGA']
+    >>> intensity_measure_types('PGA, SA(1.00)')
+    ['PGA', 'SA(1.0)']
+    >>> intensity_measure_types('SA(0.1), SA(0.10)')
+    Traceback (most recent call last):
+      ...
+    ValueError: Duplicated IMTs in SA(0.1), SA(0.10)
+    """
+    imts = []
+    for chunk in value.split(','):
+        imts.append(str(imt.from_string(chunk.strip())))
+    if len(distinct(imts)) < len(imts):
+        raise ValueError('Duplicated IMTs in %s' % value)
+    return imts
+
+
+def check_levels(imls, imt):
+    """
+    Raise a ValueError if the given levels are invalid.
+
+    :param imls: a list of intensity measure and levels
+    :param imt: the intensity measure type
+
+    >>> check_levels([0.1, 0.2], 'PGA')  # ok
+    >>> check_levels([0.1], 'PGA')
+    Traceback (most recent call last):
+       ...
+    ValueError: Not enough imls for PGA: [0.1]
+    >>> check_levels([0.2, 0.1], 'PGA')
+    Traceback (most recent call last):
+       ...
+    ValueError: The imls for PGA are not sorted: [0.2, 0.1]
+    >>> check_levels([0.2, 0.2], 'PGA')
+    Traceback (most recent call last):
+       ...
+    ValueError: Found duplicated levels for PGA: [0.2, 0.2]
+    """
+    if len(imls) < 2:
+        raise ValueError('Not enough imls for %s: %s' % (imt, imls))
+    elif imls != sorted(imls):
+        raise ValueError('The imls for %s are not sorted: %s' % (imt, imls))
+    elif len(distinct(imls)) < len(imls):
+        raise ValueError("Found duplicated levels for %s: %s" % (imt, imls))
+
+
+def intensity_measure_types_and_levels(value):
+    """
+    :param value: input string
+    :returns: Intensity Measure Type and Levels dictionary
+
+    >>> intensity_measure_types_and_levels('{"SA(0.10)": [0.1, 0.2]}')
+    {'SA(0.1)': [0.1, 0.2]}
+    """
+    dic = dictionary(value)
+    for imt_str, imls in dic.items():
+        norm_imt = str(imt.from_string(imt_str))
+        if norm_imt != imt_str:
+            dic[norm_imt] = imls
+            del dic[imt_str]
+        check_levels(imls, imt_str)  # ValueError if the levels are invalid
+    return dic
+
+
+def loss_ratios(value):
+    """
+    :param value: input string
+    :returns: dictionary loss_type -> loss ratios
+
+    >>> loss_ratios('{"structural": [0.1, 0.2]}')
+    {'structural': [0.1, 0.2]}
+    """
+    dic = dictionary(value)
+    for lt, ratios in dic.items():
+        for ratio in ratios:
+            if not 0 <= ratio <= 1:
+                raise ValueError('Loss ratio %f for loss_type %s is not in '
+                                 'the range [0, 1]' % (ratio, lt))
+        check_levels(ratios, lt)  # ValueError if the levels are invalid
+    return dic
+
+
+def dictionary(value):
+    """
+    :param value:
+        input string corresponding to a literal Python object
+    :returns:
+        the Python object
+
+    >>> dictionary('')
+    {}
+    >>> dictionary('{}')
+    {}
+    >>> dictionary('{"a": 1}')
+    {'a': 1}
+    >>> dictionary('"vs30_clustering: true"')  # an error really done by a user
+    Traceback (most recent call last):
+       ...
+    ValueError: '"vs30_clustering: true"' is not a valid Python dictionary
+    """
+    if not value:
+        return {}
+    try:
+        dic = dict(ast.literal_eval(value))
+    except:
+        raise ValueError('%r is not a valid Python dictionary' % value)
+    return dic
+
+
+def floatdict(value):
+    """
+    :param value:
+        input string corresponding to a literal Python number or dictionary
+    :returns:
+        a Python dictionary key -> number
+
+    >>> floatdict("200")
+    {'default': 200}
+
+    >>> text = "{'active shallow crust': 250., 'default': 200}"
+    >>> sorted(floatdict(text).items())
+    [('active shallow crust', 250.0), ('default', 200)]
+    """
+    value = ast.literal_eval(value)
+    if isinstance(value, (int, float)):
+        return {'default': value}
+    return value
+
+
+# ########################### SOURCES/RUPTURES ############################# #
+
+def mag_scale_rel(value):
+    """
+    :param value:
+        name of a Magnitude-Scale relationship in hazardlib
+    :returns:
+        the corresponding hazardlib object
+    """
+    value = value.strip()
+    if value not in SCALEREL:
+        raise ValueError(
+            "'%s' is not a recognized magnitude-scale relationship" % value)
+    return value
+
+
+def pmf(value):
+    """
+    Comvert a string into a Probability Mass Function.
+
+    :param value:
+        a sequence of probabilities summing up to 1 (no commas)
+    :returns:
+        a list of pairs [(probability, index), ...] with index starting from 0
+
+    >>> pmf("0.157 0.843")
+    [(0.157, 0), (0.843, 1)]
+    """
+    probs = probabilities(value)
+    if sum(map(Decimal, value.split())) != 1:
+        raise ValueError('The probabilities %s do not sum up to 1!' % value)
+    return [(p, i) for i, p in enumerate(probs)]
+
+
+def check_weights(nodes_with_a_weight):
+    """
+    Ensure that the sum of the values is 1
+
+    :param nodes_with_a_weight: a list of Node objects with a weight attribute
+    """
+    weights = [n['weight'] for n in nodes_with_a_weight]
+    if abs(sum(weights) - 1.) > 1E-12:
+        raise ValueError('The weights do not sum up to 1: %s' % weights)
+    return nodes_with_a_weight
+
+
+def weights(value):
+    """
+    Space-separated list of weights:
+
+    >>> weights('0.1 0.2 0.7')
+    [0.1, 0.2, 0.7]
+
+    >>> weights('0.1 0.2 0.8')
+    Traceback (most recent call last):
+      ...
+    ValueError: The weights do not sum up to 1: [0.1, 0.2, 0.8]
+    """
+    probs = probabilities(value)
+    if abs(sum(probs) - 1.) > 1E-12:
+        raise ValueError('The weights do not sum up to 1: %s' % probs)
+    return probs
+
+
+def hypo_list(nodes):
+    """
+    :param nodes: a hypoList node with N hypocenter nodes
+    :returns: a numpy array of shape (N, 3) with strike, dip and weight
+    """
+    check_weights(nodes)
+    data = []
+    for node in nodes:
+        data.append([node['alongStrike'], node['downDip'], node['weight']])
+    return numpy.array(data, float)
+
+
+def slip_list(nodes):
+    """
+    :param nodes: a slipList node with N slip nodes
+    :returns: a numpy array of shape (N, 2) with slip angle and weight
+    """
+    check_weights(nodes)
+    data = []
+    for node in nodes:
+        data.append([slip_range(~node), node['weight']])
+    return numpy.array(data, float)
+
+
+def posList(value):
+    """
+    :param value:
+        a string with the form `lon1 lat1 [depth1] ...  lonN latN [depthN]`
+        without commas, where the depts are optional.
+    :returns:
+        a list of floats without other validations
+    """
+    values = value.split()
+    num_values = len(values)
+    if num_values % 3 and num_values % 2:
+        raise ValueError('Wrong number: nor pairs not triplets: %s' % values)
+    try:
+        return list(map(float_, values))
+    except Exception as exc:
+        raise ValueError('Found a non-float in %s: %s' % (value, exc))
+
+
+def point3d(value, lon, lat, depth):
+    """
+    This is used to convert nodes of the form
+    <hypocenter lon="LON" lat="LAT" depth="DEPTH"/>
+
+    :param value: None
+    :param lon: longitude string
+    :param lat: latitude string
+    :returns: a validated triple (lon, lat, depth)
+    """
+    return longitude(lon), latitude(lat), positivefloat(depth)
+
+
+strike_range = FloatRange(0, 360)
+slip_range = strike_range
+dip_range = FloatRange(0, 90)
+rake_range = FloatRange(-180, 180)
+
+
+def ab_values(value):
+    """
+    a and b values of the GR magniture-scaling relation.
+    a is a positive float, b is just a float.
+    """
+    a, b = value.split()
+    return positivefloat(a), float_(b)
+
+
+def integers(value):
+    """
+    :param value: input string
+    :returns: non-empty list of integers
+
+    >>> integers('1, 2')
+    [1, 2]
+    >>> integers(' ')
+    Traceback (most recent call last):
+       ...
+    ValueError: Not a list of integers: ' '
+    """
+    values = value.replace(',', ' ').split()
+    if not values:
+        raise ValueError('Not a list of integers: %r' % value)
+    try:
+        ints = [int(float(v)) for v in values]
+    except:
+        raise ValueError('Not a list of integers: %r' % value)
+    return ints
+
+
+def positiveints(value):
+    """
+    >>> positiveints('1, -1')
+    Traceback (most recent call last):
+       ...
+    ValueError: -1 is negative in '1, -1'
+    """
+    ints = integers(value)
+    for val in ints:
+        if val < 0:
+            raise ValueError('%d is negative in %r' % (val, value))
+    return ints
+
+
+# ############################## site model ################################ #
+
+vs30_type = ChoiceCI('measured', 'inferred')
+
+SiteParam = collections.namedtuple(
+    'SiteParam', 'z1pt0 z2pt5 measured vs30 lon lat backarc'.split())
+
+
+def site_param(z1pt0, z2pt5, vs30Type, vs30, lon, lat, backarc="false"):
+    """
+    Used to convert a node like
+
+       <site lon="24.7125" lat="42.779167" vs30="462" vs30Type="inferred"
+       z1pt0="100" z2pt5="5" backarc="False"/>
+
+    into a 7-tuple (z1pt0, z2pt5, measured, vs30, backarc, lon, lat)
+    """
+    return SiteParam(positivefloat(z1pt0), positivefloat(z2pt5),
+                     vs30_type(vs30Type) == 'measured',
+                     positivefloat(vs30), longitude(lon),
+                     latitude(lat), boolean(backarc))
+
+# used for the exposure validation
+cost_type = Choice('structural', 'nonstructural', 'contents',
+                   'business_interruption')
+
+cost_type_type = Choice('aggregated', 'per_area', 'per_asset')
+
+
+###########################################################################
+
+class Param(object):
+    """
+    A descriptor for validated parameters with a default, to be
+    used as attributes in ParamSet objects.
+
+    :param validator: the validator
+    :param default: the default value
+    """
+    NODEFAULT = object()
+
+    def __init__(self, validator, default=NODEFAULT, name=None):
+        if not callable(validator):
+            raise ValueError(
+                '%r for %s is not a validator: it is not callable'
+                % (validator, name))
+        if not hasattr(validator, '__name__'):
+            raise ValueError(
+                '%r for %s is not a validator: it has no __name__'
+                % (validator, name))
+
+        self.validator = validator
+        self.default = default
+        self.name = name  # set by ParamSet.__metaclass__
+
+    def __get__(self, obj, objclass):
+        if obj is not None:
+            if self.default is self.NODEFAULT:
+                raise AttributeError(self.name)
+            return self.default
+        return self
+
+
+class MetaParamSet(type):
+    """
+    Set the `.name` attribute of every Param instance defined inside
+    any subclass of ParamSet.
+    """
+    def __init__(cls, name, bases, dic):
+        for name, val in dic.items():
+            if isinstance(val, Param):
+                val.name = name
+
+
+# used in commonlib.oqvalidation
+class ParamSet(with_metaclass(MetaParamSet, hdf5.LiteralAttrs)):
+    """
+    A set of valid interrelated parameters. Here is an example
+    of usage:
+
+    >>> class MyParams(ParamSet):
+    ...     a = Param(positiveint)
+    ...     b = Param(positivefloat)
+    ...
+    ...     def is_valid_not_too_big(self):
+    ...         "The sum of a and b must be under 10: a={a} and b={b}"
+    ...         return self.a + self.b < 10
+
+    >>> mp = MyParams(a='1', b='7.2')
+    >>> mp
+    <MyParams a=1, b=7.2>
+
+    >>> MyParams(a='1', b='9.2').validate()
+    Traceback (most recent call last):
+    ...
+    ValueError: The sum of a and b must be under 10: a=1 and b=9.2
+
+    The constrains are applied in lexicographic order. The attribute
+    corresponding to a Param descriptor can be set as usual:
+
+    >>> mp.a = '2'
+    >>> mp.a
+    '2'
+
+    A list with the literal strings can be extracted as follows:
+
+    >>> mp.to_params()
+    [('a', "'2'"), ('b', '7.2')]
+
+    It is possible to build a new object from a dictionary of parameters
+    which are assumed to be already validated:
+
+    >>> MyParams.from_(dict(a="'2'", b='7.2'))
+    <MyParams a='2', b=7.2>
+    """
+    params = {}
+
+    @classmethod
+    def check(cls, dic):
+        """
+        Convert a dictionary name->string into a dictionary name->value
+        by converting the string. If the name does not correspond to a
+        known parameter, just ignore it and print a warning.
+        """
+        res = {}
+        for name, text in dic.items():
+            try:
+                p = getattr(cls, name)
+            except AttributeError:
+                logging.warn('Ignored unknown parameter %s', name)
+            else:
+                res[name] = p.validator(text)
+        return res
+
+    @classmethod
+    def from_(cls, dic):
+        """
+        Build a new ParamSet from a dictionary of string-valued parameters
+        which are assumed to be already valid.
+        """
+        self = cls.__new__(cls)
+        for k, v in dic.items():
+            setattr(self, k, ast.literal_eval(v))
+        return self
+
+    def to_params(self):
+        """
+        Convert the instance dictionary into a sorted list of pairs
+        (name, valrepr) where valrepr is the string representation of
+        the underlying value.
+        """
+        dic = self.__dict__
+        return [(k, repr(dic[k])) for k in sorted(dic)
+                if not k.startswith('_')]
+
+    def __init__(self, **names_vals):
+        for name, val in names_vals.items():
+            if name.startswith(('_', 'is_valid_')):
+                raise NameError('The parameter name %s is not acceptable'
+                                % name)
+            try:
+                convert = getattr(self.__class__, name).validator
+            except AttributeError:
+                logging.warn("The parameter '%s' is unknown, ignoring" % name)
+                continue
+            try:
+                value = convert(val)
+            except Exception as exc:
+                raise ValueError('%s: could not convert to %s: %s=%s'
+                                 % (exc, convert.__name__, name, val))
+            setattr(self, name, value)
+
+    def validate(self):
+        """
+        Apply the `is_valid` methods to self and possibly raise a ValueError.
+        """
+        # it is important to have the validator applied in a fixed order
+        valids = [getattr(self, valid)
+                  for valid in sorted(dir(self.__class__))
+                  if valid.startswith('is_valid_')]
+        for is_valid in valids:
+            if not is_valid():
+                docstring = is_valid.__doc__.strip()
+                doc = textwrap.fill(docstring.format(**vars(self)))
+                raise ValueError(doc)
+
+    def __iter__(self):
+        for item in sorted(vars(self).items()):
+            yield item


### PR DESCRIPTION
Currently the Hazard Modeler Toolkit depends on the engine because it performs a few calls to libraries in commonlib. This is ugly:

1) the engine should only contains libraries related to the calculators; since the HTMK does not need the calculators it should not depend on the engine
2) hazardlib should be able to read and write sources without depending on the engine, it should be a self-contained library

The solution is to move a few files from the engine into hazardlib.