### PR TITLE
Recognize the task flag .shared_dir_on

### DIFF
--- a/openquake/baselib/parallel.py
+++ b/openquake/baselib/parallel.py
@@ -175,13 +175,14 @@ elif OQ_DISTRIBUTE == 'ipython':
 
 def oq_distribute(task=None):
     """
-    If the task has an `oq_distribute` attribute, call it and return its value,
-    otherwise return the current value of the variable OQ_DISTRIBUTE;
+    If the task has an attribute `shared_dir_on` which is false,
+    return 'futures' even if OQ_DISTRIBUTE is `celery`, otherwise
+    return the current value of the variable OQ_DISTRIBUTE;
     if undefined, return 'futures'.
     """
     env = os.environ.get('OQ_DISTRIBUTE', 'futures').lower()
     if hasattr(task, 'shared_dir_on'):
-        if env in ('celery', 'ipython') and not task.shared_dir_on:
+        if env == 'celery' and not task.shared_dir_on:
             logging.warn(
                 'Task `%s` will be run on the controller node only, since '
                 'no `shared_dir` has been specified' % task.__name__)


### PR DESCRIPTION
This is a preliminary step towards https://github.com/gem/oq-engine/issues/2497.
The idea is that tasks requiring a shared directory have an attribute `.shared_dir_on` which is true if the `shared_dir` is set in the engine side and false otherwise. If `.shared_dir_on` is false, such tasks are run through `concurrent.futures` and not through celery. Regular tasks (including legacy tasks) have no such attribute and they are run as before (i.e. with celery).