### PR TITLE
Saved mesh as 32 bit floats

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,5 @@
   [Michele Simionato]
+  * Increased IMPERFECT_RECTANGLE_TOLERANCE to 0.002
   * Enabled rtree filtering only if the site collection is at sea level
   * Added a `parallel.Computer` base class
   * Changed the default distance from filtering from Rjb to Rrup

--- a/openquake/hazardlib/geo/mesh.py
+++ b/openquake/hazardlib/geo/mesh.py
@@ -28,7 +28,8 @@ from openquake.hazardlib.geo.point import Point
 from openquake.hazardlib.geo import geodetic
 from openquake.hazardlib.geo import utils as geo_utils
 
-mesh_dt = numpy.dtype([('lon', float), ('lat', float), ('depth', float)])
+F32 = numpy.float32
+point3d = numpy.dtype([('lon', F32), ('lat', F32), ('depth', F32)])
 
 
 def build_array(lons_lats_depths):
@@ -37,7 +38,7 @@ def build_array(lons_lats_depths):
     lon, lat, depth and shape (n,) + lons.shape.
     """
     shape = (len(lons_lats_depths),) + lons_lats_depths[0][0].shape
-    arr = numpy.zeros(shape, mesh_dt)
+    arr = numpy.zeros(shape, point3d)
     for i, (lons, lats, depths) in enumerate(lons_lats_depths):
         arr['lon'][i] = lons
         arr['lat'][i] = lats

--- a/openquake/hazardlib/geo/surface/planar.py
+++ b/openquake/hazardlib/geo/surface/planar.py
@@ -75,7 +75,7 @@ class PlanarSurface(BaseQuadrilateralSurface):
     #: as well as maximum offset of a bottom left corner from a line drawn
     #: downdip perpendicular to top edge from top left corner, expressed
     #: as a fraction of the surface's area.
-    IMPERFECT_RECTANGLE_TOLERANCE = 0.001
+    IMPERFECT_RECTANGLE_TOLERANCE = 0.002
 
     _slots_ = ('mesh_spacing strike dip width length '
                'corner_lons corner_lats corner_depths '

--- a/openquake/hazardlib/geo/surface/planar.py
+++ b/openquake/hazardlib/geo/surface/planar.py
@@ -75,7 +75,7 @@ class PlanarSurface(BaseQuadrilateralSurface):
     #: as well as maximum offset of a bottom left corner from a line drawn
     #: downdip perpendicular to top edge from top left corner, expressed
     #: as a fraction of the surface's area.
-    IMPERFECT_RECTANGLE_TOLERANCE = 0.0008
+    IMPERFECT_RECTANGLE_TOLERANCE = 0.001
 
     _slots_ = ('mesh_spacing strike dip width length '
                'corner_lons corner_lats corner_depths '


### PR DESCRIPTION
In this way we reduce by half the memory and data transfer. Notice that `lon` and `lat` are already considered 32 bit floats in the site collection, so we are not losing any real precision.