### PR TITLE
In get_surface_boundaries order points in clockwise order

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,7 @@
+  [Paolo Tormene]
+  * Fixed clockwise order of vertices of surface boundaries, as needed for
+    WKT MULTIPOLYGON strings while exporting ruptures
+
   [Michele Simionato]
   * Added input checks to the GmfComputer
   * Fixed bug when splitting area sources into point sources for

--- a/openquake/hazardlib/geo/surface/planar.py
+++ b/openquake/hazardlib/geo/surface/planar.py
@@ -660,7 +660,7 @@ class PlanarSurface(BaseQuadrilateralSurface):
 
     def get_surface_boundaries(self):
         """
-        The corners lons/lats
+        The corners lons/lats in WKT-friendly order (clockwise)
         """
-        return [self.corner_lons.take([0, 1, 2, 3, 0])], \
-               [self.corner_lats.take([0, 1, 2, 3, 0])]
+        return [self.corner_lons.take([0, 1, 3, 2, 0])], \
+               [self.corner_lats.take([0, 1, 3, 2, 0])]


### PR DESCRIPTION
The clockwise order is needed for WKT MULTIPOLYGON strings.
We have to make sure this change does not break the behavior of other functionalities.

Fixes https://github.com/gem/oq-engine/issues/2618