### PR TITLE
Enabled rtree filtering only if the site collection is at sea level

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,5 @@
   [Michele Simionato]
+  * Enabled rtree filtering only if the site collection is at sea level
   * Added a `parallel.Computer` base class
   * Changed the default distance from filtering from Rjb to Rrup
   * Saved data transfer information automatically in `parallel.Starmap`

--- a/openquake/hazardlib/calc/filters.py
+++ b/openquake/hazardlib/calc/filters.py
@@ -157,7 +157,8 @@ class SourceFilter(object):
             self.integration_distance = integration_distance
         self.sitecol = sitecol
         self.use_rtree = use_rtree and rtree and (
-            integration_distance and sitecol is not None)
+            integration_distance and sitecol is not None and
+            sitecol.at_sea_level())
         if self.use_rtree:
             fixed_lons, self.idl = fix_lons_idl(sitecol.lons)
             self.index = rtree.index.Index()

--- a/openquake/hazardlib/site.py
+++ b/openquake/hazardlib/site.py
@@ -369,6 +369,10 @@ class FilteredSiteCollection(object):
         """Return a mesh with the given lons, lats, and depths"""
         return Mesh(self.lons, self.lats, self.depths)
 
+    def at_sea_level(self):
+        """True if all depths are zero"""
+        return (self.depths == 0).all()
+
     def filter(self, mask):
         """
         Create a FilteredSiteCollection with only a subset of sites


### PR DESCRIPTION
Since the rtree filtering is ignoring the depths, it cannot be used when there is a non-trivial topography.