### PR TITLE
New constructor for Polygon class to parse a wkt polygon string

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -27,6 +27,7 @@ Nick Ackerley           December 2015
 Trevor Allen            July 2016
 Jonathan Griffin        October 2016
 Ozkan Kale              October 2016
+Valerio Poggi           March 2017
 
 Research
 --------
@@ -40,3 +41,4 @@ Julio Garcia            March 2014
 Robin Gee               September 2015
 Silvia Canessa          December 2015
 Nick Ackerley           December 2015
+Valerio Poggi           March 2017

--- a/openquake/hazardlib/geo/polygon.py
+++ b/openquake/hazardlib/geo/polygon.py
@@ -87,7 +87,7 @@ class Polygon(object):
         Create a polygon object from a WKT (Well-Known Text) string.
 
         :param wkt_string:
-            A standard WKT polygon string
+            A standard WKT polygon string.
         :returns:
             New :class:`Polygon` object.
         """

--- a/openquake/hazardlib/geo/polygon.py
+++ b/openquake/hazardlib/geo/polygon.py
@@ -89,7 +89,7 @@ class Polygon(object):
         :param wkt_string:
             A standard WKT polygon string
         :returns:
-            New :class:`Polygon` object. 
+            New :class:`Polygon` object.
         """
         # Avoid calling class' constructor
         polygon = object.__new__(cls)

--- a/openquake/hazardlib/geo/polygon.py
+++ b/openquake/hazardlib/geo/polygon.py
@@ -19,6 +19,7 @@
 """
 Module :mod:`openquake.hazardlib.geo.polygon` defines :class:`Polygon`.
 """
+import re
 import numpy
 import shapely.geometry
 
@@ -79,6 +80,48 @@ class Polygon(object):
         pairs.append(pairs[0])
 
         return 'POLYGON((%s))' % ', '.join(pairs)
+
+    @classmethod
+    def _from_wkt(cls, wkt_string):
+        """
+        Create a polygon object from a WKT (Well-Known Text) string.
+
+        :param wkt_string:
+            A standard WKT string, either a simple or a composite polygon
+        :returns:
+            New :class:`Polygon` object. 
+        """
+        # Avoid calling class' constructor
+        polygon = object.__new__(cls)
+
+        if type(wkt_string) != str:
+            raise ValueError('input is not a WKT string')
+        if wkt_string[0:7] != 'POLYGON':
+            raise ValueError('input string is not a WKT polygon')
+
+        # Extract polygon groups (if composite polygon)
+        wkt_string = wkt_string.split('((')[1]
+        wkt_string = wkt_string.split('))')[0]
+        wkt_string = wkt_string.split('),(')
+
+        # Extract lat/lon coordinates from polygon groups
+        lons = []
+        lats = []
+        for wkt_group in wkt_string:
+            wkt_array = wkt_group.split(',')
+            # Note: last element of is redundant (closed polygon)
+            # and thus it is removed from the array
+            for wkt_point in wkt_array[:-1]:
+                point = re.split(' +', wkt_point)
+                lons.append(float(point[0]))
+                lats.append(float(point[1]))
+
+        # Fill the polygon object
+        polygon.lons = numpy.array(lons)
+        polygon.lats = numpy.array(lats)
+        polygon._projection = None
+        polygon._polygon2d = None
+        return polygon
 
     @classmethod
     def _from_2d(cls, polygon2d, proj):

--- a/openquake/hazardlib/tests/geo/polygon_test.py
+++ b/openquake/hazardlib/tests/geo/polygon_test.py
@@ -291,7 +291,7 @@ class PolygonEdgesTestCase(unittest.TestCase):
 class PolygonFromWktTestCase(unittest.TestCase):
     def test(self):
         wkt_string = 'POLYGON((22. -15.,24. -15.,24. -10.,22. -15.))'
-        poly = polygon.Polygon._from_wkt(wkt_string)
+        poly = polygon.Polygon.from_wkt(wkt_string)
         self.assertEqual(list(poly.lats), [-15, -15, -10])
         self.assertEqual(list(poly.lons), [22, 24, 24])
         self.assertEqual(poly.lats.dtype, 'float')

--- a/openquake/hazardlib/tests/geo/polygon_test.py
+++ b/openquake/hazardlib/tests/geo/polygon_test.py
@@ -288,6 +288,15 @@ class PolygonEdgesTestCase(unittest.TestCase):
 
         self.assertTrue(self.poly.intersects(mesh).all())
 
+class PolygonFromWktTestCase(unittest.TestCase):
+    def test(self):
+        wkt_string = 'POLYGON((22. -15.,24. -15.,24. -10.,22. -15.))'
+        poly = polygon.Polygon._from_wkt(wkt_string)
+        self.assertEqual(list(poly.lats), [-15, -15, -10])
+        self.assertEqual(list(poly.lons), [22, 24, 24])
+        self.assertEqual(poly.lats.dtype, 'float')
+        self.assertEqual(poly.lons.dtype, 'float')
+        self.assertTrue(poly.wkt != '')
 
 class PolygonFrom2dTestCase(unittest.TestCase):
     def test(self):

--- a/openquake/hazardlib/tests/geo/polygon_test.py
+++ b/openquake/hazardlib/tests/geo/polygon_test.py
@@ -288,15 +288,17 @@ class PolygonEdgesTestCase(unittest.TestCase):
 
         self.assertTrue(self.poly.intersects(mesh).all())
 
+
 class PolygonFromWktTestCase(unittest.TestCase):
     def test(self):
-        wkt_string = 'POLYGON((22. -15.,24. -15.,24. -10.,22. -15.))'
+        wkt_string = 'POLYGON((22.0 -15.0, 24.0 -15.0, 24.0 -10.0, 22.0 -15.0))'
         poly = polygon.Polygon.from_wkt(wkt_string)
         self.assertEqual(list(poly.lats), [-15, -15, -10])
         self.assertEqual(list(poly.lons), [22, 24, 24])
         self.assertEqual(poly.lats.dtype, 'float')
         self.assertEqual(poly.lons.dtype, 'float')
-        self.assertTrue(poly.wkt != '')
+        self.assertEqual(poly.wkt, wkt_string)
+
 
 class PolygonFrom2dTestCase(unittest.TestCase):
     def test(self):


### PR DESCRIPTION
A Polygon object can now be alternatively instantiated by directly passing a WKT string in input. Overload is made using a separate (private) classmethod.