### PR TITLE
Improved the error message for XML files which are not NRML

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,5 @@
   [Michele Simionato]
+  * Improved the error message for XML files which are not NRML
   * Added a test making sure that every GSIM is listed in the API documentation
   * Added a `logscale(x_min, x_max, n)` function in valid.py
   * Updated the documentation of the API

--- a/openquake/baselib/node.py
+++ b/openquake/baselib/node.py
@@ -820,10 +820,16 @@ class ValidatingXmlParser(object):
                     self.p.ParseFile(f)
         return self._root
 
-    def _start_element(self, name, attrs):
+    def _start_element(self, longname, attrs):
+        try:
+            xmlns, name = longname.split('}')
+        except ValueError:
+            name = tag = longname
+        else:
+            tag = '{' + longname
         self._ancestors.append(
-            Node('{' + name, attrs, lineno=self.p.CurrentLineNumber))
-        if self.stop and name.split('}')[1] == self.stop:
+            Node(tag, attrs, lineno=self.p.CurrentLineNumber))
+        if self.stop and name == self.stop:
             for anc in reversed(self._ancestors):
                 self._end_element(anc.tag)
             raise self.Exit

--- a/openquake/baselib/node.py
+++ b/openquake/baselib/node.py
@@ -823,9 +823,9 @@ class ValidatingXmlParser(object):
     def _start_element(self, longname, attrs):
         try:
             xmlns, name = longname.split('}')
-        except ValueError:
+        except ValueError:  # no namespace in the longname
             name = tag = longname
-        else:
+        else:  # fix the tag with an opening brace
             tag = '{' + longname
         self._ancestors.append(
             Node(tag, attrs, lineno=self.p.CurrentLineNumber))

--- a/openquake/hazardlib/nrml.py
+++ b/openquake/hazardlib/nrml.py
@@ -293,7 +293,9 @@ def read(source, chatty=True, stop=None):
     """
     vparser = ValidatingXmlParser(validators, stop)
     nrml = vparser.parse_file(source)
-    assert striptag(nrml.tag) == 'nrml', nrml.tag
+    if striptag(nrml.tag) != 'nrml':
+        raise ValueError('%s: expected a node of kind nrml, got %s' %
+                         (source, nrml.tag))
     # extract the XML namespace URL ('http://openquake.org/xmlns/nrml/0.5')
     xmlns = nrml.tag.split('}')[0][1:]
     if xmlns != NRML05 and chatty:


### PR DESCRIPTION
An user was using an invalid NRML exposure, but the error message was bad. This fixes the issue.