### PR TITLE
Fix a print that prevents compileall on Python 3

### DIFF
--- a/openquake/hazardlib/tests/geo/surface/base_surface_test.py
+++ b/openquake/hazardlib/tests/geo/surface/base_surface_test.py
@@ -392,7 +392,7 @@ class GetAzimuthTestCase(unittest.TestCase):
         azimuths = surface.get_azimuth(mesh)
         expected = numpy.array([0, 90, 180])
         azimuths[azimuths > 180] = azimuths[azimuths > 180] - 360
-        print expected, azimuths
+        print(expected, azimuths)
         numpy.testing.assert_almost_equal(expected, azimuths, 1)
 
     def test_02(self):

--- a/openquake/hazardlib/tests/geo/surface/base_surface_test.py
+++ b/openquake/hazardlib/tests/geo/surface/base_surface_test.py
@@ -392,7 +392,6 @@ class GetAzimuthTestCase(unittest.TestCase):
         azimuths = surface.get_azimuth(mesh)
         expected = numpy.array([0, 90, 180])
         azimuths[azimuths > 180] = azimuths[azimuths > 180] - 360
-        print(expected, azimuths)
         numpy.testing.assert_almost_equal(expected, azimuths, 1)
 
     def test_02(self):


### PR DESCRIPTION
This is breaking `python3 -m compileall` in https://github.com/gem/oq-builders/pull/57