### PR TITLE
Use CDN ftp mirror instead of upstream

### DIFF
--- a/requirements-py27-linux64.txt
+++ b/requirements-py27-linux64.txt
@@ -6,36 +6,36 @@
 # We also provide pre-compiled manylinux1 wheels for
 # h5py, Shapely, psutil, Rtree, PyYAML, Basemap
 
-http://ftp.openquake.org/wheelhouse/linux/py/setuptools-28.8.0-py2.py3-none-any.whl
-http://ftp.openquake.org/wheelhouse/linux/py27/pkgconfig-1.1.0-cp27-none-any.whl
-http://ftp.openquake.org/wheelhouse/linux/py/mock-1.3.0-py2.py3-none-any.whl
-http://ftp.openquake.org/wheelhouse/linux/py27/h5py-2.7.0-cp27-cp27mu-manylinux1_x86_64.whl
-http://ftp.openquake.org/wheelhouse/linux/py27/nose-1.3.7-py2-none-any.whl
-http://ftp.openquake.org/wheelhouse/linux/py27/numpy-1.11.1-cp27-cp27mu-manylinux1_x86_64.whl
-http://ftp.openquake.org/wheelhouse/linux/py27/scipy-0.17.1-cp27-cp27mu-manylinux1_x86_64.whl
-http://ftp.openquake.org/wheelhouse/linux/py27/psutil-3.4.2-cp27-cp27mu-manylinux1_x86_64.whl
-http://ftp.openquake.org/wheelhouse/linux/py27/Shapely-1.5.13-cp27-cp27mu-manylinux1_x86_64.whl
-http://ftp.openquake.org/wheelhouse/linux/py27/docutils-0.12-cp27-none-any.whl
-http://ftp.openquake.org/wheelhouse/linux/py/decorator-4.0.11-py2.py3-none-any.whl
-http://ftp.openquake.org/wheelhouse/linux/py/funcsigs-1.0.2-py2.py3-none-any.whl
-http://ftp.openquake.org/wheelhouse/linux/py/pbr-1.8.0-py2.py3-none-any.whl
-http://ftp.openquake.org/wheelhouse/linux/py/six-1.10.0-py2.py3-none-any.whl
-http://ftp.openquake.org/wheelhouse/linux/py27/futures-3.0.5-py2-none-any.whl
-http://ftp.openquake.org/wheelhouse/linux/py27/PyYAML-3.12-cp27-cp27mu-manylinux1_x86_64.whl
+http://cdn.ftp.openquake.org/wheelhouse/linux/py/setuptools-28.8.0-py2.py3-none-any.whl
+http://cdn.ftp.openquake.org/wheelhouse/linux/py27/pkgconfig-1.1.0-cp27-none-any.whl
+http://cdn.ftp.openquake.org/wheelhouse/linux/py/mock-1.3.0-py2.py3-none-any.whl
+http://cdn.ftp.openquake.org/wheelhouse/linux/py27/h5py-2.7.0-cp27-cp27mu-manylinux1_x86_64.whl
+http://cdn.ftp.openquake.org/wheelhouse/linux/py27/nose-1.3.7-py2-none-any.whl
+http://cdn.ftp.openquake.org/wheelhouse/linux/py27/numpy-1.11.1-cp27-cp27mu-manylinux1_x86_64.whl
+http://cdn.ftp.openquake.org/wheelhouse/linux/py27/scipy-0.17.1-cp27-cp27mu-manylinux1_x86_64.whl
+http://cdn.ftp.openquake.org/wheelhouse/linux/py27/psutil-3.4.2-cp27-cp27mu-manylinux1_x86_64.whl
+http://cdn.ftp.openquake.org/wheelhouse/linux/py27/Shapely-1.5.13-cp27-cp27mu-manylinux1_x86_64.whl
+http://cdn.ftp.openquake.org/wheelhouse/linux/py27/docutils-0.12-cp27-none-any.whl
+http://cdn.ftp.openquake.org/wheelhouse/linux/py/decorator-4.0.11-py2.py3-none-any.whl
+http://cdn.ftp.openquake.org/wheelhouse/linux/py/funcsigs-1.0.2-py2.py3-none-any.whl
+http://cdn.ftp.openquake.org/wheelhouse/linux/py/pbr-1.8.0-py2.py3-none-any.whl
+http://cdn.ftp.openquake.org/wheelhouse/linux/py/six-1.10.0-py2.py3-none-any.whl
+http://cdn.ftp.openquake.org/wheelhouse/linux/py27/futures-3.0.5-py2-none-any.whl
+http://cdn.ftp.openquake.org/wheelhouse/linux/py27/PyYAML-3.12-cp27-cp27mu-manylinux1_x86_64.whl
 
 ## Extra ##
 
 ### Rtree ###
 # comment the following lines to skip installation
 # of Rtree (experimental wheel, optional feature)
-http://ftp.openquake.org/wheelhouse/linux/py27/Rtree-0.8.2-cp27-cp27mu-manylinux1_x86_64.whl
+http://cdn.ftp.openquake.org/wheelhouse/linux/py27/Rtree-0.8.2-cp27-cp27mu-manylinux1_x86_64.whl
 
 ### Plotting ###
 # comment the following lines to skip installation
 # of the plotting libraries (optional feature)
-http://ftp.openquake.org/wheelhouse/linux/py27/matplotlib-1.5.3-cp27-cp27mu-manylinux1_x86_64.whl
-http://ftp.openquake.org/wheelhouse/linux/py/pyparsing-2.1.10-py2.py3-none-any.whl
-http://ftp.openquake.org/wheelhouse/linux/py/python_dateutil-2.6.0-py2.py3-none-any.whl
-http://ftp.openquake.org/wheelhouse/linux/py/cycler-0.10.0-py2.py3-none-any.whl
-http://ftp.openquake.org/wheelhouse/linux/py27/pyproj-1.9.5.1-cp27-cp27mu-manylinux1_x86_64.whl
-http://ftp.openquake.org/wheelhouse/linux/py27/basemap-1.1.0-cp27-cp27mu-manylinux1_x86_64.whl
+http://cdn.ftp.openquake.org/wheelhouse/linux/py27/matplotlib-1.5.3-cp27-cp27mu-manylinux1_x86_64.whl
+http://cdn.ftp.openquake.org/wheelhouse/linux/py/pyparsing-2.1.10-py2.py3-none-any.whl
+http://cdn.ftp.openquake.org/wheelhouse/linux/py/python_dateutil-2.6.0-py2.py3-none-any.whl
+http://cdn.ftp.openquake.org/wheelhouse/linux/py/cycler-0.10.0-py2.py3-none-any.whl
+http://cdn.ftp.openquake.org/wheelhouse/linux/py27/pyproj-1.9.5.1-cp27-cp27mu-manylinux1_x86_64.whl
+http://cdn.ftp.openquake.org/wheelhouse/linux/py27/basemap-1.1.0-cp27-cp27mu-manylinux1_x86_64.whl

--- a/requirements-py27-macos.txt
+++ b/requirements-py27-macos.txt
@@ -5,21 +5,21 @@
 
 # GEM Mirror
 
-http://ftp.openquake.org/wheelhouse/macos/py/setuptools-28.8.0-py2.py3-none-any.whl
-http://ftp.openquake.org/wheelhouse/macos/py27/pkgconfig-1.1.0-cp27-none-any.whl
-http://ftp.openquake.org/wheelhouse/macos/py/mock-1.3.0-py2.py3-none-any.whl
-http://ftp.openquake.org/wheelhouse/macos/py27/h5py-2.7.0-cp27-cp27m-macosx_10_6_intel.macosx_10_9_intel.macosx_10_9_x86_64.macosx_10_10_intel.macosx_10_10_x86_64.whl
-http://ftp.openquake.org/wheelhouse/macos/py27/nose-1.3.7-py2-none-any.whl
-http://ftp.openquake.org/wheelhouse/macos/py27/numpy-1.11.3-cp27-cp27m-macosx_10_6_intel.macosx_10_9_intel.macosx_10_9_x86_64.macosx_10_10_intel.macosx_10_10_x86_64.whl
-http://ftp.openquake.org/wheelhouse/macos/py27/scipy-0.17.1-cp27-cp27m-macosx_10_6_intel.macosx_10_9_intel.macosx_10_9_x86_64.macosx_10_10_intel.macosx_10_10_x86_64.whl
-http://ftp.openquake.org/wheelhouse/macos/py27/psutil-4.4.2-cp27-cp27m-macosx_10_11_intel.whl
-http://ftp.openquake.org/wheelhouse/macos/py27/Shapely-1.5.17.post1-cp27-cp27m-macosx_10_6_intel.whl
-http://ftp.openquake.org/wheelhouse/macos/py27/docutils-0.12-cp27-none-any.whl
-http://ftp.openquake.org/wheelhouse/macos/py/decorator-4.0.11-py2.py3-none-any.whl
-http://ftp.openquake.org/wheelhouse/macos/py/funcsigs-1.0.2-py2.py3-none-any.whl
-http://ftp.openquake.org/wheelhouse/macos/py/pbr-1.8.0-py2.py3-none-any.whl
-http://ftp.openquake.org/wheelhouse/macos/py/six-1.10.0-py2.py3-none-any.whl
-http://ftp.openquake.org/wheelhouse/macos/py27/futures-3.0.5-py2-none-any.whl
+http://cdn.ftp.openquake.org/wheelhouse/macos/py/setuptools-28.8.0-py2.py3-none-any.whl
+http://cdn.ftp.openquake.org/wheelhouse/macos/py27/pkgconfig-1.1.0-cp27-none-any.whl
+http://cdn.ftp.openquake.org/wheelhouse/macos/py/mock-1.3.0-py2.py3-none-any.whl
+http://cdn.ftp.openquake.org/wheelhouse/macos/py27/h5py-2.7.0-cp27-cp27m-macosx_10_6_intel.macosx_10_9_intel.macosx_10_9_x86_64.macosx_10_10_intel.macosx_10_10_x86_64.whl
+http://cdn.ftp.openquake.org/wheelhouse/macos/py27/nose-1.3.7-py2-none-any.whl
+http://cdn.ftp.openquake.org/wheelhouse/macos/py27/numpy-1.11.3-cp27-cp27m-macosx_10_6_intel.macosx_10_9_intel.macosx_10_9_x86_64.macosx_10_10_intel.macosx_10_10_x86_64.whl
+http://cdn.ftp.openquake.org/wheelhouse/macos/py27/scipy-0.17.1-cp27-cp27m-macosx_10_6_intel.macosx_10_9_intel.macosx_10_9_x86_64.macosx_10_10_intel.macosx_10_10_x86_64.whl
+http://cdn.ftp.openquake.org/wheelhouse/macos/py27/psutil-4.4.2-cp27-cp27m-macosx_10_11_intel.whl
+http://cdn.ftp.openquake.org/wheelhouse/macos/py27/Shapely-1.5.17.post1-cp27-cp27m-macosx_10_6_intel.whl
+http://cdn.ftp.openquake.org/wheelhouse/macos/py27/docutils-0.12-cp27-none-any.whl
+http://cdn.ftp.openquake.org/wheelhouse/macos/py/decorator-4.0.11-py2.py3-none-any.whl
+http://cdn.ftp.openquake.org/wheelhouse/macos/py/funcsigs-1.0.2-py2.py3-none-any.whl
+http://cdn.ftp.openquake.org/wheelhouse/macos/py/pbr-1.8.0-py2.py3-none-any.whl
+http://cdn.ftp.openquake.org/wheelhouse/macos/py/six-1.10.0-py2.py3-none-any.whl
+http://cdn.ftp.openquake.org/wheelhouse/macos/py27/futures-3.0.5-py2-none-any.whl
 
 ## Extra ##
 
@@ -28,9 +28,9 @@ http://ftp.openquake.org/wheelhouse/macos/py27/futures-3.0.5-py2-none-any.whl
 ### Plotting ###
 # comment the following lines to skip installation
 # of the plotting libraries (optional feature)
-http://ftp.openquake.org/wheelhouse/macos/py27/matplotlib-1.5.3-cp27-cp27m-macosx_10_6_intel.macosx_10_9_intel.macosx_10_9_x86_64.macosx_10_10_intel.macosx_10_10_x86_64.whl
-http://ftp.openquake.org/wheelhouse/macos/py/pyparsing-2.1.10-py2.py3-none-any.whl
-http://ftp.openquake.org/wheelhouse/macos/py/python_dateutil-2.6.0-py2.py3-none-any.whl
-http://ftp.openquake.org/wheelhouse/macos/py/cycler-0.10.0-py2.py3-none-any.whl
-http://ftp.openquake.org/wheelhouse/macos/py27/pyproj-1.9.5.1-cp27-cp27m-macosx_10_6_intel.whl
-http://ftp.openquake.org/wheelhouse/macos/py27/basemap-1.1.0-cp27-cp27m-macosx_10_6_intel.whl
+http://cdn.ftp.openquake.org/wheelhouse/macos/py27/matplotlib-1.5.3-cp27-cp27m-macosx_10_6_intel.macosx_10_9_intel.macosx_10_9_x86_64.macosx_10_10_intel.macosx_10_10_x86_64.whl
+http://cdn.ftp.openquake.org/wheelhouse/macos/py/pyparsing-2.1.10-py2.py3-none-any.whl
+http://cdn.ftp.openquake.org/wheelhouse/macos/py/python_dateutil-2.6.0-py2.py3-none-any.whl
+http://cdn.ftp.openquake.org/wheelhouse/macos/py/cycler-0.10.0-py2.py3-none-any.whl
+http://cdn.ftp.openquake.org/wheelhouse/macos/py27/pyproj-1.9.5.1-cp27-cp27m-macosx_10_6_intel.whl
+http://cdn.ftp.openquake.org/wheelhouse/macos/py27/basemap-1.1.0-cp27-cp27m-macosx_10_6_intel.whl

--- a/requirements-py35-linux64.txt
+++ b/requirements-py35-linux64.txt
@@ -6,35 +6,35 @@
 # We also provide pre-compiled manylinux1 wheels for
 # h5py, Shapely, psutil, Rtree, PyYAML, Basemap
 
-http://ftp.openquake.org/wheelhouse/linux/py/setuptools-28.8.0-py2.py3-none-any.whl
-http://ftp.openquake.org/wheelhouse/linux/py35/pkgconfig-1.1.0-py3-none-any.whl
-http://ftp.openquake.org/wheelhouse/linux/py/mock-1.3.0-py2.py3-none-any.whl
-http://ftp.openquake.org/wheelhouse/linux/py35/h5py-2.7.0-cp35-cp35m-manylinux1_x86_64.whl
-http://ftp.openquake.org/wheelhouse/linux/py35/nose-1.3.7-py3-none-any.whl
-http://ftp.openquake.org/wheelhouse/linux/py35/numpy-1.11.1-cp35-cp35m-manylinux1_x86_64.whl
-http://ftp.openquake.org/wheelhouse/linux/py35/scipy-0.17.1-cp35-cp35m-manylinux1_x86_64.whl
-http://ftp.openquake.org/wheelhouse/linux/py35/psutil-3.4.2-cp35-cp35m-manylinux1_x86_64.whl
-http://ftp.openquake.org/wheelhouse/linux/py35/Shapely-1.5.13-cp35-cp35m-manylinux1_x86_64.whl
-http://ftp.openquake.org/wheelhouse/linux/py35/docutils-0.12-py3-none-any.whl
-http://ftp.openquake.org/wheelhouse/linux/py/decorator-4.0.11-py2.py3-none-any.whl
-http://ftp.openquake.org/wheelhouse/linux/py/funcsigs-1.0.2-py2.py3-none-any.whl
-http://ftp.openquake.org/wheelhouse/linux/py/pbr-1.8.0-py2.py3-none-any.whl
-http://ftp.openquake.org/wheelhouse/linux/py/six-1.10.0-py2.py3-none-any.whl
-http://ftp.openquake.org/wheelhouse/linux/py35/PyYAML-3.12-cp35-cp35m-manylinux1_x86_64.whl
+http://cdn.ftp.openquake.org/wheelhouse/linux/py/setuptools-28.8.0-py2.py3-none-any.whl
+http://cdn.ftp.openquake.org/wheelhouse/linux/py35/pkgconfig-1.1.0-py3-none-any.whl
+http://cdn.ftp.openquake.org/wheelhouse/linux/py/mock-1.3.0-py2.py3-none-any.whl
+http://cdn.ftp.openquake.org/wheelhouse/linux/py35/h5py-2.7.0-cp35-cp35m-manylinux1_x86_64.whl
+http://cdn.ftp.openquake.org/wheelhouse/linux/py35/nose-1.3.7-py3-none-any.whl
+http://cdn.ftp.openquake.org/wheelhouse/linux/py35/numpy-1.11.1-cp35-cp35m-manylinux1_x86_64.whl
+http://cdn.ftp.openquake.org/wheelhouse/linux/py35/scipy-0.17.1-cp35-cp35m-manylinux1_x86_64.whl
+http://cdn.ftp.openquake.org/wheelhouse/linux/py35/psutil-3.4.2-cp35-cp35m-manylinux1_x86_64.whl
+http://cdn.ftp.openquake.org/wheelhouse/linux/py35/Shapely-1.5.13-cp35-cp35m-manylinux1_x86_64.whl
+http://cdn.ftp.openquake.org/wheelhouse/linux/py35/docutils-0.12-py3-none-any.whl
+http://cdn.ftp.openquake.org/wheelhouse/linux/py/decorator-4.0.11-py2.py3-none-any.whl
+http://cdn.ftp.openquake.org/wheelhouse/linux/py/funcsigs-1.0.2-py2.py3-none-any.whl
+http://cdn.ftp.openquake.org/wheelhouse/linux/py/pbr-1.8.0-py2.py3-none-any.whl
+http://cdn.ftp.openquake.org/wheelhouse/linux/py/six-1.10.0-py2.py3-none-any.whl
+http://cdn.ftp.openquake.org/wheelhouse/linux/py35/PyYAML-3.12-cp35-cp35m-manylinux1_x86_64.whl
 
 ## Extra ##
 
 ### Rtree ###
 # comment the following lines to skip installation
 # of Rtree (experimental wheel, optional feature)
-http://ftp.openquake.org/wheelhouse/linux/py35/Rtree-0.8.2-cp35-cp35m-manylinux1_x86_64.whl
+http://cdn.ftp.openquake.org/wheelhouse/linux/py35/Rtree-0.8.2-cp35-cp35m-manylinux1_x86_64.whl
 
 ### Plotting ###
 # comment the following lines to skip installation
 # of the plotting libraries (optional feature)
-http://ftp.openquake.org/wheelhouse/linux/py35/matplotlib-1.5.3-cp35-cp35m-manylinux1_x86_64.whl
-http://ftp.openquake.org/wheelhouse/linux/py/pyparsing-2.1.10-py2.py3-none-any.whl
-http://ftp.openquake.org/wheelhouse/linux/py/python_dateutil-2.6.0-py2.py3-none-any.whl
-http://ftp.openquake.org/wheelhouse/linux/py/cycler-0.10.0-py2.py3-none-any.whl
-http://ftp.openquake.org/wheelhouse/linux/py35/pyproj-1.9.5.1-cp35-cp35m-manylinux1_x86_64.whl
-http://ftp.openquake.org/wheelhouse/linux/py35/basemap-1.1.0-cp35-cp35m-manylinux1_x86_64.whl
+http://cdn.ftp.openquake.org/wheelhouse/linux/py35/matplotlib-1.5.3-cp35-cp35m-manylinux1_x86_64.whl
+http://cdn.ftp.openquake.org/wheelhouse/linux/py/pyparsing-2.1.10-py2.py3-none-any.whl
+http://cdn.ftp.openquake.org/wheelhouse/linux/py/python_dateutil-2.6.0-py2.py3-none-any.whl
+http://cdn.ftp.openquake.org/wheelhouse/linux/py/cycler-0.10.0-py2.py3-none-any.whl
+http://cdn.ftp.openquake.org/wheelhouse/linux/py35/pyproj-1.9.5.1-cp35-cp35m-manylinux1_x86_64.whl
+http://cdn.ftp.openquake.org/wheelhouse/linux/py35/basemap-1.1.0-cp35-cp35m-manylinux1_x86_64.whl

--- a/requirements-py35-macos.txt
+++ b/requirements-py35-macos.txt
@@ -5,20 +5,20 @@
 
 # GEM Mirror
 
-http://ftp.openquake.org/wheelhouse/macos/py/setuptools-28.8.0-py2.py3-none-any.whl
-http://ftp.openquake.org/wheelhouse/macos/py35/pkgconfig-1.1.0-py3-none-any.whl
-http://ftp.openquake.org/wheelhouse/macos/py/mock-1.3.0-py2.py3-none-any.whl
-http://ftp.openquake.org/wheelhouse/macos/py35/h5py-2.7.0-cp35-cp35m-macosx_10_6_intel.macosx_10_9_intel.macosx_10_9_x86_64.macosx_10_10_intel.macosx_10_10_x86_64.whl
-http://ftp.openquake.org/wheelhouse/macos/py35/nose-1.3.7-py3-none-any.whl
-http://ftp.openquake.org/wheelhouse/macos/py35/numpy-1.11.3-cp35-cp35m-macosx_10_6_intel.macosx_10_9_intel.macosx_10_9_x86_64.macosx_10_10_intel.macosx_10_10_x86_64.whl
-http://ftp.openquake.org/wheelhouse/macos/py35/scipy-0.17.1-cp35-cp35m-macosx_10_6_intel.macosx_10_9_intel.macosx_10_9_x86_64.macosx_10_10_intel.macosx_10_10_x86_64.whl
-http://ftp.openquake.org/wheelhouse/macos/py35/psutil-4.4.2-cp35-cp35m-macosx_10_6_intel.whl
-http://ftp.openquake.org/wheelhouse/macos/py35/Shapely-1.5.17.post1-cp35-cp35m-macosx_10_6_intel.whl
-http://ftp.openquake.org/wheelhouse/macos/py35/docutils-0.12-py3-none-any.whl
-http://ftp.openquake.org/wheelhouse/macos/py/decorator-4.0.11-py2.py3-none-any.whl
-http://ftp.openquake.org/wheelhouse/macos/py/funcsigs-1.0.2-py2.py3-none-any.whl
-http://ftp.openquake.org/wheelhouse/macos/py/pbr-1.8.0-py2.py3-none-any.whl
-http://ftp.openquake.org/wheelhouse/macos/py/six-1.10.0-py2.py3-none-any.whl
+http://cdn.ftp.openquake.org/wheelhouse/macos/py/setuptools-28.8.0-py2.py3-none-any.whl
+http://cdn.ftp.openquake.org/wheelhouse/macos/py35/pkgconfig-1.1.0-py3-none-any.whl
+http://cdn.ftp.openquake.org/wheelhouse/macos/py/mock-1.3.0-py2.py3-none-any.whl
+http://cdn.ftp.openquake.org/wheelhouse/macos/py35/h5py-2.7.0-cp35-cp35m-macosx_10_6_intel.macosx_10_9_intel.macosx_10_9_x86_64.macosx_10_10_intel.macosx_10_10_x86_64.whl
+http://cdn.ftp.openquake.org/wheelhouse/macos/py35/nose-1.3.7-py3-none-any.whl
+http://cdn.ftp.openquake.org/wheelhouse/macos/py35/numpy-1.11.3-cp35-cp35m-macosx_10_6_intel.macosx_10_9_intel.macosx_10_9_x86_64.macosx_10_10_intel.macosx_10_10_x86_64.whl
+http://cdn.ftp.openquake.org/wheelhouse/macos/py35/scipy-0.17.1-cp35-cp35m-macosx_10_6_intel.macosx_10_9_intel.macosx_10_9_x86_64.macosx_10_10_intel.macosx_10_10_x86_64.whl
+http://cdn.ftp.openquake.org/wheelhouse/macos/py35/psutil-4.4.2-cp35-cp35m-macosx_10_6_intel.whl
+http://cdn.ftp.openquake.org/wheelhouse/macos/py35/Shapely-1.5.17.post1-cp35-cp35m-macosx_10_6_intel.whl
+http://cdn.ftp.openquake.org/wheelhouse/macos/py35/docutils-0.12-py3-none-any.whl
+http://cdn.ftp.openquake.org/wheelhouse/macos/py/decorator-4.0.11-py2.py3-none-any.whl
+http://cdn.ftp.openquake.org/wheelhouse/macos/py/funcsigs-1.0.2-py2.py3-none-any.whl
+http://cdn.ftp.openquake.org/wheelhouse/macos/py/pbr-1.8.0-py2.py3-none-any.whl
+http://cdn.ftp.openquake.org/wheelhouse/macos/py/six-1.10.0-py2.py3-none-any.whl
 
 ## Extra ##
 
@@ -27,9 +27,9 @@ http://ftp.openquake.org/wheelhouse/macos/py/six-1.10.0-py2.py3-none-any.whl
 ### Plotting ###
 # comment the following lines to skip installation
 # of the plotting libraries (optional feature)
-http://ftp.openquake.org/wheelhouse/macos/py35/matplotlib-1.5.3-cp35-cp35m-macosx_10_6_intel.macosx_10_9_intel.macosx_10_9_x86_64.macosx_10_10_intel.macosx_10_10_x86_64.whl
-http://ftp.openquake.org/wheelhouse/linux/py/pyparsing-2.1.10-py2.py3-none-any.whl
-http://ftp.openquake.org/wheelhouse/linux/py/python_dateutil-2.6.0-py2.py3-none-any.whl
-http://ftp.openquake.org/wheelhouse/linux/py/cycler-0.10.0-py2.py3-none-any.whl
-http://ftp.openquake.org/wheelhouse/macos/py35/pyproj-1.9.5.1-cp35-cp35m-macosx_10_6_intel.whl
-http://ftp.openquake.org/wheelhouse/macos/py35/basemap-1.1.0-cp35-cp35m-macosx_10_6_intel.whl
+http://cdn.ftp.openquake.org/wheelhouse/macos/py35/matplotlib-1.5.3-cp35-cp35m-macosx_10_6_intel.macosx_10_9_intel.macosx_10_9_x86_64.macosx_10_10_intel.macosx_10_10_x86_64.whl
+http://cdn.ftp.openquake.org/wheelhouse/linux/py/pyparsing-2.1.10-py2.py3-none-any.whl
+http://cdn.ftp.openquake.org/wheelhouse/linux/py/python_dateutil-2.6.0-py2.py3-none-any.whl
+http://cdn.ftp.openquake.org/wheelhouse/linux/py/cycler-0.10.0-py2.py3-none-any.whl
+http://cdn.ftp.openquake.org/wheelhouse/macos/py35/pyproj-1.9.5.1-cp35-cp35m-macosx_10_6_intel.whl
+http://cdn.ftp.openquake.org/wheelhouse/macos/py35/basemap-1.1.0-cp35-cp35m-macosx_10_6_intel.whl


### PR DESCRIPTION
Download the wheels from an ftp proxy on Linode instead of directly from our internal ftp. This reduces the load on our uplink and the cdn can provide stale cache if upstream is down.