### PR TITLE
Removed the warning about missing rtree

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,6 @@
+  [Michele Simionato]
+  * Removed the warning about missing rtree
+
 python-oq-hazardlib (0.22.0-0~precise01) precise; urgency=low
 
   [Marco Pagani, Meya Yanger Walling]

--- a/openquake/hazardlib/calc/filters.py
+++ b/openquake/hazardlib/calc/filters.py
@@ -59,6 +59,7 @@ the index can be compensed. Finally, there is a function
 `filter_sites_by_distance_to_rupture` based on the Joyner-Boore distance.
 """
 import sys
+import logging
 from contextlib import contextmanager
 import numpy
 try:
@@ -154,6 +155,9 @@ class SourceFilter(object):
             self.index = rtree.index.Index()
             for sid, lon, lat in zip(sitecol.sids, fixed_lons, sitecol.lats):
                 self.index.insert(sid, (lon, lat, lon, lat))
+        if rtree is None:
+            logging.info('Using distance filtering on %d sites [no rtree]',
+                         len(sitecol))
 
     def get_affected_box(self, src):
         """

--- a/openquake/hazardlib/calc/filters.py
+++ b/openquake/hazardlib/calc/filters.py
@@ -138,7 +138,7 @@ class SourceFilter(object):
     cannot be properly pickled (https://github.com/Toblerity/rtree/issues/65).
 
     :param sitecol:
-        :class:`openquake.hazardlib.site.SiteCollection` instance
+        :class:`openquake.hazardlib.site.SiteCollection` instance (or None)
     :param integration_distance:
         Threshold distance in km, this value gets passed straight to
         :meth:`openquake.hazardlib.source.base.BaseSeismicSource.filter_sites_by_distance_to_source`
@@ -156,8 +156,7 @@ class SourceFilter(object):
             for sid, lon, lat in zip(sitecol.sids, fixed_lons, sitecol.lats):
                 self.index.insert(sid, (lon, lat, lon, lat))
         if rtree is None:
-            logging.info('Using distance filtering on %d sites [no rtree]',
-                         len(sitecol))
+            logging.info('Using distance filtering [no rtree]')
 
     def get_affected_box(self, src):
         """

--- a/openquake/hazardlib/calc/filters.py
+++ b/openquake/hazardlib/calc/filters.py
@@ -59,14 +59,12 @@ the index can be compensed. Finally, there is a function
 `filter_sites_by_distance_to_rupture` based on the Joyner-Boore distance.
 """
 import sys
-import logging
 from contextlib import contextmanager
 import numpy
 try:
     import rtree
 except ImportError:
     rtree = None
-    logging.warn('Cannot find the rtree module, using slow filtering')
 from openquake.baselib.python3compat import raise_
 from openquake.hazardlib.site import FilteredSiteCollection
 from openquake.hazardlib.geo.utils import fix_lons_idl


### PR DESCRIPTION
To avoid scaring the users. Missing rtree is not an issue.