### PR TITLE
Introduced a magnitude-dependent IntegrationDistance

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,6 @@
+  [Michele Simionato]
+  * Introduced a magnitude-dependent integration distance
+
   [Robin Gee, Michele Simionato]
   * Implemented support for sites above the level of the sea
 

--- a/openquake/hazardlib/calc/filters.py
+++ b/openquake/hazardlib/calc/filters.py
@@ -210,27 +210,23 @@ class SourceFilter(object):
             for source in sources:
                 yield source, sites
             return
-        for source in sources:
+        for src in sources:
             if self.use_rtree:  # Rtree filtering
-                box = self.get_affected_box(source)
+                box = self.get_affected_box(src)
                 sids = numpy.array(sorted(self.index.intersection(box)))
                 if len(sids):
-                    source.nsites = len(sids)
-                    yield source, FilteredSiteCollection(sids, sites.complete)
+                    src.nsites = len(sids)
+                    yield src, FilteredSiteCollection(sids, sites.complete)
             elif not self.integration_distance:
-                yield source, sites
+                yield src, sites
             else:  # normal filtering
-                try:
-                    maxdist = self.integration_distance[
-                        source.tectonic_region_type]
-                except TypeError:  # passed a scalar, not a dictionary
-                    maxdist = self.integration_distance
-                with context(source):
-                    s_sites = source.filter_sites_by_distance_to_source(
+                maxdist = self.integration_distance[src.tectonic_region_type]
+                with context(src):
+                    s_sites = src.filter_sites_by_distance_to_source(
                         maxdist, sites)
                 if s_sites is not None:
-                    source.nsites = len(s_sites)
-                    yield source, s_sites
+                    src.nsites = len(s_sites)
+                    yield src, s_sites
 
     def __getstate__(self):
         return dict(integration_distance=self.integration_distance,

--- a/openquake/hazardlib/calc/filters.py
+++ b/openquake/hazardlib/calc/filters.py
@@ -61,7 +61,6 @@ the index can be compensed. Finally, there is a function
 import sys
 import logging
 from contextlib import contextmanager
-from scipy.interpolate import interp1d
 import numpy
 try:
     import rtree
@@ -119,48 +118,6 @@ def filter_sites_by_distance_to_rupture(rupture, integration_distance, sites):
     """
     jb_dist = rupture.surface.get_joyner_boore_distance(sites.mesh)
     return sites.filter(jb_dist <= integration_distance)
-
-
-class MagnitudeDistance(object):
-    """
-    Pickleable object with a .get property returning the integration distance
-    associated with a given magnitude.
-
-    >>> maxdist = MagnitudeDistance([
-    ...          (1, 10), (2, 20), (3, 30), (4, 40), (5, 100), (6, 200),
-    ...          (7, 400), (8, 800)])
-    >>> maxdist.get(5.5)
-    array(150.0)
-    """
-    _interp = None
-
-    @property
-    def get(self):
-        if self._interp is not None:
-            return self._interp
-        if isinstance(self.value, list):
-            self._interp = interp1d(self.mags, self.dists)
-        else:
-            self._interp = lambda mag: self.value
-        return self._interp
-
-    def __init__(self, value):
-        self.value = value
-        if isinstance(value, list):  # assume a list of pairs (mag, dist)
-            value.sort()  # make sure the list is sorted by magnitude
-            self.mags, self.dists = zip(*value)
-
-    def __getstate__(self):
-        return dict(value=self.value)
-
-    def __str__(self):
-        return repr(self.value)
-
-    def max(self):
-        if isinstance(self.value, list):
-            return self.value[-1][1]
-        else:
-            return self.value
 
 
 class SourceFilter(object):

--- a/openquake/hazardlib/calc/filters.py
+++ b/openquake/hazardlib/calc/filters.py
@@ -211,7 +211,7 @@ class SourceFilter(object):
                 yield source, sites
             return
         for src in sources:
-            if self.use_rtree:  # Rtree filtering
+            if self.use_rtree:  # Rtree filtering, used in the controller
                 box = self.get_affected_box(src)
                 sids = numpy.array(sorted(self.index.intersection(box)))
                 if len(sids):
@@ -219,7 +219,7 @@ class SourceFilter(object):
                     yield src, FilteredSiteCollection(sids, sites.complete)
             elif not self.integration_distance:
                 yield src, sites
-            else:  # normal filtering
+            else:  # normal filtering, used in the workers
                 max_mag = src.get_min_max_mag()[1]
                 maxdist = self.integration_distance(
                     src.tectonic_region_type, max_mag)

--- a/openquake/hazardlib/calc/filters.py
+++ b/openquake/hazardlib/calc/filters.py
@@ -148,9 +148,12 @@ class SourceFilter(object):
         by default True, i.e. try to use the rtree module if available
     """
     def __init__(self, sitecol, integration_distance, use_rtree=True):
-        if isinstance(integration_distance, dict):
-            integration_distance = valid.IntegrationDistance(integration_distance)
-        self.integration_distance = integration_distance
+        if (isinstance(integration_distance, dict) and not
+                isinstance(integration_distance, valid.IntegrationDistance)):
+            self.integration_distance = valid.IntegrationDistance(
+                integration_distance)
+        else:
+            self.integration_distance = integration_distance
         self.sitecol = sitecol
         self.use_rtree = use_rtree and rtree and (
             integration_distance and sitecol is not None)
@@ -169,10 +172,7 @@ class SourceFilter(object):
         :param src: a source object
         :returns: a bounding box (min_lon, min_lat, max_lon, max_lat)
         """
-        try:
-            maxdist = self.integration_distance[src.tectonic_region_type]
-        except TypeError:  # passed a scalar, not a dictionary
-            maxdist = self.integration_distance
+        maxdist = self.integration_distance[src.tectonic_region_type]
         min_lon, min_lat, max_lon, max_lat = src.get_bounding_box(maxdist)
         if self.idl:  # apply IDL fix
             if min_lon < 0 and max_lon > 0:

--- a/openquake/hazardlib/calc/filters.py
+++ b/openquake/hazardlib/calc/filters.py
@@ -220,7 +220,9 @@ class SourceFilter(object):
             elif not self.integration_distance:
                 yield src, sites
             else:  # normal filtering
-                maxdist = self.integration_distance[src.tectonic_region_type]
+                max_mag = src.get_min_max_mag()[1]
+                maxdist = self.integration_distance(
+                    src.tectonic_region_type, max_mag)
                 with context(src):
                     s_sites = src.filter_sites_by_distance_to_source(
                         maxdist, sites)

--- a/openquake/hazardlib/calc/filters.py
+++ b/openquake/hazardlib/calc/filters.py
@@ -60,6 +60,7 @@ the index can be compensed. Finally, there is a function
 """
 import sys
 import logging
+import collections
 from contextlib import contextmanager
 import numpy
 try:
@@ -148,7 +149,7 @@ class SourceFilter(object):
         by default True, i.e. try to use the rtree module if available
     """
     def __init__(self, sitecol, integration_distance, use_rtree=True):
-        if (isinstance(integration_distance, dict) and not
+        if (isinstance(integration_distance, collections.Mapping) and not
                 isinstance(integration_distance, valid.IntegrationDistance)):
             self.integration_distance = valid.IntegrationDistance(
                 integration_distance)

--- a/openquake/hazardlib/calc/filters.py
+++ b/openquake/hazardlib/calc/filters.py
@@ -156,6 +156,12 @@ class MagnitudeDistance(object):
     def __str__(self):
         return repr(self.value)
 
+    def max(self):
+        if isinstance(self.value, list):
+            return self.value[-1][1]
+        else:
+            return self.value
+
 
 class SourceFilter(object):
     """

--- a/openquake/hazardlib/calc/filters.py
+++ b/openquake/hazardlib/calc/filters.py
@@ -149,7 +149,7 @@ class SourceFilter(object):
     """
     def __init__(self, sitecol, integration_distance, use_rtree=True):
         if isinstance(integration_distance, dict):
-            integration_distance = valid.MaximumDistance(integration_distance)
+            integration_distance = valid.IntegrationDistance(integration_distance)
         self.integration_distance = integration_distance
         self.sitecol = sitecol
         self.use_rtree = use_rtree and rtree and (

--- a/openquake/hazardlib/calc/filters.py
+++ b/openquake/hazardlib/calc/filters.py
@@ -67,6 +67,7 @@ try:
 except ImportError:
     rtree = None
 from openquake.baselib.python3compat import raise_
+from openquake.hazardlib import valid
 from openquake.hazardlib.site import FilteredSiteCollection
 from openquake.hazardlib.geo.utils import fix_lons_idl
 
@@ -147,6 +148,8 @@ class SourceFilter(object):
         by default True, i.e. try to use the rtree module if available
     """
     def __init__(self, sitecol, integration_distance, use_rtree=True):
+        if isinstance(integration_distance, dict):
+            integration_distance = valid.MaximumDistance(integration_distance)
         self.integration_distance = integration_distance
         self.sitecol = sitecol
         self.use_rtree = use_rtree and rtree and (

--- a/openquake/hazardlib/calc/hazard_curve.py
+++ b/openquake/hazardlib/calc/hazard_curve.py
@@ -158,8 +158,7 @@ def poe_map(src, s_sites, imtls, cmaker, trunclevel, ctx_mon, pne_mon,
                         bb.update([dist], [p.longitude], [p.latitude])
     except Exception as err:
         etype, err, tb = sys.exc_info()
-        msg = 'An error occurred with source id=%s. Error: %s'
-        msg %= (src.source_id, str(err))
+        msg = '%s (source id=%s)' % (str(err), src.source_id)
         raise_(etype, msg, tb)
     return ~pmap
 
@@ -183,10 +182,7 @@ def pmap_from_grp(
     else:  # list of sources
         trt = sources[0].tectonic_region_type
         group = SourceGroup(trt, sources, 'src_group', 'indep', 'indep')
-    try:
-        maxdist = source_site_filter.integration_distance[trt]
-    except:
-        maxdist = source_site_filter.integration_distance
+    maxdist = source_site_filter.integration_distance
     if hasattr(gsims, 'keys'):  # dictionary trt -> gsim
         gsims = [gsims[trt]]
     with GroundShakingIntensityModel.forbid_instantiation():

--- a/openquake/hazardlib/gsim/base.py
+++ b/openquake/hazardlib/gsim/base.py
@@ -291,9 +291,8 @@ class ContextMaker(object):
         if self.maximum_distance:
             # self.maximum_distance can be just a scalar number in km
             # or a function magniture -> distance
-            maxdist = (self.maximum_distance(rupture.mag)
-                       if callable(self.maximum_distance)
-                       else self.maximum_distance)
+            maxdist = self.maximum_distance(
+                rupture.tectonic_region_type, rupture.mag)
             mask = distances <= maxdist
             if mask.any():
                 sites = site_collection.filter(mask)

--- a/openquake/hazardlib/gsim/base.py
+++ b/openquake/hazardlib/gsim/base.py
@@ -144,6 +144,10 @@ class FarAwayRupture(Exception):
 class ContextMaker(object):
     """
     A class to manage the creation of contexts for distances, sites, rupture.
+    It has also a method `.get_close(sites, rupture)` returning the closest
+    sites to the rupture and their distances. The integration distance can be
+    None if the sites have been already filtered: in that case returns all the
+    sites and all the distances.
     """
     REQUIRES = ['DISTANCES', 'SITES_PARAMETERS', 'RUPTURE_PARAMETERS']
 
@@ -300,6 +304,8 @@ class ContextMaker(object):
         :raises: a FarAwayRupture exception is the rupture is far away
         """
         distances = get_distances(rupture, sites.mesh, distance_type)
+        if self.maximum_distance is None:  # for sites already filtered
+            return sites, distances
         mask = distances <= self.maximum_distance(
             rupture.tectonic_region_type, rupture.mag)
         if mask.any():

--- a/openquake/hazardlib/gsim/base.py
+++ b/openquake/hazardlib/gsim/base.py
@@ -289,7 +289,12 @@ class ContextMaker(object):
         distances = get_distances(rupture, site_collection.mesh, 'rjb')
         sites = site_collection
         if self.maximum_distance:
-            mask = distances <= self.maximum_distance
+            # self.maximum_distance can be just a scalar number in km
+            # or a function magniture -> distance
+            maxdist = (self.maximum_distance(rupture.mag)
+                       if callable(self.maximum_distance)
+                       else self.maximum_distance)
+            mask = distances <= maxdist
             if mask.any():
                 sites = site_collection.filter(mask)
                 distances = distances[mask]

--- a/openquake/hazardlib/gsim/base.py
+++ b/openquake/hazardlib/gsim/base.py
@@ -297,8 +297,8 @@ class ContextMaker(object):
 
     def get_closest(self, sites, rupture, distance_type='rjb'):
         """
-        :param rupture: a rupture
         :param sites: a (Filtered)SiteColletion
+        :param rupture: a rupture
         :param distance_type: default 'rjb'
         :returns: (close sites, close distances)
         :raises: a FarAwayRupture exception if the rupture is far away

--- a/openquake/hazardlib/gsim/base.py
+++ b/openquake/hazardlib/gsim/base.py
@@ -301,7 +301,7 @@ class ContextMaker(object):
         :param sites: a (Filtered)SiteColletion
         :param distance_type: default 'rjb'
         :returns: (close sites, close distances)
-        :raises: a FarAwayRupture exception is the rupture is far away
+        :raises: a FarAwayRupture exception if the rupture is far away
         """
         distances = get_distances(rupture, sites.mesh, distance_type)
         if self.maximum_distance is None:  # for sites already filtered

--- a/openquake/hazardlib/gsim/base.py
+++ b/openquake/hazardlib/gsim/base.py
@@ -144,7 +144,7 @@ class FarAwayRupture(Exception):
 class ContextMaker(object):
     """
     A class to manage the creation of contexts for distances, sites, rupture.
-    It has also a method `.get_close(sites, rupture)` returning the closest
+    It has also a method `.get_closest(sites, rupture)` returning the closest
     sites to the rupture and their distances. The integration distance can be
     None if the sites have been already filtered: in that case returns all the
     sites and all the distances.
@@ -290,12 +290,12 @@ class ContextMaker(object):
             and distance parameters) is unknown.
         """
         rctx = self.make_rupture_context(rupture)
-        sites, distances = self.get_close(site_collection, rupture, 'rjb')
+        sites, distances = self.get_closest(site_collection, rupture, 'rjb')
         sctx = self.make_sites_context(sites)
         dctx = self.make_distances_context(sites, rupture, {'rjb': distances})
         return (sctx, rctx, dctx)
 
-    def get_close(self, sites, rupture, distance_type='rjb'):
+    def get_closest(self, sites, rupture, distance_type='rjb'):
         """
         :param rupture: a rupture
         :param sites: a (Filtered)SiteColletion

--- a/openquake/hazardlib/tests/acceptance/stochastic_test.py
+++ b/openquake/hazardlib/tests/acceptance/stochastic_test.py
@@ -131,7 +131,7 @@ class StochasticEventSetTestCase(unittest.TestCase):
         ses = stochastic_event_set(
             [self.area1, self.area2],
             sites=sites,
-            source_site_filter=filters.SourceFilter(sites, 100.)
+            source_site_filter=filters.SourceFilter(sites, {'default': 100.})
         )
 
         rates = self._extract_rates(ses, time_span=self.time_span,

--- a/openquake/hazardlib/tests/calc/hazard_curve_test.py
+++ b/openquake/hazardlib/tests/calc/hazard_curve_test.py
@@ -137,7 +137,7 @@ class HazardCurvesFiltersTestCase(unittest.TestCase):
         numpy.testing.assert_allclose(result[1], 0)  # no contrib to site 2
 
         # test that depths are kept after filtering (sites 3 and 4 remain)
-        s_filter = SourceFilter(sitecol, 100)
+        s_filter = SourceFilter(sitecol, {'default': 100})
         numpy.testing.assert_array_equal(
             s_filter.get_close_sites(sources[0]).depths, ([1, -1]))
 

--- a/openquake/hazardlib/tests/calc/hazard_curve_test.py
+++ b/openquake/hazardlib/tests/calc/hazard_curve_test.py
@@ -18,11 +18,11 @@ import pickle
 import numpy
 
 import openquake.hazardlib
-from openquake.hazardlib import const
+from openquake.hazardlib import const, valid
 from openquake.hazardlib.geo.point import Point
 from openquake.hazardlib.tom import PoissonTOM
 from openquake.hazardlib.calc.hazard_curve import calc_hazard_curves
-from openquake.hazardlib.calc.filters import SourceFilter, MagnitudeDistance
+from openquake.hazardlib.calc.filters import SourceFilter
 from openquake.baselib.parallel import Sequential, Processmap
 from openquake.hazardlib.site import Site, SiteCollection
 from openquake.hazardlib.gsim import akkar_bommer_2010
@@ -35,11 +35,11 @@ from openquake.hazardlib.source.point import PointSource
 
 class HazardCurvesFiltersTestCase(unittest.TestCase):
     def test_MagnitudeDistance_pickleable(self):
-        md = MagnitudeDistance(
-            [(1, 10), (2, 20), (3, 30), (4, 40), (5, 100), (6, 200),
-             (7, 400), (8, 800)])
+        md = valid.MaximumDistance(
+            dict(default=[(1, 10), (2, 20), (3, 30), (4, 40), (5, 100),
+                          (6, 200), (7, 400), (8, 800)]))
         md2 = pickle.loads(pickle.dumps(md))
-        self.assertEqual(md.value, md2.value)
+        self.assertEqual(md.dic, md2.dic)
 
     def test_point_sources(self):
         sources = [

--- a/openquake/hazardlib/tests/calc/hazard_curve_test.py
+++ b/openquake/hazardlib/tests/calc/hazard_curve_test.py
@@ -35,7 +35,7 @@ from openquake.hazardlib.source.point import PointSource
 
 class HazardCurvesFiltersTestCase(unittest.TestCase):
     def test_MagnitudeDistance_pickleable(self):
-        md = valid.MaximumDistance(
+        md = valid.IntegrationDistance(
             dict(default=[(1, 10), (2, 20), (3, 30), (4, 40), (5, 100),
                           (6, 200), (7, 400), (8, 800)]))
         md2 = pickle.loads(pickle.dumps(md))

--- a/openquake/hazardlib/tests/calc/hazard_curve_test.py
+++ b/openquake/hazardlib/tests/calc/hazard_curve_test.py
@@ -14,6 +14,7 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 import unittest
+import pickle
 import numpy
 
 import openquake.hazardlib
@@ -21,7 +22,8 @@ from openquake.hazardlib import const
 from openquake.hazardlib.geo.point import Point
 from openquake.hazardlib.tom import PoissonTOM
 from openquake.hazardlib.calc.hazard_curve import calc_hazard_curves
-from openquake.hazardlib.calc.filters import SourceFilter
+from openquake.hazardlib.calc.filters import (
+    SourceFilter, MagnitudeDistanceFunction)
 from openquake.baselib.parallel import Sequential, Processmap
 from openquake.hazardlib.site import Site, SiteCollection
 from openquake.hazardlib.gsim import akkar_bommer_2010
@@ -33,6 +35,13 @@ from openquake.hazardlib.source.point import PointSource
 
 
 class HazardCurvesFiltersTestCase(unittest.TestCase):
+    def test_mdf_pickleable(self):
+        mdf = MagnitudeDistanceFunction(
+            [(1, 10), (2, 20), (3, 30), (4, 40), (5, 100), (6, 200),
+             (7, 400), (8, 800)])
+        mdf2 = pickle.loads(pickle.dumps(mdf))
+        self.assertEqual(mdf.value, mdf2.value)
+
     def test_point_sources(self):
         sources = [
             openquake.hazardlib.source.PointSource(

--- a/openquake/hazardlib/tests/calc/hazard_curve_test.py
+++ b/openquake/hazardlib/tests/calc/hazard_curve_test.py
@@ -34,7 +34,7 @@ from openquake.hazardlib.source.point import PointSource
 
 
 class HazardCurvesFiltersTestCase(unittest.TestCase):
-    def test_mdf_pickleable(self):
+    def test_MagnitudeDistance_pickleable(self):
         md = MagnitudeDistance(
             [(1, 10), (2, 20), (3, 30), (4, 40), (5, 100), (6, 200),
              (7, 400), (8, 800)])

--- a/openquake/hazardlib/tests/calc/hazard_curve_test.py
+++ b/openquake/hazardlib/tests/calc/hazard_curve_test.py
@@ -22,8 +22,7 @@ from openquake.hazardlib import const
 from openquake.hazardlib.geo.point import Point
 from openquake.hazardlib.tom import PoissonTOM
 from openquake.hazardlib.calc.hazard_curve import calc_hazard_curves
-from openquake.hazardlib.calc.filters import (
-    SourceFilter, MagnitudeDistanceFunction)
+from openquake.hazardlib.calc.filters import SourceFilter, MagnitudeDistance
 from openquake.baselib.parallel import Sequential, Processmap
 from openquake.hazardlib.site import Site, SiteCollection
 from openquake.hazardlib.gsim import akkar_bommer_2010
@@ -36,11 +35,11 @@ from openquake.hazardlib.source.point import PointSource
 
 class HazardCurvesFiltersTestCase(unittest.TestCase):
     def test_mdf_pickleable(self):
-        mdf = MagnitudeDistanceFunction(
+        md = MagnitudeDistance(
             [(1, 10), (2, 20), (3, 30), (4, 40), (5, 100), (6, 200),
              (7, 400), (8, 800)])
-        mdf2 = pickle.loads(pickle.dumps(mdf))
-        self.assertEqual(mdf.value, mdf2.value)
+        md2 = pickle.loads(pickle.dumps(md))
+        self.assertEqual(md.value, md2.value)
 
     def test_point_sources(self):
         sources = [

--- a/openquake/hazardlib/valid.py
+++ b/openquake/hazardlib/valid.py
@@ -748,17 +748,17 @@ def maximum_distance(value):
     :param value:
         input string corresponding to a valid maximum distance
     :returns:
-        a MaximumDistance mapping
+        a IntegrationDistance mapping
     """
-    return MaximumDistance(floatdict(value))
+    return IntegrationDistance(floatdict(value))
 
 
-class MaximumDistance(collections.Mapping):
+class IntegrationDistance(collections.Mapping):
     """
     Pickleable object wrapping a dictionary of integration distances per
     tectonic region type.
 
-    >>> maxdist = MaximumDistance({'default': [
+    >>> maxdist = IntegrationDistance({'default': [
     ...          (1, 10), (2, 20), (3, 30), (4, 40), (5, 100), (6, 200),
     ...          (7, 400), (8, 800)]})
     >>> maxdist('default', mag=5.5)

--- a/openquake/hazardlib/valid.py
+++ b/openquake/hazardlib/valid.py
@@ -774,7 +774,7 @@ class MaximumDistance(collections.Mapping):
             else:
                 self.dic[trt] = float(value)
 
-    def __call__(self, mag, trt):
+    def __call__(self, trt, mag):
         maxdist = getdefault(self.dic, trt)
         if isinstance(maxdist, float):  # scalar maximum distance
             return maxdist
@@ -783,8 +783,10 @@ class MaximumDistance(collections.Mapping):
         try:
             md = self.interp[trt]  # retrieve from the cache
         except KeyError:  # fill the cache
-            md = self.interp[trt] = interp1d(*self.magdist[trt])
-        return md[mag]
+            magdist = getdefault(self.magdist, trt)
+            md = self.interp[trt] = interp1d(
+                *magdist, fill_value='extrapolate')
+        return md(mag)
 
     def __getitem__(self, trt):
         value = self.dic[trt]
@@ -798,9 +800,6 @@ class MaximumDistance(collections.Mapping):
 
     def __len__(self):
         return len(self.dic)
-
-    def __getstate__(self):
-        return dict(dic=self.dic)
 
     def __repr__(self):
         return repr(self.dic)

--- a/openquake/hazardlib/valid.py
+++ b/openquake/hazardlib/valid.py
@@ -761,12 +761,12 @@ class IntegrationDistance(collections.Mapping):
     >>> maxdist = IntegrationDistance({'default': [
     ...          (1, 10), (2, 20), (3, 30), (4, 40), (5, 100), (6, 200),
     ...          (7, 400), (8, 800)]})
-    >>> maxdist('default', mag=5.5)
+    >>> maxdist('Some TRT', mag=5.5)
     array(150.0)
     """
     def __init__(self, dic):
-        self.dic = dic  # TRT -> list of pairs
-        self.magdist = {}  # TRT -> magdist
+        self.dic = dic  # TRT -> float or list of pairs
+        self.magdist = {}  # TRT -> (magnitudes, distances)
         for trt, value in dic.items():
             if isinstance(value, list):  # assume a list of pairs (mag, dist)
                 value.sort()  # make sure the list is sorted by magnitude

--- a/openquake/hazardlib/valid.py
+++ b/openquake/hazardlib/valid.py
@@ -789,7 +789,7 @@ class MaximumDistance(collections.Mapping):
         return md(mag)
 
     def __getitem__(self, trt):
-        value = self.dic[trt]
+        value = getdefault(self.dic, trt)
         if isinstance(value, float):  # scalar maximum distance
             return value
         # get the maximum magnitude distance

--- a/openquake/hazardlib/valid.py
+++ b/openquake/hazardlib/valid.py
@@ -28,11 +28,12 @@ import collections
 from decimal import Decimal
 
 import numpy
+from scipy.interpolate import interp1d
 
 from openquake.baselib.python3compat import with_metaclass
+from openquake.baselib.general import distinct
 from openquake.baselib import hdf5
 from openquake.hazardlib import imt, scalerel, gsim
-from openquake.baselib.general import distinct
 
 SCALEREL = scalerel.get_available_magnitude_scalerel()
 
@@ -728,6 +729,81 @@ def floatdict(value):
     if isinstance(value, (int, float, list)):
         return {'default': value}
     return value
+
+
+def getdefault(dic_with_default, key):
+    """
+    :param dic_with_default: a dictionary with a 'default' key
+    :param key: a key that may be present in the dictionary or not
+    :returns: the value associated to the key, or to 'default'
+    """
+    try:
+        return dic_with_default[key]
+    except KeyError:
+        return dic_with_default['default']
+
+
+def maximum_distance(value):
+    """
+    :param value:
+        input string corresponding to a valid maximum distance
+    :returns:
+        a MaximumDistance mapping
+    """
+    return MaximumDistance(floatdict(value))
+
+
+class MaximumDistance(collections.Mapping):
+    """
+    Pickleable object wrapping a dictionary of integration distances per
+    tectonic region type.
+
+    >>> maxdist = MaximumDistance({'default': [
+    ...          (1, 10), (2, 20), (3, 30), (4, 40), (5, 100), (6, 200),
+    ...          (7, 400), (8, 800)]})
+    >>> maxdist('default', mag)
+    array(150.0)
+    """
+    def __init__(self, dic):
+        self.dic = dic  # TRT -> list of pairs
+        self.magdist = {}  # TRT -> magdist
+        for trt, value in dic.items():
+            if isinstance(value, list):  # assume a list of pairs (mag, dist)
+                value.sort()  # make sure the list is sorted by magnitude
+                self.magdist[trt] = zip(*value)
+            else:
+                self.dic[trt] = float(value)
+
+    def __call__(self, mag, trt):
+        maxdist = getdefault(self.dic, trt)
+        if isinstance(maxdist, float):  # scalar maximum distance
+            return maxdist
+        if not hasattr(self, 'interp'):
+            self.interp = {}  # function cache
+        try:
+            md = self.interp[trt]  # retrieve from the cache
+        except KeyError:  # fill the cache
+            md = self.interp[trt] = interp1d(*self.magdist[trt])
+        return md[mag]
+
+    def __getitem__(self, trt):
+        value = self.dic[trt]
+        if isinstance(value, float):  # scalar maximum distance
+            return value
+        # get the maximum magnitude distance
+        return value[-1][1]
+
+    def __iter__(self):
+        return iter(self.dic)
+
+    def __len__(self):
+        return len(self.dic)
+
+    def __getstate__(self):
+        return dict(dic=self.dic)
+
+    def __repr__(self):
+        return repr(self.dic)
 
 
 # ########################### SOURCES/RUPTURES ############################# #

--- a/openquake/hazardlib/valid.py
+++ b/openquake/hazardlib/valid.py
@@ -709,6 +709,7 @@ def dictionary(value):
     return dic
 
 
+# used for the maximum distance parameter in the job.ini file
 def floatdict(value):
     """
     :param value:
@@ -724,7 +725,7 @@ def floatdict(value):
     [('active shallow crust', 250.0), ('default', 200)]
     """
     value = ast.literal_eval(value)
-    if isinstance(value, (int, float)):
+    if isinstance(value, (int, float, list)):
         return {'default': value}
     return value
 

--- a/openquake/hazardlib/valid.py
+++ b/openquake/hazardlib/valid.py
@@ -761,7 +761,7 @@ class MaximumDistance(collections.Mapping):
     >>> maxdist = MaximumDistance({'default': [
     ...          (1, 10), (2, 20), (3, 30), (4, 40), (5, 100), (6, 200),
     ...          (7, 400), (8, 800)]})
-    >>> maxdist('default', mag)
+    >>> maxdist('default', mag=5.5)
     array(150.0)
     """
     def __init__(self, dic):


### PR DESCRIPTION
Once upon a time, the integration distance was a simple float, nowadays it is a dictionary `{tectonic_region_type: float}` which may have a `"default" key`, used to extract the distance for unspecified tectonic region types (i.e. the dictionary `{'default': 200}` gives a distance of 200 km to all tectonic region types).

With this pull request the integration distance will become an even more complex dictionary (which deserves to be of its own type)  which values can be list of pairs (magnitude, distance). From such pairs the `IntegrationDistance` object will build interpolating functions giving the distance for any magnitude. Such functions will be used in `ContextMaker.get_close` to filter the sites close to a given rupture.

A companion PR in the engine side will be open shortly.