### PR TITLE
Support for tiling

### DIFF
--- a/openquake/baselib/general.py
+++ b/openquake/baselib/general.py
@@ -223,6 +223,8 @@ def split_in_slices(number, num_slices):
     >>> split_in_slices(2, 4)
     [slice(0, 1, None), slice(1, 2, None)]
     """
+    assert number > 0, number
+    assert num_slices > 0, num_slices
     blocksize = int(math.ceil(number / num_slices))
     slices = []
     start = 0

--- a/openquake/baselib/general.py
+++ b/openquake/baselib/general.py
@@ -208,11 +208,11 @@ def block_splitter(items, max_weight, weight=lambda item: 1, kind=nokey):
         yield ws
 
 
-def split_in_slices(number, hint):
+def split_in_slices(number, num_slices):
     """
     :param number: a positive number to split in slices
-    :param hint: a hint for the number of slices to return
-    :returns: a list of slices with length close to `hint`
+    :param num_slices: the number of slices to return (at most)
+    :returns: a list of slices
 
     >>> split_in_slices(4, 2)
     [slice(0, 2, None), slice(2, 4, None)]
@@ -223,7 +223,7 @@ def split_in_slices(number, hint):
     >>> split_in_slices(2, 4)
     [slice(0, 1, None), slice(1, 2, None)]
     """
-    blocksize = int(math.ceil(number / hint))
+    blocksize = int(math.ceil(number / num_slices))
     slices = []
     start = 0
     while True:

--- a/openquake/baselib/general.py
+++ b/openquake/baselib/general.py
@@ -208,6 +208,31 @@ def block_splitter(items, max_weight, weight=lambda item: 1, kind=nokey):
         yield ws
 
 
+def split_in_slices(number, hint):
+    """
+    :param number: a positive number to split in slices
+    :param hint: a hint for the number of slices to return
+    :returns: a list of slices with length close to `hint`
+
+    >>> split_in_slices(5, 1)
+    [slice(0, 5, None)]
+    >>> split_in_slices(5, 2)
+    [slice(0, 2, None), slice(2, 4, None), slice(4, 5, None)]
+    >>> split_in_slices(4, 2)
+    [slice(0, 2, None), slice(2, 4, None)]
+    """
+    blocksize = number // hint
+    slices = []
+    start = 0
+    while True:
+        stop = min(start + blocksize, number)
+        slices.append(slice(start, stop))
+        if stop == number:
+            break
+        start += blocksize
+    return slices
+
+
 def split_in_blocks(sequence, hint, weight=lambda item: 1, key=nokey):
     """
     Split the `sequence` in a number of WeightedSequences close to `hint`.
@@ -225,6 +250,9 @@ def split_in_blocks(sequence, hint, weight=lambda item: 1, key=nokey):
      [<WeightedSequence ['A', 'B'], weight=2>, <WeightedSequence ['C', 'D'], weight=2>, <WeightedSequence ['E'], weight=1>]
 
     """
+    if isinstance(sequence, int):
+        return split_in_slices(sequence, hint)
+
     if hint == 0:  # do not split
         return sequence
     items = list(sequence) if key is nokey else sorted(sequence, key=key)

--- a/openquake/baselib/general.py
+++ b/openquake/baselib/general.py
@@ -219,7 +219,7 @@ def split_in_slices(number, hint):
     >>> split_in_slices(5, 1)
     [slice(0, 5, None)]
     >>> split_in_slices(5, 2)
-    [slice(0, 2, None), slice(2, 4, None), slice(4, 5, None)]
+    [slice(0, 3, None), slice(3, 5, None)]
     >>> split_in_slices(2, 4)
     [slice(0, 1, None), slice(1, 2, None)]
     """

--- a/openquake/baselib/general.py
+++ b/openquake/baselib/general.py
@@ -214,14 +214,16 @@ def split_in_slices(number, hint):
     :param hint: a hint for the number of slices to return
     :returns: a list of slices with length close to `hint`
 
+    >>> split_in_slices(4, 2)
+    [slice(0, 2, None), slice(2, 4, None)]
     >>> split_in_slices(5, 1)
     [slice(0, 5, None)]
     >>> split_in_slices(5, 2)
     [slice(0, 2, None), slice(2, 4, None), slice(4, 5, None)]
-    >>> split_in_slices(4, 2)
-    [slice(0, 2, None), slice(2, 4, None)]
+    >>> split_in_slices(2, 4)
+    [slice(0, 1, None), slice(1, 2, None)]
     """
-    blocksize = number // hint
+    blocksize = int(math.ceil(number / hint))
     slices = []
     start = 0
     while True:

--- a/openquake/baselib/parallel.py
+++ b/openquake/baselib/parallel.py
@@ -735,7 +735,7 @@ class Threadmap(BaseStarmap):
     MapReduce implementation based on threads. For instance
 
     >>> from collections import Counter
-    >>> c = Threadmap(Counter, [('hello',), ('world',)]).reduce()
+    >>> c = Threadmap(Counter, [('hello',), ('world',)], poolsize=4).reduce()
     """
     poolfactory = staticmethod(
         lambda size: multiprocessing.dummy.Pool(size))
@@ -746,5 +746,5 @@ class Processmap(BaseStarmap):
     MapReduce implementation based on processes. For instance
 
     >>> from collections import Counter
-    >>> c = Processmap(Counter, [('hello',), ('world',)]).reduce()
+    >>> c = Processmap(Counter, [('hello',), ('world',)], poolsize=4).reduce()
     """

--- a/openquake/baselib/parallel.py
+++ b/openquake/baselib/parallel.py
@@ -736,6 +736,8 @@ class Threadmap(BaseStarmap):
 
     >>> from collections import Counter
     >>> c = Threadmap(Counter, [('hello',), ('world',)], poolsize=4).reduce()
+    >>> sorted(c.items())
+    [('d', 1), ('e', 1), ('h', 1), ('l', 3), ('o', 2), ('r', 1), ('w', 1)]
     """
     poolfactory = staticmethod(
         lambda size: multiprocessing.dummy.Pool(size))
@@ -747,4 +749,6 @@ class Processmap(BaseStarmap):
 
     >>> from collections import Counter
     >>> c = Processmap(Counter, [('hello',), ('world',)], poolsize=4).reduce()
+    >>> sorted(c.items())
+    [('d', 1), ('e', 1), ('h', 1), ('l', 3), ('o', 2), ('r', 1), ('w', 1)]
     """

--- a/openquake/hazardlib/calc/filters.py
+++ b/openquake/hazardlib/calc/filters.py
@@ -191,7 +191,7 @@ class SourceFilter(object):
         min_lon, min_lat, max_lon, max_lat = self.get_affected_box(src)
         return (min_lon, min_lat), max_lon - min_lon, max_lat - min_lat
 
-    def affected(self, source):
+    def get_close_sites(self, source):
         """
         Returns the sites within the integration distance from the source,
         or None.

--- a/openquake/hazardlib/calc/gmf.py
+++ b/openquake/hazardlib/calc/gmf.py
@@ -59,6 +59,9 @@ class GmfComputer(object):
     :param imts:
         a sorted list of Intensity Measure Type strings
 
+    :param gsims:
+        a set of GSIM instances
+
     :param truncation_level:
         Float, number of standard deviations for truncation of the intensity
         distribution, or ``None``.
@@ -86,7 +89,7 @@ class GmfComputer(object):
         self.rupture = rupture
         self.sites = sites
         self.imts = [from_string(imt) for imt in imts]
-        self.gsims = gsims
+        self.gsims = set(gsims)
         self.truncation_level = truncation_level
         self.correlation_model = correlation_model
         self.samples = samples

--- a/openquake/hazardlib/sourceconverter.py
+++ b/openquake/hazardlib/sourceconverter.py
@@ -326,7 +326,7 @@ def split_filter_source(src, src_filter):
             nr = split.num_ruptures
             split.serial = src.serial[start:start + nr]
             start += nr
-        if src_filter.affected(split) is not None:
+        if src_filter.get_close_sites(split) is not None:
             split_sources.append(split)
     return split_sources
 

--- a/openquake/hazardlib/tests/calc/hazard_curve_test.py
+++ b/openquake/hazardlib/tests/calc/hazard_curve_test.py
@@ -131,7 +131,7 @@ class HazardCurvesFiltersTestCase(unittest.TestCase):
         # test that depths are kept after filtering (sites 3 and 4 remain)
         s_filter = SourceFilter(sitecol, 100)
         numpy.testing.assert_array_equal(
-            s_filter.affected(sources[0]).depths, ([1, -1]))
+            s_filter.get_close_sites(sources[0]).depths, ([1, -1]))
 
 
 # this example originally came from the Hazard Modeler Toolkit

--- a/openquake/hazardlib/valid.py
+++ b/openquake/hazardlib/valid.py
@@ -910,7 +910,8 @@ def simple_slice(value):
         start, stop = value.split(':')
         start = ast.literal_eval(start)
         stop = ast.literal_eval(stop)
-        assert start < stop
+        if start is not None and stop is not None:
+            assert start < stop
     except:
         raise ValueError('invalid slice: %s' % value)
     return (start, stop)

--- a/openquake/hazardlib/valid.py
+++ b/openquake/hazardlib/valid.py
@@ -899,6 +899,23 @@ def positiveints(value):
     return ints
 
 
+def simple_slice(value):
+    """
+    A simple slice with step 1.
+
+    >>> simple_slice('2:5')
+    slice(2, 5, None)
+    >>> simple_slice('0:None')
+    slice(0, None, None)
+    """
+    try:
+        start, stop = value.split(':')
+        start = ast.literal_eval(start)
+        stop = ast.literal_eval(stop)
+    except:
+        raise ValueError('invalid slice: %s' % value)
+    return slice(start, stop)
+
 # ############################## site model ################################ #
 
 vs30_type = ChoiceCI('measured', 'inferred')

--- a/openquake/hazardlib/valid.py
+++ b/openquake/hazardlib/valid.py
@@ -901,20 +901,19 @@ def positiveints(value):
 
 def simple_slice(value):
     """
-    A simple slice with step 1.
-
     >>> simple_slice('2:5')
-    slice(2, 5, None)
+    (2, 5)
     >>> simple_slice('0:None')
-    slice(0, None, None)
+    (0, None)
     """
     try:
         start, stop = value.split(':')
         start = ast.literal_eval(start)
         stop = ast.literal_eval(stop)
+        assert start < stop
     except:
         raise ValueError('invalid slice: %s' % value)
-    return slice(start, stop)
+    return (start, stop)
 
 # ############################## site model ################################ #
 


### PR DESCRIPTION
I am adding a function `split_in_slices` that will be used by the engine to split large collections of sites in tiles. I am also adding a validation function `simple_slice` that will be used by the engine to select the slice of sites of interest (i.e. in the job.ini one can write sites_slice=0:100 and only the first 100 sites of the sites_csv file will be considered). There is also one renaming and a docstring fix.