### PR TITLE
Made safeprint more robust

### DIFF
--- a/openquake/baselib/general.py
+++ b/openquake/baselib/general.py
@@ -832,7 +832,9 @@ def safeprint(*args, **kwargs):
     new_args = []
     # when stdout is redirected to a file, python 2 uses ascii for the writer;
     # python 3 uses what is configured in the system (i.e. 'utf-8')
-    str_encoding = sys.stdout.encoding or 'ascii'
+    # if sys.stdout is replaced by a StringIO instance, Python 2 does not
+    # have an attribute 'encoding', and we assume ascii in that case
+    str_encoding = getattr(sys.stdout, 'encoding', None) or 'ascii'
     for s in args:
         new_args.append(s.encode('utf-8').decode(str_encoding, 'ignore'))
 


### PR DESCRIPTION
Fixes the error in https://ci.openquake.org/job/master_oq-engine/3415/console