### PR TITLE
Area sources are not point sources

### DIFF
--- a/openquake/hazardlib/source/area.py
+++ b/openquake/hazardlib/source/area.py
@@ -40,7 +40,9 @@ class AreaSource(ParametricSeismicSource):
     Other parameters (except ``location``) are the same as for
     :class:`~openquake.hazardlib.source.point.PointSource`.
     """
-    _slots_ = PointSource._slots_ + 'polygon area_discretization'.split()
+    _slots_ = ParametricSeismicSource._slots_ + '''upper_seismogenic_depth
+    lower_seismogenic_depth nodal_plane_distribution hypocenter_distribution
+    polygon area_discretization'''.split()
 
     MODIFICATIONS = set(())
 

--- a/openquake/hazardlib/source/area.py
+++ b/openquake/hazardlib/source/area.py
@@ -65,6 +65,7 @@ class AreaSource(ParametricSeismicSource):
         self.hypocenter_distribution = hypocenter_distribution
         self.polygon = polygon
         self.area_discretization = area_discretization
+        self.location = None
         self.max_radius = 0
 
     def get_rupture_enclosing_polygon(self, dilation=0):

--- a/openquake/hazardlib/source/area.py
+++ b/openquake/hazardlib/source/area.py
@@ -19,12 +19,13 @@ Module :mod:`openquake.hazardlib.source.area` defines :class:`AreaSource`.
 from copy import deepcopy
 from openquake.hazardlib.geo import Point
 from openquake.hazardlib.source.point import PointSource
+from openquake.hazardlib.source.base import ParametricSeismicSource
 from openquake.hazardlib.source.rupture import ParametricProbabilisticRupture
 from openquake.baselib.slots import with_slots
 
 
 @with_slots
-class AreaSource(PointSource):
+class AreaSource(ParametricSeismicSource):
     """
     Area source represents uniform seismicity occurring over a geographical
     region.
@@ -54,16 +55,17 @@ class AreaSource(PointSource):
                  nodal_plane_distribution, hypocenter_distribution,
                  # area-specific parameters
                  polygon, area_discretization):
-        super(AreaSource, self).__init__(
+        PointSource.__init__(
+            self,
             source_id, name, tectonic_region_type, mfd, rupture_mesh_spacing,
             magnitude_scaling_relationship, rupture_aspect_ratio,
             temporal_occurrence_model, upper_seismogenic_depth,
             lower_seismogenic_depth, location=None,
             nodal_plane_distribution=nodal_plane_distribution,
-            hypocenter_distribution=hypocenter_distribution,
-        )
+            hypocenter_distribution=hypocenter_distribution)
         self.polygon = polygon
         self.area_discretization = area_discretization
+        self.maxradius = 0
 
     def get_rupture_enclosing_polygon(self, dilation=0):
         """
@@ -159,3 +161,7 @@ class AreaSource(PointSource):
         return super(PointSource, self).filter_sites_by_distance_to_source(
             integration_distance, sites
         )
+
+    _get_rupture_dimensions = PointSource.__dict__['_get_rupture_dimensions']
+    _get_max_rupture_projection_radius = PointSource.__dict__[
+        '_get_max_rupture_projection_radius']

--- a/openquake/hazardlib/source/area.py
+++ b/openquake/hazardlib/source/area.py
@@ -151,17 +151,8 @@ class AreaSource(ParametricSeismicSource):
                 len(self.nodal_plane_distribution.data) *
                 len(self.hypocenter_distribution.data))
 
-    def filter_sites_by_distance_to_source(self, integration_distance, sites):
-        """
-        Overrides :meth:`implementation
-        <openquake.hazardlib.source.point.PointSource.filter_sites_by_distance_to_source>`
-        of the point source class just to call the :meth:`base class one
-        <openquake.hazardlib.source.base.BaseSeismicSource.filter_sites_by_distance_to_source>`.
-        """
-        return super(PointSource, self).filter_sites_by_distance_to_source(
-            integration_distance, sites
-        )
-
     _get_rupture_dimensions = PointSource.__dict__['_get_rupture_dimensions']
     _get_max_rupture_projection_radius = PointSource.__dict__[
         '_get_max_rupture_projection_radius']
+    filter_sites_by_distance_to_source = PointSource.__dict__[
+        'filter_sites_by_distance_to_source']

--- a/openquake/hazardlib/source/area.py
+++ b/openquake/hazardlib/source/area.py
@@ -155,5 +155,4 @@ class AreaSource(ParametricSeismicSource):
     _get_rupture_dimensions = PointSource.__dict__['_get_rupture_dimensions']
     _get_max_rupture_projection_radius = PointSource.__dict__[
         '_get_max_rupture_projection_radius']
-    filter_sites_by_distance_to_source = PointSource.__dict__[
-        'filter_sites_by_distance_to_source']
+    _get_rupture_surface = PointSource.__dict__['_get_rupture_surface']

--- a/openquake/hazardlib/source/area.py
+++ b/openquake/hazardlib/source/area.py
@@ -65,7 +65,6 @@ class AreaSource(ParametricSeismicSource):
         self.hypocenter_distribution = hypocenter_distribution
         self.polygon = polygon
         self.area_discretization = area_discretization
-        self.location = None
         self.max_radius = 0
 
     def get_rupture_enclosing_polygon(self, dilation=0):

--- a/openquake/hazardlib/source/area.py
+++ b/openquake/hazardlib/source/area.py
@@ -55,17 +55,17 @@ class AreaSource(ParametricSeismicSource):
                  nodal_plane_distribution, hypocenter_distribution,
                  # area-specific parameters
                  polygon, area_discretization):
-        PointSource.__init__(
-            self,
+        super(AreaSource, self).__init__(
             source_id, name, tectonic_region_type, mfd, rupture_mesh_spacing,
             magnitude_scaling_relationship, rupture_aspect_ratio,
-            temporal_occurrence_model, upper_seismogenic_depth,
-            lower_seismogenic_depth, location=None,
-            nodal_plane_distribution=nodal_plane_distribution,
-            hypocenter_distribution=hypocenter_distribution)
+            temporal_occurrence_model)
+        self.upper_seismogenic_depth = upper_seismogenic_depth
+        self.lower_seismogenic_depth = lower_seismogenic_depth
+        self.nodal_plane_distribution = nodal_plane_distribution
+        self.hypocenter_distribution = hypocenter_distribution
         self.polygon = polygon
         self.area_discretization = area_discretization
-        self.maxradius = 0
+        self.max_radius = 0
 
     def get_rupture_enclosing_polygon(self, dilation=0):
         """

--- a/openquake/hazardlib/sourceconverter.py
+++ b/openquake/hazardlib/sourceconverter.py
@@ -597,7 +597,7 @@ class SourceConverter(RuptureConverter):
     """
     Convert sources from valid nodes into Hazardlib objects.
     """
-    def __init__(self, investigation_time, rupture_mesh_spacing,
+    def __init__(self, investigation_time=50., rupture_mesh_spacing=10.,
                  complex_fault_mesh_spacing=None, width_of_mfd_bin=1.0,
                  area_source_discretization=None):
         self.area_source_discretization = area_source_discretization


### PR DESCRIPTION
Since the beginning of time hazardlib has considered AreaSources to be subclasses of PointSources. This makes no logical sense (area sources contain point sources, they are NOT point sources: they have no location!) and it is error prone: for instance any check `isinstance(src, PointSource)` is buggy, since `src` can be an AreaSource and not a PointSource as everybody would expect. For this reason the engine code is littered with checks like `src.__class__.__name__ == 'PointSource'` that are suboptimal. After several years, I am finally fixing this original sin. It was probably originated from the need to use some PointSource methods in the AreaSource class, but there is no need to inherit from it, we can just copy the needed methods, as I am doing in this pull request.