### PR TITLE
Make sure that `task_info` is stored always

### DIFF
--- a/openquake/baselib/parallel.py
+++ b/openquake/baselib/parallel.py
@@ -658,11 +658,10 @@ class Starmap(object):
             task_no += 1
             if task_no == 1:  # first time
                 self.progress('Submitting %s "%s" tasks', nargs, self.name)
-            if isinstance(args[-1], Monitor):  # add incremental task number
+            if isinstance(args[-1], Monitor):
+                # add incremental task number and task weight
                 args[-1].task_no = task_no
-                weight = getattr(args[0], 'weight', None)
-                if weight:
-                    args[-1].weight = weight
+                args[-1].weight = getattr(args[0], 'weight', 1.)
             self.submit(*args)
         if not task_no:
             self.progress('No %s tasks were submitted', self.name)


### PR DESCRIPTION
Before it was stored only for tasks with a weight. This affects the generation of the .rst report and `task_info` view. Here is an example for an event based calculation:

```
$ oq show task_info
======================= ===== ====== ===== === =========
operation-duration      mean  stddev min   max num_tasks
compute_ruptures        5.431 5.777  1.227 24  13       
compute_gmfs_and_curves 21    22     2.462 74  20       
======================= ===== ====== ===== === =========
```

Before the line for `compute_gmfs_and_curves` was missing, because there is an `if` that stores the information only if there is a weight.