### PR TITLE
Merged source.base.SourceGroup inside sourceconverter.SourceGroup

### DIFF
--- a/openquake/hazardlib/calc/hazard_curve.py
+++ b/openquake/hazardlib/calc/hazard_curve.py
@@ -246,7 +246,7 @@ def pmap_from_grp(
     if isinstance(sources, SourceGroup):
         group = sources
         sources = group.sources
-        trt = group.src_list[0].tectonic_region_type
+        trt = sources[0].tectonic_region_type
     else:  # list of sources
         trt = sources[0].tectonic_region_type
         group = SourceGroup(trt, sources, 'src_group', 'indep', 'indep')
@@ -328,7 +328,8 @@ def calc_hazard_curves_ext(
     # This is ensuring backward compatibility i.e. processing a list of
     # sources
     if not isinstance(groups[0], SourceGroup):
-        groups = [SourceGroup(groups, 'src_group', 'indep', 'indep')]
+        trt = groups[0].tectonic_region_type  # is a source
+        groups = [SourceGroup(trt, groups, 'src_group', 'indep', 'indep')]
 
     imtls = DictArray(imtls)
     sitecol = source_site_filter.sitecol
@@ -342,11 +343,11 @@ def calc_hazard_curves_ext(
         # Fill the dictionary with sources for the different tectonic regions
         # belonging to this group
         if indep:
-            for src in group.src_list:
+            for src in group.sources:
                 sources_by_trt[src.tectonic_region_type].append(src)
                 weights_by_trt[src.tectonic_region_type][src.source_id] = 1
         else:
-            for src in group.src_list:
+            for src in group.sources:
                 sources_by_trt[src.tectonic_region_type].append(src)
                 w = group.srcs_weights[src.source_id]
                 weights_by_trt[src.tectonic_region_type][src.source_id] = w
@@ -355,7 +356,8 @@ def calc_hazard_curves_ext(
         for trt in sources_by_trt:
             gsim = gsim_by_trt[trt]
             # Create a temporary group
-            tmp_group = SourceGroup(sources_by_trt[trt],
+            tmp_group = SourceGroup(trt,
+                                    sources_by_trt[trt],
                                     'temp',
                                     group.src_interdep,
                                     group.rup_interdep,

--- a/openquake/hazardlib/calc/hazard_curve.py
+++ b/openquake/hazardlib/calc/hazard_curve.py
@@ -68,7 +68,7 @@ from openquake.hazardlib.gsim.base import ContextMaker, FarAwayRupture
 from openquake.hazardlib.gsim.base import GroundShakingIntensityModel
 from openquake.hazardlib.calc.filters import SourceFilter
 from openquake.hazardlib.imt import from_string
-from openquake.hazardlib.source.base import SourceGroup
+from openquake.hazardlib.sourceconverter import SourceGroup
 
 
 def zero_curves(num_sites, imtls):
@@ -245,11 +245,11 @@ def pmap_from_grp(
     """
     if isinstance(sources, SourceGroup):
         group = sources
-        sources = group.src_list
-    else:
-        group = SourceGroup(sources, 'src_group', 'indep', 'indep')
-        sources = group.src_list
-    trt = sources[0].tectonic_region_type
+        sources = group.sources
+        trt = group.src_list[0].tectonic_region_type
+    else:  # list of sources
+        trt = sources[0].tectonic_region_type
+        group = SourceGroup(trt, sources, 'src_group', 'indep', 'indep')
     try:
         maxdist = source_site_filter.integration_distance[trt]
     except:

--- a/openquake/hazardlib/calc/hazard_curve.py
+++ b/openquake/hazardlib/calc/hazard_curve.py
@@ -61,7 +61,7 @@ import numpy
 
 from openquake.baselib.python3compat import raise_, zip
 from openquake.baselib.performance import Monitor
-from openquake.baselib.general import DictArray
+from openquake.baselib.general import DictArray, groupby
 from openquake.baselib.parallel import Sequential
 from openquake.hazardlib.probability_map import ProbabilityMap
 from openquake.hazardlib.gsim.base import ContextMaker, FarAwayRupture
@@ -327,9 +327,10 @@ def calc_hazard_curves_ext(
     """
     # This is ensuring backward compatibility i.e. processing a list of
     # sources
-    if not isinstance(groups[0], SourceGroup):
-        trt = groups[0].tectonic_region_type  # is a source
-        groups = [SourceGroup(trt, groups, 'src_group', 'indep', 'indep')]
+    if not isinstance(groups[0], SourceGroup):  # sent list of sources
+        dic = groupby(groups, operator.attrgetter('tectonic_region_type'))
+        groups = [SourceGroup(trt, dic[trt], 'src_group', 'indep', 'indep')
+                  for trt in dic]
 
     imtls = DictArray(imtls)
     sitecol = source_site_filter.sitecol

--- a/openquake/hazardlib/source/base.py
+++ b/openquake/hazardlib/source/base.py
@@ -18,65 +18,8 @@ Module :mod:`openquake.hazardlib.source.base` defines a base class for
 seismic sources.
 """
 import abc
-import numpy
 from openquake.baselib.slots import with_slots
 from openquake.baselib.python3compat import with_metaclass
-
-
-class SourceGroup(object):
-    """
-    :param src_list:
-        A list containing seismic sources
-    :param name:
-        The name of the group
-    :param src_interdep:
-        A string specifying if the sources in this cluster are independent or
-        mutually exclusive
-    :param rup_indep:
-        A string specifying if the ruptures within each source of the cluster
-        are independent or mutually exclusive
-    :param weights:
-        A dictionary whose keys are the source IDs of the cluster and the
-        values are the weights associated with each source
-    """
-
-    @property
-    def source_id(self):
-        """Name of the source group"""
-        # alias useful for the write_source_model function
-        return self.name
-
-    def __init__(self, src_list, name, src_interdep='indep',
-                 rup_interdep='indep', srcs_weights=None, trt=''):
-        # checks
-        self._check_init_variables(src_list, name, src_interdep, rup_interdep,
-                                   srcs_weights)
-        # set instance parameters
-        self.src_list = src_list
-        self.name = name
-        self.src_interdep = src_interdep
-        self.rup_interdep = rup_interdep
-        if srcs_weights is None:
-            n = len(src_list)
-            self.srcs_weights = numpy.ones(n) / n
-        else:
-            self.srcs_weights = srcs_weights
-        self.tectonic_region_type = trt
-
-    def _check_init_variables(self, src_list, name, src_interdep, rup_interdep,
-                              srcs_weights):
-        if src_interdep not in ('indep', 'mutex'):
-            raise ValueError('source interdependence incorrect %s ' %
-                             src_interdep)
-        if rup_interdep not in ('indep', 'mutex'):
-            raise ValueError('rupture interdependence incorrect %s ' %
-                             rup_interdep)
-        # check srcs weights defined by the user
-        if srcs_weights is not None:
-            assert abs(1. - sum(srcs_weights)) < 1e-6
-
-    def __iter__(self):
-        return iter(self.src_list)
 
 
 @with_slots

--- a/openquake/hazardlib/sourceconverter.py
+++ b/openquake/hazardlib/sourceconverter.py
@@ -20,6 +20,7 @@ import math
 import copy
 import operator
 import collections
+import numpy
 
 from openquake.baselib.node import context, striptag
 from openquake.hazardlib import geo, mfd, pmf, source
@@ -67,6 +68,17 @@ class SourceGroup(collections.Sequence):
         the tectonic region type all the sources belong to
     :param list sources:
         a list of hazardlib source objects
+    :param name:
+        The name of the group
+    :param src_interdep:
+        A string specifying if the sources in this cluster are independent or
+        mutually exclusive
+    :param rup_indep:
+        A string specifying if the ruptures within each source of the cluster
+        are independent or mutually exclusive
+    :param weights:
+        A dictionary whose keys are the source IDs of the cluster and the
+        values are the weights associated with each source
     :param min_mag:
         the minimum magnitude among the given sources
     :param max_mag:
@@ -99,10 +111,22 @@ class SourceGroup(collections.Sequence):
         # return SourceGroups, ordered by TRT string
         return sorted(source_stats_dict.values())
 
-    def __init__(self, trt, sources=None,
+    def __init__(self, trt, sources=None, name=None, src_interdep='indep',
+                 rup_interdep='indep', srcs_weights=None,
                  min_mag=None, max_mag=None, id=0, eff_ruptures=-1):
+        # checks
+        self._check_init_variables(sources, name, src_interdep, rup_interdep,
+                                   srcs_weights)
         self.trt = trt
-        self.sources = self.src_list = []
+        self.sources = []
+        self.name = name
+        self.src_interdep = src_interdep
+        self.rup_interdep = rup_interdep
+        if srcs_weights is None:
+            n = len(sources)
+            self.srcs_weights = numpy.ones(n) / n
+        else:
+            self.srcs_weights = srcs_weights
         self.min_mag = min_mag
         self.max_mag = max_mag
         self.id = id
@@ -111,6 +135,18 @@ class SourceGroup(collections.Sequence):
                 self.update(src)
         self.source_model = None  # to be set later, in CompositionInfo
         self.eff_ruptures = eff_ruptures  # set later nby get_rlzs_assoc
+
+    def _check_init_variables(self, src_list, name, src_interdep, rup_interdep,
+                              srcs_weights):
+        if src_interdep not in ('indep', 'mutex'):
+            raise ValueError('source interdependence incorrect %s ' %
+                             src_interdep)
+        if rup_interdep not in ('indep', 'mutex'):
+            raise ValueError('rupture interdependence incorrect %s ' %
+                             rup_interdep)
+        # check srcs weights defined by the user
+        if srcs_weights is not None:
+            assert abs(1. - sum(srcs_weights)) < 1e-6
 
     def tot_ruptures(self):
         return sum(src.num_ruptures for src in self.sources)
@@ -782,8 +818,7 @@ class SourceConverter(RuptureConverter):
         :param node:
             a node with tag sourceGroup
         :returns:
-            a :class:`openquake.commonlib.source.SourceGroup` instance
-            mimicking a :class:`openquake.hazardlib.source.base.SourceGroup`
+            a :class:`SourceGroup` instance
         """
         trt = node['tectonicRegion']
         srcs_weights = node.attrib.get('srcs_weights')

--- a/openquake/hazardlib/sourceconverter.py
+++ b/openquake/hazardlib/sourceconverter.py
@@ -54,8 +54,13 @@ class SourceModel(object):
         Return an empty copy of the source model, i.e. without sources,
         but with the proper attributes for each SourceGroup contained within.
         """
-        src_groups = [SourceGroup(sg.trt, [], sg.min_mag, sg.max_mag, sg.id)
-                      for sg in self.src_groups]
+        src_groups = []
+        for grp in self.src_groups:
+            sg = SourceGroup(grp.trt)
+            sg.min_mag = grp.min_mag
+            sg.max_mag = grp.max_mag
+            sg.id = grp.id
+            src_groups.append(sg)
         return self.__class__(self.name, self.weight, self.path, src_groups,
                               self.num_gsim_paths, self.ordinal, self.samples)
 
@@ -122,7 +127,7 @@ class SourceGroup(collections.Sequence):
         self.name = name
         self.src_interdep = src_interdep
         self.rup_interdep = rup_interdep
-        if srcs_weights is None:
+        if srcs_weights is None and sources is not None:
             n = len(sources)
             self.srcs_weights = numpy.ones(n) / n
         else:

--- a/openquake/hazardlib/sourceconverter.py
+++ b/openquake/hazardlib/sourceconverter.py
@@ -56,10 +56,8 @@ class SourceModel(object):
         """
         src_groups = []
         for grp in self.src_groups:
-            sg = SourceGroup(grp.trt)
-            sg.min_mag = grp.min_mag
-            sg.max_mag = grp.max_mag
-            sg.id = grp.id
+            sg = copy.copy(grp)
+            sg.sources = []
             src_groups.append(sg)
         return self.__class__(self.name, self.weight, self.path, src_groups,
                               self.num_gsim_paths, self.ordinal, self.samples)
@@ -120,9 +118,9 @@ class SourceGroup(collections.Sequence):
                  rup_interdep='indep', srcs_weights=None,
                  min_mag=None, max_mag=None, id=0, eff_ruptures=-1):
         # checks
+        self.trt = trt
         self._check_init_variables(sources, name, src_interdep, rup_interdep,
                                    srcs_weights)
-        self.trt = trt
         self.sources = []
         self.name = name
         self.src_interdep = src_interdep
@@ -152,6 +150,10 @@ class SourceGroup(collections.Sequence):
         # check srcs weights defined by the user
         if srcs_weights is not None:
             assert abs(1. - sum(srcs_weights)) < 1e-6
+        # check TRT
+        for src in src_list:
+            assert src.tectonic_region_type == self.trt, (
+                src.tectonic_region_type, self.trt)
 
     def tot_ruptures(self):
         return sum(src.num_ruptures for src in self.sources)

--- a/openquake/hazardlib/sourceconverter.py
+++ b/openquake/hazardlib/sourceconverter.py
@@ -151,9 +151,10 @@ class SourceGroup(collections.Sequence):
         if srcs_weights is not None:
             assert abs(1. - sum(srcs_weights)) < 1e-6
         # check TRT
-        for src in src_list:
-            assert src.tectonic_region_type == self.trt, (
-                src.tectonic_region_type, self.trt)
+        if src_list:  # can be None
+            for src in src_list:
+                assert src.tectonic_region_type == self.trt, (
+                    src.tectonic_region_type, self.trt)
 
     def tot_ruptures(self):
         return sum(src.num_ruptures for src in self.sources)

--- a/openquake/hazardlib/sourcewriter.py
+++ b/openquake/hazardlib/sourcewriter.py
@@ -484,7 +484,7 @@ def build_complex_fault_source_node(fault_source):
 
 @obj_to_node.add('SourceGroup')
 def build_source_group(source_group):
-    source_nodes = [obj_to_node(src) for src in source_group.src_list]
+    source_nodes = [obj_to_node(src) for src in source_group.sources]
     attrs = dict(tectonicRegion=source_group.trt)
     if source_group.name:
         attrs['name'] = source_group.name

--- a/openquake/hazardlib/tests/calc/hazard_curve_new_test.py
+++ b/openquake/hazardlib/tests/calc/hazard_curve_new_test.py
@@ -32,7 +32,7 @@ from openquake.hazardlib.calc.hazard_curve import pmap_from_grp
 from openquake.hazardlib.gsim.sadigh_1997 import SadighEtAl1997
 from openquake.hazardlib.site import Site, SiteCollection
 from openquake.hazardlib.pmf import PMF
-from openquake.hazardlib.source.base import SourceGroup
+from openquake.hazardlib.sourceconverter import SourceGroup
 
 
 def _create_rupture(distance, magnitude,
@@ -119,7 +119,8 @@ class HazardCurvesTestCase01(unittest.TestCase):
 
     def test_hazard_curve_B(self):
         # Test simple calculation
-        group = SourceGroup([self.src2], 'test', 'indep', 'indep')
+        group = SourceGroup(
+            TRT.ACTIVE_SHALLOW_CRUST, [self.src2], 'test', 'indep', 'indep')
         groups = [group]
         curves = calc_hazard_curves_ext(groups,
                                         self.sites,
@@ -141,7 +142,8 @@ class HazardCurvePerGroupTest(HazardCurvesTestCase01):
                 (rupture, PMF([(0.6, 0), (0.4, 1)]))]
         src = NonParametricSeismicSource('0', 'test', TRT.ACTIVE_SHALLOW_CRUST,
                                          data)
-        group = SourceGroup([src], 'test', 'indep', 'mutex')
+        group = SourceGroup(
+            src.tectonic_region_type, [src], 'test', 'indep', 'mutex')
         crv = pmap_from_grp(group, self.sites, self.imtls,
                             gsim_by_trt, truncation_level=None)[0]
         npt.assert_almost_equal(numpy.array([0.35000, 0.32497, 0.10398]),
@@ -151,7 +153,9 @@ class HazardCurvePerGroupTest(HazardCurvesTestCase01):
         # Test that the uniformity of a group (in terms of tectonic region)
         # is correctly checked
         gsim_by_trt = [SadighEtAl1997()]
-        group = SourceGroup([self.src1, self.src3], 'test', 'indep', 'indep')
+        group = SourceGroup(
+            TRT.ACTIVE_SHALLOW_CRUST, [self.src1, self.src3],
+            'test', 'indep', 'indep')
         self.assertRaises(AssertionError, pmap_from_grp, group,
                           self.sites, self.imtls, gsim_by_trt,
                           truncation_level=None)

--- a/openquake/hazardlib/tests/calc/hazard_curve_new_test.py
+++ b/openquake/hazardlib/tests/calc/hazard_curve_new_test.py
@@ -152,13 +152,9 @@ class HazardCurvePerGroupTest(HazardCurvesTestCase01):
     def test_raise_error_non_uniform_group(self):
         # Test that the uniformity of a group (in terms of tectonic region)
         # is correctly checked
-        gsim_by_trt = [SadighEtAl1997()]
-        group = SourceGroup(
-            TRT.ACTIVE_SHALLOW_CRUST, [self.src1, self.src3],
-            'test', 'indep', 'indep')
-        self.assertRaises(AssertionError, pmap_from_grp, group,
-                          self.sites, self.imtls, gsim_by_trt,
-                          truncation_level=None)
+        self.assertRaises(
+            AssertionError, SourceGroup, TRT.ACTIVE_SHALLOW_CRUST,
+            [self.src1, self.src3], 'test', 'indep', 'indep')
 
 
 class HazardCurvesTestCase02(HazardCurvesTestCase01):

--- a/openquake/hazardlib/tests/source/base_test.py
+++ b/openquake/hazardlib/tests/source/base_test.py
@@ -21,7 +21,7 @@ from openquake.hazardlib import const
 from openquake.hazardlib.mfd import EvenlyDiscretizedMFD
 from openquake.hazardlib.scalerel.peer import PeerMSR
 from openquake.hazardlib.source.base import ParametricSeismicSource
-from openquake.hazardlib.source.base import SourceGroup
+from openquake.hazardlib.sourceconverter import SourceGroup
 from openquake.hazardlib.geo import Polygon, Point, RectangularMesh
 from openquake.hazardlib.calc import filters
 from openquake.hazardlib.site import \
@@ -171,7 +171,8 @@ class SeismicSourceGroupTestCase(unittest.TestCase):
 
     def test_init1(self):
         # test simple instantiation
-        grp = SourceGroup(src_list=[self.source],
+        grp = SourceGroup(self.source.tectonic_region_type,
+                          src_list=[self.source],
                           name='',
                           src_interdep='indep',
                           rup_interdep='indep',
@@ -180,7 +181,8 @@ class SeismicSourceGroupTestCase(unittest.TestCase):
 
     def test_init2(self):
         # test default weighting
-        grp = SourceGroup(src_list=[self.source, self.source, self.source],
+        grp = SourceGroup(self.source.tectonic_region_type,
+                          src_list=[self.source, self.source, self.source],
                           name='',
                           src_interdep='indep',
                           rup_interdep='indep',
@@ -189,12 +191,14 @@ class SeismicSourceGroupTestCase(unittest.TestCase):
 
     def test_init3(self):
         # test default weighting
-        SourceGroup(src_list=[self.source, self.source, self.source],
+        SourceGroup(self.source.tectonic_region_type,
+                    src_list=[self.source, self.source, self.source],
                     name='',
                     src_interdep='indep',
                     rup_interdep='indep',
                     srcs_weights=[0.3333, 0.3334, 0.3333])
 
     def test_wrong_label(self):
-        self.assertRaises(ValueError, SourceGroup, [self.source], 'name',
-                          'aaaa', 'indep', None)
+        self.assertRaises(ValueError, SourceGroup,
+                          self.source.tectonic_region_type,
+                          [self.source], 'name', 'aaaa', 'indep', None)

--- a/openquake/hazardlib/tests/source/base_test.py
+++ b/openquake/hazardlib/tests/source/base_test.py
@@ -21,7 +21,6 @@ from openquake.hazardlib import const
 from openquake.hazardlib.mfd import EvenlyDiscretizedMFD
 from openquake.hazardlib.scalerel.peer import PeerMSR
 from openquake.hazardlib.source.base import ParametricSeismicSource
-from openquake.hazardlib.sourceconverter import SourceGroup
 from openquake.hazardlib.geo import Polygon, Point, RectangularMesh
 from openquake.hazardlib.calc import filters
 from openquake.hazardlib.site import \
@@ -154,51 +153,3 @@ class SeismicSourceFilterSitesByRuptureTestCase(
         )
         numpy.testing.assert_array_equal(filtered.indices,
                                          [0, 1, 2, 3, 4, 5, 6, 7, 8])
-
-
-class SeismicSourceGroupTestCase(unittest.TestCase):
-
-    def setUp(self):
-        # Create a source
-        self.source_class = FakeSource
-        mfd = EvenlyDiscretizedMFD(min_mag=3, bin_width=1,
-                                   occurrence_rates=[5, 6, 7])
-        self.source = FakeSource('source_id', 'name', const.TRT.VOLCANIC,
-                                 mfd=mfd, rupture_mesh_spacing=2,
-                                 magnitude_scaling_relationship=PeerMSR(),
-                                 rupture_aspect_ratio=1,
-                                 temporal_occurrence_model=PoissonTOM(50.))
-
-    def test_init1(self):
-        # test simple instantiation
-        grp = SourceGroup(self.source.tectonic_region_type,
-                          src_list=[self.source],
-                          name='',
-                          src_interdep='indep',
-                          rup_interdep='indep',
-                          srcs_weights=None)
-        assert(len(grp.src_list) == 1)
-
-    def test_init2(self):
-        # test default weighting
-        grp = SourceGroup(self.source.tectonic_region_type,
-                          src_list=[self.source, self.source, self.source],
-                          name='',
-                          src_interdep='indep',
-                          rup_interdep='indep',
-                          srcs_weights=None)
-        assert(len(grp.srcs_weights) == 3)
-
-    def test_init3(self):
-        # test default weighting
-        SourceGroup(self.source.tectonic_region_type,
-                    src_list=[self.source, self.source, self.source],
-                    name='',
-                    src_interdep='indep',
-                    rup_interdep='indep',
-                    srcs_weights=[0.3333, 0.3334, 0.3333])
-
-    def test_wrong_label(self):
-        self.assertRaises(ValueError, SourceGroup,
-                          self.source.tectonic_region_type,
-                          [self.source], 'name', 'aaaa', 'indep', None)


### PR DESCRIPTION
As requested by @mmpagani . This avoids the confusion of having two classes with the same name but slightly different. This change does not break the engine: https://travis-ci.org/gem/oq-engine/builds/192575307