### PR TITLE
Fixed XML to HDF5 tests

### DIFF
--- a/openquake/baselib/hdf5.py
+++ b/openquake/baselib/hdf5.py
@@ -283,7 +283,7 @@ class File(h5py.File):
         if hasattr(text, 'strip'):
             text = text.strip()
         attrib = nodedict.get('attrib', {})
-        path = os.path.join(root, tag)
+        path = '/'.join([root, tag])
         nodes = nodedict.get('nodes', [])
         if text:
             setitem(path, text)
@@ -308,7 +308,7 @@ def _resolve_duplicates(dicts):
         group = list(grp)
         if len(group) > 1:  # there are duplicate tags
             for i, dic in enumerate(group, 1):
-                dic['tag'] += '-%d' % i
+                dic['tag'] += ';%d' % i
     return dicts
 
 

--- a/openquake/baselib/hdf5.py
+++ b/openquake/baselib/hdf5.py
@@ -308,7 +308,7 @@ def _resolve_duplicates(dicts):
         group = list(grp)
         if len(group) > 1:  # there are duplicate tags
             for i, dic in enumerate(group, 1):
-                dic['tag'] += ';%d' % i
+                dic['tag'] += '-%d' % i
     return dicts
 
 


### PR DESCRIPTION
There was a wrong `os.path.join` producing `\\` on Windows and causing the error  in https://ci.openquake.org/job/windows/job/master_oq-hazardlib/155/console/
Now the tests are green: https://ci.openquake.org/job/windows/job/zdevel_oq-hazardlib/4